### PR TITLE
KDA_prefill_sm89

### DIFF
--- a/README_KDA_cutlass_prefill.md
+++ b/README_KDA_cutlass_prefill.md
@@ -1,0 +1,60 @@
+# KDA prefill (CUDA)
+
+Fused-style **KDA (Kimi Delta Attention) prefill** for float32: two kernels (intra-chunk KKT / W–U, then inter-chunk recurrence). Targets **sm_89+** (CMake default: `89`). Layout matches [cuLA](https://github.com/inclusionAI/cuLA) KDA tensor conventions: `q/k/g` `[B,H,T,K]`, `v/o` `[B,H,T,V]`, `beta` `[B,H,T]`, chunk buffers `w/u` `[B,H,num_chunks,C,K|V]`.
+
+Standalone **CMake** build plus **ctypes** benchmark (`src/main.py`). Tensor layout matches [cuLA](https://github.com/inclusionAI/cuLA) KDA conventions for a future port into `csrc/kda/sm90/`.
+
+## Build
+
+```bash
+cmake -S . -B build -DCMAKE_CUDA_ARCHITECTURES=89
+cmake --build build
+```
+
+Artifacts: `libkda_prefill.a`, `libkda_prefill_runtime.so` (C ABI: `kda_prefill_f32`).
+
+## Python benchmark (optional FLA)
+
+Requires PyTorch and, for FLA comparison, [flash-linear-attention](https://github.com/sustcsonglin/flash-linear-attention) (`fla`).
+
+```bash
+python src/main.py --suite fla-benchmark --B 2 --H 8 --T 4096 --K 64 --V 64 --C 32
+```
+
+- `local-benchmark` — CUDA only  
+- `fla-only-benchmark` — FLA only  
+- `fla-benchmark` — both + quick accuracy check vs `chunk_kda`
+
+## Tuning env (optional)
+
+| Variable | Role |
+|----------|------|
+| `KDA_INTRA_THREADS` | Block size for intra-chunk kernel |
+| `KDA_INTER_THREADS` | Block size for inter-chunk kernel |
+| `KDA_INTER_SHARDS` | V-way sharding for inter kernel (must divide `V`) |
+
+## Benchmark vs FLA (flash-linear-attention)
+
+**Hardware:** NVIDIA **RTX 4070**, **sm_89** (Ada). CMake built with `CMAKE_CUDA_ARCHITECTURES=89`.
+
+**Setup:** `K=V=64`, chunk `C=32`. Local path is **float32**; FLA `chunk_kda` in `src/main.py` runs **bf16** — timing numbers are not apples-to-apples on dtype, but useful as a rough baseline.
+
+Latest sweep (machine‑logged) is under [`analysis/ncu/20260409-193656-large-shape-compare/`](analysis/ncu/20260409-193656-large-shape-compare/README.md): summary table in that folder’s README, raw CSV [`benchmark_results.csv`](analysis/ncu/20260409-193656-large-shape-compare/benchmark_results.csv), console captures in [`benchmarks/`](analysis/ncu/20260409-193656-large-shape-compare/benchmarks/).
+
+| Shape (B,H,T) | iters | Local ms | FLA ms | Local / FLA |
+|---------------|------:|---------:|-------:|------------:|
+| (2,8,4096) | 10 | 1.8884 | 1.1918 | 1.58× |
+| (2,8,8192) | 10 | 3.6517 | 3.1311 | 1.17× |
+| (4,8,4096) | 10 | 3.8848 | 3.0597 | 1.27× |
+| (2,16,4096) | 10 | 3.8868 | 3.1079 | 1.25× |
+| (2,8,16384) | 5 | 7.2716 | 6.5675 | 1.11× |
+
+Quick accuracy line from the same harness (local fp32 vs FLA bf16): `max_abs ≈ 4.09`, `mean_abs ≈ 0.80` on the small validation shape inside `src/main.py` (see folder README).
+
+## Profiling artifacts
+
+`analysis/ncu/20260409-193656-large-shape-compare/` holds the FLA comparison CSV, console logs under `benchmarks/`, and a short README. Optional for builds.
+
+## Supported shapes
+
+Instantiated in `src/kda.cu`: `(K,V,C)` in `(64,64,64)`, `(64,64,32)`, `(128,128,64)`, `(128,128,32)`.

--- a/include/kda_api.hpp
+++ b/include/kda_api.hpp
@@ -1,0 +1,232 @@
+#pragma once
+#include <cuda_runtime.h>
+
+#include "kda_prefill_io.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+#include "kda_kernel.hpp"
+#include "kda_params.hpp"
+
+namespace kda {
+namespace api {
+
+inline void check_cuda(cudaError_t err, const char* msg) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(err));
+  }
+}
+
+inline void check_sm89_or_newer(const cudaDeviceProp& prop) {
+  const int sm = prop.major * 10 + prop.minor;
+  if (sm < 89) {
+    throw std::runtime_error(
+        "KDA prefill requires an sm89-or-newer GPU, but current device is sm_" +
+        std::to_string(prop.major) + std::to_string(prop.minor));
+  }
+}
+
+template <typename T>
+inline void normalize_prefill_io(KdaPrefillIO<T>& io) {
+  if (io.chunk_size <= 0) {
+    throw std::runtime_error("prefill io chunk_size must be positive");
+  }
+  if (io.num_chunks <= 0) {
+    io.num_chunks = (io.seq_len + io.chunk_size - 1) / io.chunk_size;
+  }
+}
+
+template <typename T>
+inline void validate_prefill_io(const KdaPrefillIO<T>& io) {
+  if (!io.q_ptr || !io.k_ptr || !io.v_ptr || !io.g_ptr || !io.beta_ptr ||
+      !io.w_ptr || !io.u_ptr || !io.o_ptr) {
+    throw std::runtime_error("prefill io contains null pointers");
+  }
+  if (io.batch_size <= 0 || io.num_heads <= 0 || io.seq_len <= 0 ||
+      io.head_dim <= 0 || io.value_dim <= 0 || io.chunk_size <= 0) {
+    throw std::runtime_error("prefill io dimensions must be positive");
+  }
+}
+
+// Split V across inter-chunk blocks to bound per-block shared memory.
+inline int choose_inter_v_shards(int value_dim,
+                                 int base_inter_blocks,
+                                 int target_inter_blocks) {
+  if (value_dim <= 0 || base_inter_blocks <= 0) {
+    return 1;
+  }
+
+  int desired_shards =
+      (target_inter_blocks + base_inter_blocks - 1) / base_inter_blocks;
+  desired_shards = std::max(1, std::min(desired_shards, value_dim));
+
+  for (int shards = desired_shards; shards <= value_dim; ++shards) {
+    if (value_dim % shards == 0) {
+      return shards;
+    }
+  }
+  return desired_shards;
+}
+
+
+inline int read_env_threads_override(const char* name, int fallback) {
+  const char* value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    return fallback;
+  }
+  const int parsed = std::atoi(value);
+  return parsed > 0 ? parsed : fallback;
+}
+
+inline int read_env_positive_override(const char* name, int fallback) {
+  const char* value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    return fallback;
+  }
+  const int parsed = std::atoi(value);
+  return parsed > 0 ? parsed : fallback;
+}
+
+template <typename Params>
+inline size_t intra_chunk_smem_bytes() {
+  using T = typename Params::element_type;
+  return sizeof(T) *
+             (Params::C * (Params::K_DIM + 1) + Params::C * (Params::V_DIM + 1) +
+              Params::C * (Params::K_DIM + 1) + Params::C) +
+         sizeof(float) * (Params::C * (Params::C + 1) + Params::C);
+}
+
+template <typename Params>
+inline size_t inter_chunk_smem_bytes(const Params& params) {
+  using T = typename Params::element_type;
+  const size_t wmma_scratch =
+      (Params::K_DIM == 64 && Params::V_DIM == 64 && Params::C == 32 &&
+       params.inter_v_tile == 16)
+          ? sizeof(float) * Params::K_DIM * params.inter_v_tile
+          : 0;
+  return sizeof(float) * (Params::K_DIM * (params.inter_v_tile + 1)) +
+         sizeof(T) * (Params::C * (Params::K_DIM + 1) + Params::C * (Params::K_DIM + 1) +
+                      Params::C * (params.inter_v_tile + 1)) +
+         sizeof(float) * (Params::C + Params::C * (Params::K_DIM + 1)) +
+         wmma_scratch;
+}
+
+template <typename Params>
+inline size_t fused_prefill_smem_bytes(const Params& params) {
+  using T = typename Params::element_type;
+  const size_t k_stride = Params::K_DIM + 1;
+  const size_t v_stride = params.inter_v_tile + 1;
+  const size_t m_stride = Params::C + 1;
+  return sizeof(T) *
+             (2 * Params::C * k_stride + 2 * Params::C * k_stride +
+              2 * Params::C * k_stride + 2 * Params::C * v_stride +
+              2 * Params::C + Params::C * k_stride + Params::C * v_stride) +
+         sizeof(float) *
+             (Params::K_DIM * v_stride + Params::C * m_stride +
+              Params::C * k_stride + Params::C);
+}
+
+template <typename Params>
+inline void launch_kda_prefill_kernel(Params params,
+                                      cudaStream_t stream = 0,
+                                      int intra_threads = 256,
+                                      int default_inter_threads = 256) {
+  if (params.seq_len <= 0 || params.batch_size <= 0 || params.num_heads <= 0) {
+    return;
+  }
+
+  int dev = 0;
+  check_cuda(cudaGetDevice(&dev), "get current device failed");
+  cudaDeviceProp prop{};
+  check_cuda(cudaGetDeviceProperties(&prop, dev), "get device properties failed");
+  check_sm89_or_newer(prop);
+
+  const int base_inter_blocks = params.batch_size * params.num_heads;
+  const int target_inter_blocks =
+      std::max(prop.multiProcessorCount * 2, base_inter_blocks);
+  int shards =
+      choose_inter_v_shards(Params::V_DIM, base_inter_blocks, target_inter_blocks);
+  const char* inter_shards_env = std::getenv("KDA_INTER_SHARDS");
+  if (inter_shards_env != nullptr && *inter_shards_env != '\0') {
+    const int requested_shards = std::atoi(inter_shards_env);
+    if (requested_shards > 0 && Params::V_DIM % requested_shards == 0) {
+      shards = requested_shards;
+    }
+  } else if (Params::K_DIM == 64 && Params::V_DIM == 64 && Params::C == 32) {
+    shards = 4;
+  }
+
+  params.inter_v_shards = shards;
+  params.inter_v_tile = (Params::V_DIM + shards - 1) / shards;
+
+  const int intra_smem = static_cast<int>(intra_chunk_smem_bytes<Params>());
+  const int inter_smem = static_cast<int>(inter_chunk_smem_bytes(params));
+  constexpr bool use_fused_kernel = false;
+  const int fused_smem =
+      use_fused_kernel ? static_cast<int>(fused_prefill_smem_bytes(params)) : 0;
+
+  cudaError_t attr_err = cudaSuccess;
+  if constexpr (use_fused_kernel) {
+    attr_err = cudaFuncSetAttribute(
+        kernel::prefill::kda_fused_prefill_kernel<Params>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        fused_smem);
+    if (attr_err != cudaSuccess && fused_smem <= 48 * 1024) {
+      check_cuda(attr_err, "set fused shared memory attribute failed");
+    }
+  } else {
+    attr_err = cudaFuncSetAttribute(
+        kernel::prefill::kda_intra_chunk_kernel<Params>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        intra_smem);
+    if (attr_err != cudaSuccess && intra_smem <= 48 * 1024) {
+      check_cuda(attr_err, "set intra shared memory attribute failed");
+    }
+    attr_err = cudaFuncSetAttribute(
+        kernel::prefill::kda_inter_chunk_rnn_kernel<Params>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        inter_smem);
+    if (attr_err != cudaSuccess && inter_smem <= 48 * 1024) {
+      check_cuda(attr_err, "set inter shared memory attribute failed");
+    }
+  }
+
+  if constexpr (use_fused_kernel) {
+    dim3 grid_fused(params.num_heads, params.batch_size, params.inter_v_shards);
+    kernel::prefill::kda_fused_prefill_kernel<Params>
+        <<<grid_fused, default_inter_threads, fused_smem, stream>>>(params);
+    check_cuda(cudaGetLastError(), "launch kda_fused_prefill_kernel failed");
+    return;
+  }
+
+  dim3 grid_intra(params.num_chunks, params.num_heads, params.batch_size);
+  intra_threads = read_env_threads_override("KDA_INTRA_THREADS", intra_threads);
+  kernel::prefill::kda_intra_chunk_kernel<Params>
+      <<<grid_intra, intra_threads, intra_smem, stream>>>(params);
+  check_cuda(cudaGetLastError(), "launch kda_intra_chunk_kernel failed");
+
+  int inter_threads =
+      (Params::K_DIM == 64 && Params::V_DIM == 64 && Params::C == 32) ? default_inter_threads : intra_threads;
+  inter_threads = read_env_threads_override("KDA_INTER_THREADS", inter_threads);
+  dim3 grid_inter(params.num_heads, params.batch_size, params.inter_v_shards);
+  kernel::prefill::kda_inter_chunk_rnn_kernel<Params>
+      <<<grid_inter, inter_threads, inter_smem, stream>>>(params);
+  check_cuda(cudaGetLastError(), "launch kda_inter_chunk_rnn_kernel failed");
+}
+
+cudaError_t launch_kda_prefill_f32(const KdaPrefillIO<float>& io,
+                                   cudaStream_t stream = 0);
+
+inline cudaError_t launch_kda_prefill(KdaPrefillIO<float> io,
+                                      cudaStream_t stream = 0) {
+  normalize_prefill_io(io);
+  validate_prefill_io(io);
+  return launch_kda_prefill_f32(io, stream);
+}
+
+}  // namespace api
+}  // namespace kda

--- a/include/kda_kernel.hpp
+++ b/include/kda_kernel.hpp
@@ -1,0 +1,1243 @@
+#pragma once
+#include <cuda_runtime.h>
+#include <mma.h>
+#include <type_traits>
+#include "kda_math.hpp"
+#include "kda_params.hpp"
+#include "kda_tensor.hpp"
+
+namespace kda {
+namespace kernel {
+namespace prefill {
+
+namespace wmma = nvcuda::wmma;
+
+template <typename T>
+__forceinline__ __device__ float row_l2_norm_sq(
+    const T* __restrict__ data,
+    int row,
+    int dim) {
+    float norm_sq = 0.0f;
+    const int base = row * dim;
+    #pragma unroll
+    for (int d = 0; d < dim; ++d) {
+        float val = static_cast<float>(data[base + d]);
+        norm_sq += val * val;
+    }
+    return norm_sq;
+}
+
+template <int ROWS, int DIM, typename T>
+__forceinline__ __device__ void compute_sigmoid_prefix_products(
+    const T* __restrict__ data,
+    float* __restrict__ prefix_products,
+    int valid_rows,
+    int tid,
+    int num_threads) {
+    for (int d = tid; d < DIM; d += num_threads) {
+        float prefix = 1.0f;
+        #pragma unroll
+        for (int row = 0; row < ROWS; ++row) {
+            if (row < valid_rows) {
+                prefix *= static_cast<float>(math::sigmoid(data[row * DIM + d]));
+                prefix_products[row * DIM + d] = prefix;
+            } else {
+                prefix_products[row * DIM + d] = 0.0f;
+            }
+        }
+    }
+    __syncthreads();
+}
+
+template <int ROWS, int DIM, typename T>
+__forceinline__ __device__ void normalize_rows_inplace(
+    T* __restrict__ data,
+    float* __restrict__ row_scales,
+    int valid_rows,
+    float extra_scale,
+    int tid,
+    int num_threads) {
+    for (int row = tid; row < ROWS; row += num_threads) {
+        if (row >= valid_rows) {
+            row_scales[row] = 0.0f;
+            continue;
+        }
+        float norm_sq = row_l2_norm_sq(data, row, DIM);
+        row_scales[row] = rsqrtf(norm_sq + 1.0e-6f) * extra_scale;
+    }
+    __syncthreads();
+
+    for (int idx = tid; idx < ROWS * DIM; idx += num_threads) {
+        int row = idx / DIM;
+        if (row >= valid_rows) {
+            data[idx] = static_cast<T>(0);
+            continue;
+        }
+        float val = static_cast<float>(data[idx]) * row_scales[row];
+        data[idx] = static_cast<T>(val);
+    }
+}
+
+template <typename T>
+__forceinline__ __device__ void copy_async_global_to_shared(
+    T* __restrict__ dst,
+    const T* __restrict__ src) {
+    #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    unsigned dst_addr = static_cast<unsigned>(__cvta_generic_to_shared(dst));
+    asm volatile(
+        "cp.async.ca.shared.global [%0], [%1], %2;\n" ::
+            "r"(dst_addr), "l"(src), "n"(sizeof(T)));
+    #else
+    *dst = *src;
+    #endif
+}
+
+__forceinline__ __device__ void cp_async_commit_group() {
+    #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    asm volatile("cp.async.commit_group;\n" ::);
+    #endif
+}
+
+__forceinline__ __device__ void cp_async_wait_group_0() {
+    #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    asm volatile("cp.async.wait_group 0;\n" ::);
+    #endif
+}
+
+template <typename T>
+__forceinline__ __device__ float row_l2_norm_sq_strided(
+    const T* __restrict__ data,
+    int row,
+    int dim,
+    int stride) {
+    float norm_sq = 0.0f;
+    const int base = row * stride;
+    #pragma unroll
+    for (int d = 0; d < dim; ++d) {
+        float val = static_cast<float>(data[base + d]);
+        norm_sq += val * val;
+    }
+    return norm_sq;
+}
+
+template <int ROWS, int DIM, typename T>
+__forceinline__ __device__ void normalize_rows_inplace_strided(
+    T* __restrict__ data,
+    float* __restrict__ row_scales,
+    int valid_rows,
+    float extra_scale,
+    int tid,
+    int num_threads,
+    int stride) {
+    for (int row = tid; row < ROWS; row += num_threads) {
+        if (row >= valid_rows) {
+            row_scales[row] = 0.0f;
+            continue;
+        }
+        float norm_sq = row_l2_norm_sq_strided(data, row, DIM, stride);
+        row_scales[row] = rsqrtf(norm_sq + 1.0e-6f) * extra_scale;
+    }
+    __syncthreads();
+
+    for (int idx = tid; idx < ROWS * DIM; idx += num_threads) {
+        int row = idx / DIM;
+        int d = idx % DIM;
+        if (row >= valid_rows) {
+            data[row * stride + d] = static_cast<T>(0);
+            continue;
+        }
+        float val = static_cast<float>(data[row * stride + d]) * row_scales[row];
+        data[row * stride + d] = static_cast<T>(val);
+    }
+}
+
+template <typename T>
+__forceinline__ __device__ float warp_sum(float value) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffffu, value, offset);
+    }
+    return value;
+}
+
+template <typename T>
+__forceinline__ __device__ void normalize_rows_warp_32x64(
+    T* __restrict__ data,
+    float* __restrict__ row_scales,
+    int valid_rows,
+    float extra_scale,
+    int tid,
+    int stride) {
+    constexpr int rows = 32;
+    constexpr int dim = 64;
+    constexpr int warp_size = 32;
+    const int warp_id = tid / warp_size;
+    const int lane = tid % warp_size;
+    const int num_warps = blockDim.x / warp_size;
+
+    for (int row = warp_id; row < rows; row += num_warps) {
+        float norm_sq = 0.0f;
+        if (row < valid_rows) {
+            #pragma unroll
+            for (int d = lane; d < dim; d += warp_size) {
+                float val = static_cast<float>(data[row * stride + d]);
+                norm_sq += val * val;
+            }
+        }
+        norm_sq = warp_sum<float>(norm_sq);
+        if (lane == 0) {
+            row_scales[row] = (row < valid_rows)
+                ? rsqrtf(norm_sq + 1.0e-6f) * extra_scale
+                : 0.0f;
+        }
+    }
+    __syncthreads();
+
+    for (int idx = tid; idx < rows * dim; idx += blockDim.x) {
+        int row = idx / dim;
+        int d = idx % dim;
+        if (row >= valid_rows) {
+            data[row * stride + d] = static_cast<T>(0);
+            continue;
+        }
+        float val = static_cast<float>(data[row * stride + d]) * row_scales[row];
+        data[row * stride + d] = static_cast<T>(val);
+    }
+}
+
+template <typename T>
+__forceinline__ __device__ void compute_sigmoid_prefix_products_warp_32x64(
+    const T* __restrict__ data,
+    float* __restrict__ prefix_products,
+    int valid_rows,
+    int tid,
+    int data_stride,
+    int out_stride) {
+    constexpr int dim = 64;
+    constexpr int warp_size = 32;
+    const int warp_id = tid / warp_size;
+    const int lane = tid % warp_size;
+    const int num_warps = blockDim.x / warp_size;
+
+    for (int d = warp_id; d < dim; d += num_warps) {
+        float value = (lane < valid_rows)
+            ? static_cast<float>(math::sigmoid(data[lane * data_stride + d]))
+            : 1.0f;
+        #pragma unroll
+        for (int offset = 1; offset < warp_size; offset <<= 1) {
+            float prev = __shfl_up_sync(0xffffffffu, value, offset);
+            if (lane >= offset) {
+                value *= prev;
+            }
+        }
+        prefix_products[lane * out_stride + d] = (lane < valid_rows) ? value : 0.0f;
+    }
+    __syncthreads();
+}
+
+template <int ROWS, int DIM, typename T>
+__forceinline__ __device__ void compute_sigmoid_prefix_products_strided(
+    const T* __restrict__ data,
+    float* __restrict__ prefix_products,
+    int valid_rows,
+    int tid,
+    int num_threads,
+    int data_stride,
+    int out_stride) {
+    for (int d = tid; d < DIM; d += num_threads) {
+        float prefix = 1.0f;
+        #pragma unroll
+        for (int row = 0; row < ROWS; ++row) {
+            if (row < valid_rows) {
+                prefix *= static_cast<float>(math::sigmoid(data[row * data_stride + d]));
+                prefix_products[row * out_stride + d] = prefix;
+            } else {
+                prefix_products[row * out_stride + d] = 0.0f;
+            }
+        }
+    }
+    __syncthreads();
+}
+
+template <int C, int K_DIM, typename T>
+__forceinline__ __device__ void compute_intra_chunk_kkt_strided(
+    const T* __restrict__ s_K,
+    const float* __restrict__ s_G_prefix,
+    const T* __restrict__ s_Beta,
+    float* __restrict__ s_M,
+    int valid_c,
+    int tid,
+    int num_threads,
+    int k_stride,
+    int g_stride,
+    int m_stride) {
+    const int total_elements = C * C;
+    for (int idx = tid; idx < total_elements; idx += num_threads) {
+        const int row = idx / C;
+        const int col = idx % C;
+
+        if (row >= valid_c || col >= valid_c || row <= col) {
+            s_M[row * m_stride + col] = 0.0f;
+            continue;
+        }
+
+        float dot_product = 0.0f;
+        #pragma unroll
+        for (int d = 0; d < K_DIM; ++d) {
+            float k_i = static_cast<float>(s_K[row * k_stride + d]);
+            float k_j = static_cast<float>(s_K[col * k_stride + d]);
+            float decay = s_G_prefix[row * g_stride + d] / s_G_prefix[col * g_stride + d];
+            dot_product = fmaf(k_i * k_j, decay, dot_product);
+        }
+
+        float beta_i = static_cast<float>(math::softplus(s_Beta[row]));
+        s_M[row * m_stride + col] = dot_product * beta_i;
+    }
+}
+
+template <int C>
+__forceinline__ __device__ void invert_lower_triangular_strided(
+    float* __restrict__ s_M,
+    float* __restrict__ row_cache,
+    int valid_c,
+    int tid,
+    int num_threads,
+    int m_stride) {
+    for (int i = tid; i < C; i += num_threads) {
+        s_M[i * m_stride + i] = (i < valid_c) ? 1.0f : 0.0f;
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int i = 1; i < valid_c; ++i) {
+        for (int k = tid; k < i; k += num_threads) {
+            row_cache[k] = s_M[i * m_stride + k];
+        }
+        __syncthreads();
+
+        for (int j = tid; j < i; j += num_threads) {
+            float sum = 0.0f;
+            #pragma unroll
+            for (int k = 0; k < C; ++k) {
+                if (k < j || k >= i) {
+                    continue;
+                }
+                float m_kj = (k == j) ? 1.0f : s_M[k * m_stride + j];
+                sum += row_cache[k] * m_kj;
+            }
+            s_M[i * m_stride + j] = -sum;
+        }
+        __syncthreads();
+    }
+}
+
+template <int C, int K_DIM, typename T>
+__forceinline__ __device__ void compute_W_and_U_local_strided(
+    const float* __restrict__ s_M,
+    const T* __restrict__ s_K,
+    const T* __restrict__ s_V,
+    const T* __restrict__ s_G,
+    T* __restrict__ s_W,
+    T* __restrict__ s_U,
+    int valid_c,
+    int v_local_dim,
+    int tid,
+    int num_threads,
+    int m_stride,
+    int k_stride,
+    int v_stride) {
+    const int total_w = C * K_DIM;
+    for (int idx = tid; idx < total_w; idx += num_threads) {
+        const int row = idx / K_DIM;
+        const int d = idx % K_DIM;
+        if (row >= valid_c) {
+            s_W[row * k_stride + d] = static_cast<T>(0);
+            continue;
+        }
+
+        float w_acc = 0.0f;
+        #pragma unroll
+        for (int j = 0; j <= row; ++j) {
+            float m_val = s_M[row * m_stride + j];
+            float k_val = static_cast<float>(s_K[j * k_stride + d]);
+            float gamma_val = static_cast<float>(math::swish(s_G[j * k_stride + d]));
+            w_acc = fmaf(m_val, gamma_val * k_val, w_acc);
+        }
+        s_W[row * k_stride + d] = static_cast<T>(w_acc);
+    }
+
+    const int total_u = C * v_local_dim;
+    for (int idx = tid; idx < total_u; idx += num_threads) {
+        const int row = idx / v_local_dim;
+        const int d = idx % v_local_dim;
+        if (row >= valid_c) {
+            s_U[row * v_stride + d] = static_cast<T>(0);
+            continue;
+        }
+
+        float u_acc = 0.0f;
+        #pragma unroll
+        for (int j = 0; j <= row; ++j) {
+            float m_val = s_M[row * m_stride + j];
+            float v_val = static_cast<float>(s_V[j * v_stride + d]);
+            u_acc = fmaf(m_val, v_val, u_acc);
+        }
+        s_U[row * v_stride + d] = static_cast<T>(u_acc);
+    }
+}
+
+template <int C, int K_DIM, int V_DIM, typename T, typename Params>
+__forceinline__ __device__ void prefetch_chunk_stage_async(
+    T* __restrict__ s_K,
+    T* __restrict__ s_Q,
+    T* __restrict__ s_G,
+    T* __restrict__ s_V,
+    T* __restrict__ s_Beta,
+    const Params& params,
+    int batch_idx,
+    int head_idx,
+    int chunk_idx,
+    int v_begin,
+    int v_local_dim,
+    int tid,
+    int num_threads,
+    int k_stride,
+    int v_stride) {
+    const int start_token = chunk_idx * C;
+    const int remain = params.seq_len - start_token;
+    const int valid_c = (remain > 0) ? ((remain < C) ? remain : C) : 0;
+    const std::size_t qk_base =
+        ((static_cast<std::size_t>(batch_idx) * params.num_heads + head_idx) * params.seq_len + start_token) *
+        K_DIM;
+    const std::size_t v_base =
+        ((static_cast<std::size_t>(batch_idx) * params.num_heads + head_idx) * params.seq_len + start_token) *
+        V_DIM;
+    const std::size_t beta_base =
+        ((static_cast<std::size_t>(batch_idx) * params.num_heads + head_idx) * params.seq_len + start_token);
+
+    for (int idx = tid; idx < C * K_DIM; idx += num_threads) {
+        int row = idx / K_DIM;
+        int d = idx % K_DIM;
+        if (row < valid_c) {
+            copy_async_global_to_shared(&s_K[row * k_stride + d], &params.k_ptr[qk_base + row * K_DIM + d]);
+            copy_async_global_to_shared(&s_Q[row * k_stride + d], &params.q_ptr[qk_base + row * K_DIM + d]);
+            copy_async_global_to_shared(&s_G[row * k_stride + d], &params.g_ptr[qk_base + row * K_DIM + d]);
+        } else {
+            s_K[row * k_stride + d] = static_cast<T>(0);
+            s_Q[row * k_stride + d] = static_cast<T>(0);
+            s_G[row * k_stride + d] = static_cast<T>(0);
+        }
+    }
+
+    for (int idx = tid; idx < C * v_local_dim; idx += num_threads) {
+        int row = idx / v_local_dim;
+        int d = idx % v_local_dim;
+        if (row < valid_c) {
+            copy_async_global_to_shared(
+                &s_V[row * v_stride + d],
+                &params.v_ptr[v_base + row * V_DIM + (v_begin + d)]);
+        } else {
+            s_V[row * v_stride + d] = static_cast<T>(0);
+        }
+    }
+
+    for (int row = tid; row < C; row += num_threads) {
+        if (row < valid_c) {
+            copy_async_global_to_shared(&s_Beta[row], &params.beta_ptr[beta_base + row]);
+        } else {
+            s_Beta[row] = static_cast<T>(0);
+        }
+    }
+
+    cp_async_commit_group();
+}
+
+// Strictly lower-triangular KKT dot products inside the chunk.
+template <int C, int K_DIM, typename T>
+__forceinline__ __device__ void compute_intra_chunk_kkt(
+    const T* __restrict__ s_K,
+    const float* __restrict__ s_G_prefix,
+    const T* __restrict__ s_Beta,
+    float* __restrict__ s_M,
+    int valid_c,
+    int tid,
+    int num_threads) {
+    int total_elements = C * C;
+    for (int idx = tid; idx < total_elements; idx += num_threads) {
+        int row = idx / C;
+        int col = idx % C;
+
+        if (row >= valid_c || col >= valid_c || row <= col) {
+            s_M[row * C + col] = 0.0f;
+            continue;
+        }
+
+        float dot_product = 0.0f;
+        #pragma unroll
+        for (int d = 0; d < K_DIM; ++d) {
+            float k_i = static_cast<float>(s_K[row * K_DIM + d]);
+            float k_j = static_cast<float>(s_K[col * K_DIM + d]);
+            const float prefix_row = s_G_prefix[row * K_DIM + d];
+            const float prefix_col = s_G_prefix[col * K_DIM + d];
+            float decay = prefix_row / prefix_col;
+            dot_product = fmaf(k_i * k_j, decay, dot_product);
+        }
+
+        float beta_i = static_cast<float>(math::softplus(s_Beta[row]));
+        s_M[row * C + col] = dot_product * beta_i;
+    }
+}
+
+// In-place inverse of (I + L) via forward substitution; result in s_M.
+template <int C>
+__forceinline__ __device__ void invert_lower_triangular(
+    float* __restrict__ s_M,
+    float* __restrict__ row_cache,
+    int valid_c,
+    int tid,
+    int num_threads) {
+    for (int i = tid; i < C; i += num_threads) {
+        s_M[i * C + i] = (i < valid_c) ? 1.0f : 0.0f;
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int i = 1; i < valid_c; ++i) {
+        for (int k = tid; k < i; k += num_threads) {
+            row_cache[k] = s_M[i * C + k];
+        }
+        __syncthreads();
+
+        for (int j = tid; j < i; j += num_threads) {
+            float sum = 0.0f;
+            #pragma unroll
+            for (int k = 0; k < C; ++k) {
+                if (k < j || k >= i) {
+                    continue;
+                }
+                float m_kj = (k == j) ? 1.0f : s_M[k * C + j];
+                sum += row_cache[k] * m_kj;
+            }
+            s_M[i * C + j] = -sum;
+        }
+        __syncthreads();
+    }
+}
+
+// Effective W/U from inverted system; write chunk slices to global w/u.
+template <int C, int K_DIM, int V_DIM, typename T, typename Params>
+__forceinline__ __device__ void compute_W_and_U_and_store(
+    const float* __restrict__ s_M,
+    const T* __restrict__ s_K,
+    const T* __restrict__ s_V,
+    const T* __restrict__ s_G,
+    Params& params,
+    int chunk_idx, int head_idx, int batch_idx,
+    int valid_c,
+    int tid,
+    int num_threads) {
+    T* W_global = tensor::get_chunk_slice<C, K_DIM>(
+        params.w_ptr, params.batch_size, params.num_heads, params.num_chunks, batch_idx, head_idx, chunk_idx);
+    T* U_global = tensor::get_chunk_slice<C, V_DIM>(
+        params.u_ptr, params.batch_size, params.num_heads, params.num_chunks, batch_idx, head_idx, chunk_idx);
+
+    int total_w = C * K_DIM;
+    for (int idx = tid; idx < total_w; idx += num_threads) {
+        int row = idx / K_DIM;
+        int d   = idx % K_DIM;
+
+        if (row >= valid_c) {
+            W_global[row * K_DIM + d] = static_cast<T>(0);
+            continue;
+        }
+
+        float w_acc = 0.0f;
+        #pragma unroll
+        for (int j = 0; j <= row; ++j) {
+            float m_val = s_M[row * C + j];
+            int mem_idx = j * K_DIM + d;
+            float k_val = static_cast<float>(s_K[mem_idx]);
+            float gamma_val = static_cast<float>(math::swish(s_G[mem_idx]));
+            w_acc = fmaf(m_val, gamma_val * k_val, w_acc);
+        }
+        W_global[row * K_DIM + d] = static_cast<T>(w_acc);
+    }
+
+    int total_u = C * V_DIM;
+    for (int idx = tid; idx < total_u; idx += num_threads) {
+        int row = idx / V_DIM;
+        int d = idx % V_DIM;
+        if (row >= valid_c) {
+            U_global[row * V_DIM + d] = static_cast<T>(0);
+            continue;
+        }
+        float u_acc = 0.0f;
+        #pragma unroll
+        for (int j = 0; j <= row; ++j) {
+            float m_val = s_M[row * C + j];
+            float v_val = static_cast<float>(s_V[j * V_DIM + d]);
+            u_acc = fmaf(m_val, v_val, u_acc);
+        }
+        U_global[row * V_DIM + d] = static_cast<T>(u_acc);
+    }
+}
+
+template <typename T>
+__forceinline__ __device__ void wmma_store_accumulator_row_major(
+    float* __restrict__ dst,
+    const wmma::fragment<wmma::accumulator, 16, 16, 8, float>& frag) {
+    wmma::store_matrix_sync(dst, frag, 16, wmma::mem_row_major);
+}
+
+template <typename T>
+__forceinline__ __device__ void inter_chunk_wmma_64x16(
+    float* __restrict__ s_S_matrix,
+    T* __restrict__ s_Q,
+    T* __restrict__ s_W,
+    T* __restrict__ s_U,
+    float* __restrict__ s_G_prefix,
+    float* __restrict__ s_tile_scratch,
+    T* __restrict__ o_ptr,
+    std::size_t o_base,
+    int valid_c,
+    int v_begin,
+    int tid,
+    int v_stride,
+    int k_stride) {
+    const int warp_id = tid / 32;
+
+    for (int idx = tid; idx < 32 * 64; idx += blockDim.x) {
+        int row = idx / 64;
+        int k = idx % 64;
+        if (row < valid_c) {
+            s_Q[row * k_stride + k] =
+                static_cast<T>(static_cast<float>(s_Q[row * k_stride + k]) *
+                               s_G_prefix[row * k_stride + k]);
+        } else {
+            s_Q[row * k_stride + k] = static_cast<T>(0);
+        }
+    }
+    __syncthreads();
+
+    if (warp_id < 2) {
+        const int row_tile = warp_id * 16;
+        wmma::fragment<wmma::accumulator, 16, 16, 8, float> acc;
+        wmma::fill_fragment(acc, 0.0f);
+
+        #pragma unroll
+        for (int kk = 0; kk < 64; kk += 8) {
+            wmma::fragment<wmma::matrix_a, 16, 16, 8, wmma::precision::tf32, wmma::row_major> a_frag;
+            wmma::fragment<wmma::matrix_b, 16, 16, 8, wmma::precision::tf32, wmma::row_major> b_frag;
+            const float* a_ptr = reinterpret_cast<const float*>(s_Q) + row_tile * k_stride + kk;
+            const float* b_ptr = s_S_matrix + kk * v_stride;
+            wmma::load_matrix_sync(a_frag, a_ptr, k_stride);
+            wmma::load_matrix_sync(b_frag, b_ptr, v_stride);
+            wmma::mma_sync(acc, a_frag, b_frag, acc);
+        }
+        wmma_store_accumulator_row_major<T>(s_tile_scratch + row_tile * 16, acc);
+    }
+    __syncthreads();
+
+    for (int idx = tid; idx < 32 * 16; idx += blockDim.x) {
+        int row = idx / 16;
+        int v_local = idx % 16;
+        if (row < valid_c) {
+            float out = s_tile_scratch[row * 16 + v_local] +
+                        static_cast<float>(s_U[row * v_stride + v_local]);
+            o_ptr[o_base + row * 64 + (v_begin + v_local)] = static_cast<T>(out);
+        }
+    }
+    __syncthreads();
+
+    if (warp_id < 4) {
+        const int row_tile = warp_id * 16;
+        wmma::fragment<wmma::accumulator, 16, 16, 8, float> acc;
+        wmma::fill_fragment(acc, 0.0f);
+
+        #pragma unroll
+        for (int kk = 0; kk < 32; kk += 8) {
+            wmma::fragment<wmma::matrix_a, 16, 16, 8, wmma::precision::tf32, wmma::col_major> a_frag;
+            wmma::fragment<wmma::matrix_b, 16, 16, 8, wmma::precision::tf32, wmma::row_major> b_frag;
+            const float* a_ptr = reinterpret_cast<const float*>(s_W) + kk * k_stride + row_tile;
+            const float* b_ptr = reinterpret_cast<const float*>(s_U) + kk * v_stride;
+            wmma::load_matrix_sync(a_frag, a_ptr, k_stride);
+            wmma::load_matrix_sync(b_frag, b_ptr, v_stride);
+            wmma::mma_sync(acc, a_frag, b_frag, acc);
+        }
+        wmma_store_accumulator_row_major<T>(s_tile_scratch + row_tile * 16, acc);
+    }
+    __syncthreads();
+
+    for (int idx = tid; idx < 64 * 16; idx += blockDim.x) {
+        int k = idx / 16;
+        int v_local = idx % 16;
+        float decay_val = s_G_prefix[(valid_c - 1) * k_stride + k];
+        s_S_matrix[k * v_stride + v_local] =
+            s_S_matrix[k * v_stride + v_local] * decay_val + s_tile_scratch[idx];
+    }
+    __syncthreads();
+}
+
+template <int C, int K_DIM, int V_DIM, typename T, typename Params>
+__forceinline__ __device__ void compute_W_and_U_and_store_strided(
+    const float* __restrict__ s_M,
+    const T* __restrict__ s_K,
+    const T* __restrict__ s_V,
+    const T* __restrict__ s_G,
+    Params& params,
+    int chunk_idx, int head_idx, int batch_idx,
+    int valid_c,
+    int tid,
+    int num_threads,
+    int m_stride,
+    int k_stride,
+    int v_stride) {
+    T* W_global = tensor::get_chunk_slice<C, K_DIM>(
+        params.w_ptr, params.batch_size, params.num_heads, params.num_chunks, batch_idx, head_idx, chunk_idx);
+    T* U_global = tensor::get_chunk_slice<C, V_DIM>(
+        params.u_ptr, params.batch_size, params.num_heads, params.num_chunks, batch_idx, head_idx, chunk_idx);
+
+    int total_w = C * K_DIM;
+    for (int idx = tid; idx < total_w; idx += num_threads) {
+        int row = idx / K_DIM;
+        int d = idx % K_DIM;
+        if (row >= valid_c) {
+            W_global[row * K_DIM + d] = static_cast<T>(0);
+            continue;
+        }
+
+        float w_acc = 0.0f;
+        #pragma unroll
+        for (int j = 0; j <= row; ++j) {
+            float m_val = s_M[row * m_stride + j];
+            float k_val = static_cast<float>(s_K[j * k_stride + d]);
+            float gamma_val = static_cast<float>(math::swish(s_G[j * k_stride + d]));
+            w_acc = fmaf(m_val, gamma_val * k_val, w_acc);
+        }
+        W_global[row * K_DIM + d] = static_cast<T>(w_acc);
+    }
+
+    int total_u = C * V_DIM;
+    for (int idx = tid; idx < total_u; idx += num_threads) {
+        int row = idx / V_DIM;
+        int d = idx % V_DIM;
+        if (row >= valid_c) {
+            U_global[row * V_DIM + d] = static_cast<T>(0);
+            continue;
+        }
+
+        float u_acc = 0.0f;
+        #pragma unroll
+        for (int j = 0; j <= row; ++j) {
+            float m_val = s_M[row * m_stride + j];
+            float v_val = static_cast<float>(s_V[j * v_stride + d]);
+            u_acc = fmaf(m_val, v_val, u_acc);
+        }
+        U_global[row * V_DIM + d] = static_cast<T>(u_acc);
+    }
+}
+
+// Intra-chunk: KKT, invert, W/U, write intermediates.
+template <typename Params>
+__global__ void kda_intra_chunk_kernel(Params params) {
+    static_assert(Params::V_DIM >= Params::K_DIM,
+                  "temporary intra-chunk prefix buffer requires V_DIM >= K_DIM");
+    constexpr int k_stride = Params::K_DIM + 1;
+    constexpr int v_stride = Params::V_DIM + 1;
+    constexpr int m_stride = Params::C + 1;
+    int chunk_idx = blockIdx.x;
+    int head_idx  = blockIdx.y;
+    int batch_idx = blockIdx.z;
+    int tid = threadIdx.x;        
+    int num_threads = blockDim.x;  
+
+    extern __shared__ char smem[];
+    using T = typename Params::element_type; 
+    
+    T* s_K     = reinterpret_cast<T*>(smem);
+    T* s_V     = s_K + (Params::C * k_stride);
+    T* s_G     = s_V + (Params::C * v_stride);
+    T* s_Beta  = s_G + (Params::C * k_stride);
+    float* s_M = reinterpret_cast<float*>(s_Beta + Params::C);
+    float* s_row_scales = s_M + (Params::C * m_stride);
+    float* s_G_prefix = reinterpret_cast<float*>(s_V);
+
+    const int start_token = chunk_idx * Params::C;
+    const int remain = params.seq_len - start_token;
+    const int valid_c = (remain > 0) ? ((remain < Params::C) ? remain : Params::C) : 0;
+    if (valid_c <= 0) return;
+
+    const int k_base = ((batch_idx * params.num_heads + head_idx) * params.seq_len + start_token) * Params::K_DIM;
+    const int v_base = ((batch_idx * params.num_heads + head_idx) * params.seq_len + start_token) * Params::V_DIM;
+    const int b_base = ((batch_idx * params.num_heads + head_idx) * params.seq_len + start_token);
+
+    for (int idx = tid; idx < Params::C * Params::K_DIM; idx += num_threads) {
+        int r = idx / Params::K_DIM;
+        int d = idx % Params::K_DIM;
+        if (r < valid_c) {
+            copy_async_global_to_shared(&s_K[r * k_stride + d], &params.k_ptr[k_base + r * Params::K_DIM + d]);
+            copy_async_global_to_shared(&s_G[r * k_stride + d], &params.g_ptr[k_base + r * Params::K_DIM + d]);
+        } else {
+            s_K[r * k_stride + d] = static_cast<T>(0);
+            s_G[r * k_stride + d] = static_cast<T>(0);
+        }
+    }
+    for (int r = tid; r < Params::C; r += num_threads) {
+        if (r < valid_c) {
+            copy_async_global_to_shared(&s_Beta[r], &params.beta_ptr[b_base + r]);
+        } else {
+            s_Beta[r] = static_cast<T>(0);
+        }
+    }
+    cp_async_commit_group();
+    cp_async_wait_group_0();
+    __syncthreads();
+
+    normalize_rows_inplace_strided<Params::C, Params::K_DIM, T>(
+        s_K, s_row_scales, valid_c, 1.0f, tid, num_threads, k_stride);
+    __syncthreads();
+
+    compute_sigmoid_prefix_products_strided<Params::C, Params::K_DIM, T>(
+        s_G, s_G_prefix, valid_c, tid, num_threads, k_stride, v_stride);
+    compute_intra_chunk_kkt_strided<Params::C, Params::K_DIM, T>(
+        s_K, s_G_prefix, s_Beta, s_M, valid_c, tid, num_threads, k_stride, v_stride, m_stride);
+    __syncthreads(); 
+
+    invert_lower_triangular_strided<Params::C>(
+        s_M, s_row_scales, valid_c, tid, num_threads, m_stride);
+    __syncthreads(); 
+
+    for (int idx = tid; idx < Params::C * Params::V_DIM; idx += num_threads) {
+        int r = idx / Params::V_DIM;
+        int d = idx % Params::V_DIM;
+        if (r < valid_c) {
+            copy_async_global_to_shared(&s_V[r * v_stride + d], &params.v_ptr[v_base + r * Params::V_DIM + d]);
+        } else {
+            s_V[r * v_stride + d] = static_cast<T>(0);
+        }
+    }
+    cp_async_commit_group();
+    cp_async_wait_group_0();
+    __syncthreads();
+
+    compute_W_and_U_and_store_strided<Params::C, Params::K_DIM, Params::V_DIM, T, Params>(
+        s_M, s_K, s_V, s_G, params, chunk_idx, head_idx, batch_idx, valid_c, tid, num_threads,
+        m_stride, k_stride, v_stride);
+}
+
+// Inter-chunk RNN: hidden state S in shared memory, serial over chunks.
+template <typename Params>
+__global__ void kda_inter_chunk_rnn_kernel(Params params) {
+    constexpr int k_stride = Params::K_DIM + 1;
+    int head_idx = blockIdx.x;
+    int batch_idx = blockIdx.y;
+    int shard_idx = blockIdx.z;
+    int tid = threadIdx.x;
+    int num_threads = blockDim.x;
+
+    extern __shared__ char smem[];
+    using T = typename Params::element_type;
+
+    const int v_tile = params.inter_v_tile;
+    const int v_begin = shard_idx * v_tile;
+    const int v_end = (v_begin + v_tile < Params::V_DIM) ? (v_begin + v_tile) : Params::V_DIM;
+    const int v_local_dim = (v_end > v_begin) ? (v_end - v_begin) : 0;
+    if (v_local_dim <= 0) return;
+
+    float* s_S_matrix = reinterpret_cast<float*>(smem);  // [K_DIM, v_tile+1]
+    T* s_Q = reinterpret_cast<T*>(s_S_matrix + (Params::K_DIM * (v_tile + 1)));
+    T* s_W = s_Q + (Params::C * k_stride);
+    T* s_U = s_W + (Params::C * k_stride);  // [C, v_tile+1]
+    float* s_row_scales = reinterpret_cast<float*>(s_U + (Params::C * (v_tile + 1)));
+    float* s_G_prefix = s_row_scales + Params::C;
+    float* s_tile_scratch = s_G_prefix + (Params::C * k_stride);
+
+    int S_elements = Params::K_DIM * (v_tile + 1);
+    for (int i = tid; i < S_elements; i += num_threads) {
+        s_S_matrix[i] = 0.0f;
+    }
+    __syncthreads();
+
+    for (int t = 0; t < params.num_chunks; ++t) {
+        const int start_token = t * Params::C;
+        const int remain = params.seq_len - start_token;
+        const int valid_c = (remain > 0) ? ((remain < Params::C) ? remain : Params::C) : 0;
+        if (valid_c <= 0) break;
+
+        const std::size_t q_base =
+            ((static_cast<std::size_t>(batch_idx) * params.num_heads + head_idx) * params.seq_len + start_token) *
+            Params::K_DIM;
+        const T* W_global = tensor::get_chunk_slice<Params::C, Params::K_DIM>(
+            params.w_ptr, params.batch_size, params.num_heads, params.num_chunks, batch_idx, head_idx, t);
+        const T* U_global = tensor::get_chunk_slice<Params::C, Params::V_DIM>(
+            params.u_ptr, params.batch_size, params.num_heads, params.num_chunks, batch_idx, head_idx, t);
+
+        for (int idx = tid; idx < Params::C * Params::K_DIM; idx += num_threads) {
+            int r = idx / Params::K_DIM;
+            int d = idx % Params::K_DIM;
+            if (r < valid_c) {
+                copy_async_global_to_shared(&s_Q[r * k_stride + d], &params.q_ptr[q_base + r * Params::K_DIM + d]);
+                copy_async_global_to_shared(&s_W[r * k_stride + d], &W_global[r * Params::K_DIM + d]);
+            } else {
+                s_Q[r * k_stride + d] = static_cast<T>(0);
+                s_W[r * k_stride + d] = static_cast<T>(0);
+            }
+        }
+        for (int idx = tid; idx < Params::C * v_tile; idx += num_threads) {
+            int r = idx / v_tile;
+            int d_local = idx % v_tile;
+            int d_global = v_begin + d_local;
+            if (r < valid_c && d_global < Params::V_DIM) {
+                copy_async_global_to_shared(
+                    &s_U[r * (v_tile + 1) + d_local], &U_global[r * Params::V_DIM + d_global]);
+            } else {
+                s_U[r * (v_tile + 1) + d_local] = static_cast<T>(0);
+            }
+        }
+        cp_async_commit_group();
+        cp_async_wait_group_0();
+        __syncthreads();
+
+        if constexpr (Params::C == 32 && Params::K_DIM == 64) {
+            normalize_rows_warp_32x64(
+                s_Q,
+                s_row_scales,
+                valid_c,
+                rsqrtf(static_cast<float>(Params::K_DIM)),
+                tid,
+                k_stride);
+        } else {
+            normalize_rows_inplace_strided<Params::C, Params::K_DIM, T>(
+                s_Q,
+                s_row_scales,
+                valid_c,
+                rsqrtf(static_cast<float>(Params::K_DIM)),
+                tid,
+                num_threads,
+                k_stride);
+        }
+        __syncthreads();
+
+        if constexpr (Params::C == 32 && Params::K_DIM == 64) {
+            compute_sigmoid_prefix_products_warp_32x64(
+                params.g_ptr + q_base, s_G_prefix, valid_c, tid, Params::K_DIM, k_stride);
+        } else {
+            compute_sigmoid_prefix_products_strided<Params::C, Params::K_DIM, T>(
+                params.g_ptr + q_base, s_G_prefix, valid_c, tid, num_threads, Params::K_DIM, k_stride);
+        }
+
+        const std::size_t o_base =
+            ((static_cast<std::size_t>(batch_idx) * params.num_heads + head_idx) * params.seq_len + start_token) *
+            Params::V_DIM;
+
+        if constexpr (std::is_same_v<T, float> && Params::C == 32 && Params::K_DIM == 64 && Params::V_DIM == 64) {
+            if (v_local_dim == 16) {
+                inter_chunk_wmma_64x16<T>(
+                    s_S_matrix,
+                    s_Q,
+                    s_W,
+                    s_U,
+                    s_G_prefix,
+                    s_tile_scratch,
+                    params.o_ptr,
+                    o_base,
+                    valid_c,
+                    v_begin,
+                    tid,
+                    v_tile + 1,
+                    k_stride);
+            } else {
+                int O_elements = Params::C * v_local_dim;
+                for (int idx = tid; idx < O_elements; idx += num_threads) {
+                    int row = idx / v_local_dim;
+                    int v_local = idx % v_local_dim;
+                    int v_global = v_begin + v_local;
+
+                    if (row >= valid_c) continue;
+                    float o_acc = 0.0f;
+                    #pragma unroll
+                    for (int k = 0; k < Params::K_DIM; ++k) {
+                        float q_val = static_cast<float>(s_Q[row * k_stride + k]);
+                        float s_val = s_S_matrix[k * (v_tile + 1) + v_local];
+                        float prefix_decay = s_G_prefix[row * k_stride + k];
+                        o_acc = fmaf(q_val, s_val * prefix_decay, o_acc);
+                    }
+                    o_acc += static_cast<float>(s_U[row * (v_tile + 1) + v_local]);
+                    params.o_ptr[o_base + row * Params::V_DIM + v_global] = static_cast<T>(o_acc);
+                }
+                __syncthreads();
+
+                for (int idx = tid; idx < S_elements; idx += num_threads) {
+                    int k = idx / (v_tile + 1);
+                    int v_local = idx % (v_tile + 1);
+                    if (k >= Params::K_DIM || v_local >= v_local_dim) {
+                        continue;
+                    }
+                    float decay_val = s_G_prefix[(valid_c - 1) * k_stride + k];
+
+                    float update = 0.0f;
+                    #pragma unroll
+                    for (int c = 0; c < valid_c; ++c) {
+                        float w_val = static_cast<float>(s_W[c * k_stride + k]);
+                        float u_val = static_cast<float>(s_U[c * (v_tile + 1) + v_local]);
+                        update = fmaf(w_val, u_val, update);
+                    }
+                    s_S_matrix[k * (v_tile + 1) + v_local] =
+                        (s_S_matrix[k * (v_tile + 1) + v_local] * decay_val) + update;
+                }
+                __syncthreads();
+            }
+        } else {
+            int O_elements = Params::C * v_local_dim;
+            for (int idx = tid; idx < O_elements; idx += num_threads) {
+                int row = idx / v_local_dim;
+                int v_local = idx % v_local_dim;
+                int v_global = v_begin + v_local;
+
+                if (row >= valid_c) continue;
+                float o_acc = 0.0f;
+                #pragma unroll
+                for (int k = 0; k < Params::K_DIM; ++k) {
+                    float q_val = static_cast<float>(s_Q[row * k_stride + k]);
+                    float s_val = s_S_matrix[k * (v_tile + 1) + v_local];
+                    float prefix_decay = s_G_prefix[row * k_stride + k];
+                    o_acc = fmaf(q_val, s_val * prefix_decay, o_acc);
+                }
+                o_acc += static_cast<float>(s_U[row * (v_tile + 1) + v_local]);
+                params.o_ptr[o_base + row * Params::V_DIM + v_global] = static_cast<T>(o_acc);
+            }
+            __syncthreads();
+
+            for (int idx = tid; idx < S_elements; idx += num_threads) {
+                int k = idx / (v_tile + 1);
+                int v_local = idx % (v_tile + 1);
+                if (k >= Params::K_DIM || v_local >= v_local_dim) {
+                    continue;
+                }
+                float decay_val = s_G_prefix[(valid_c - 1) * k_stride + k];
+
+                float update = 0.0f;
+                #pragma unroll
+                for (int c = 0; c < valid_c; ++c) {
+                    float w_val = static_cast<float>(s_W[c * k_stride + k]);
+                    float u_val = static_cast<float>(s_U[c * (v_tile + 1) + v_local]);
+                    update = fmaf(w_val, u_val, update);
+                }
+                s_S_matrix[k * (v_tile + 1) + v_local] =
+                    (s_S_matrix[k * (v_tile + 1) + v_local] * decay_val) + update;
+            }
+            __syncthreads();
+        }
+    }
+}
+
+template <typename Params>
+__global__ void kda_fused_prefill_kernel(Params params) {
+    static_assert(Params::K_DIM == 64 && Params::V_DIM == 64 && Params::C == 32,
+                  "fused prefill kernel currently specializes 64x64x32 only");
+    int head_idx = blockIdx.x;
+    int batch_idx = blockIdx.y;
+    int shard_idx = blockIdx.z;
+    int tid = threadIdx.x;
+    int num_threads = blockDim.x;
+
+    using T = typename Params::element_type;
+    constexpr int k_stride = Params::K_DIM + 1;
+    constexpr int m_stride = Params::C + 1;
+    const int v_tile = params.inter_v_tile;
+    const int v_stride = v_tile + 1;
+    const int v_begin = shard_idx * v_tile;
+    const int v_end = (v_begin + v_tile < Params::V_DIM) ? (v_begin + v_tile) : Params::V_DIM;
+    const int v_local_dim = (v_end > v_begin) ? (v_end - v_begin) : 0;
+    if (v_local_dim <= 0) {
+        return;
+    }
+
+    extern __shared__ char smem_raw[];
+    char* smem = smem_raw;
+
+    T* s_K_stage0 = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C * k_stride;
+    T* s_K_stage1 = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C * k_stride;
+    T* s_Q_stage0 = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C * k_stride;
+    T* s_Q_stage1 = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C * k_stride;
+    T* s_G_stage0 = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C * k_stride;
+    T* s_G_stage1 = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C * k_stride;
+    T* s_V_stage0 = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C * v_stride;
+    T* s_V_stage1 = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C * v_stride;
+    T* s_Beta_stage0 = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C;
+    T* s_Beta_stage1 = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C;
+
+    float* s_S_matrix = reinterpret_cast<float*>(smem);
+    smem += sizeof(float) * Params::K_DIM * v_stride;
+    float* s_M = reinterpret_cast<float*>(smem);
+    smem += sizeof(float) * Params::C * m_stride;
+    float* s_G_prefix = reinterpret_cast<float*>(smem);
+    smem += sizeof(float) * Params::C * k_stride;
+    float* s_row_scales = reinterpret_cast<float*>(smem);
+    smem += sizeof(float) * Params::C;
+    T* s_W = reinterpret_cast<T*>(smem);
+    smem += sizeof(T) * Params::C * k_stride;
+    T* s_U = reinterpret_cast<T*>(smem);
+
+    T* s_K_stages[2] = {s_K_stage0, s_K_stage1};
+    T* s_Q_stages[2] = {s_Q_stage0, s_Q_stage1};
+    T* s_G_stages[2] = {s_G_stage0, s_G_stage1};
+    T* s_V_stages[2] = {s_V_stage0, s_V_stage1};
+    T* s_Beta_stages[2] = {s_Beta_stage0, s_Beta_stage1};
+
+    const int S_elements = Params::K_DIM * v_stride;
+    for (int i = tid; i < S_elements; i += num_threads) {
+        s_S_matrix[i] = 0.0f;
+    }
+    __syncthreads();
+
+    if (params.num_chunks <= 0) {
+        return;
+    }
+
+    int current_stage = 0;
+    prefetch_chunk_stage_async<Params::C, Params::K_DIM, Params::V_DIM, T>(
+        s_K_stages[current_stage],
+        s_Q_stages[current_stage],
+        s_G_stages[current_stage],
+        s_V_stages[current_stage],
+        s_Beta_stages[current_stage],
+        params,
+        batch_idx,
+        head_idx,
+        0,
+        v_begin,
+        v_local_dim,
+        tid,
+        num_threads,
+        k_stride,
+        v_stride);
+    cp_async_wait_group_0();
+    __syncthreads();
+
+    for (int t = 0; t < params.num_chunks; ++t) {
+        const int start_token = t * Params::C;
+        const int remain = params.seq_len - start_token;
+        const int valid_c = (remain > 0) ? ((remain < Params::C) ? remain : Params::C) : 0;
+        if (valid_c <= 0) {
+            break;
+        }
+
+        T* s_K = s_K_stages[current_stage];
+        T* s_Q = s_Q_stages[current_stage];
+        T* s_G = s_G_stages[current_stage];
+        T* s_V = s_V_stages[current_stage];
+        T* s_Beta = s_Beta_stages[current_stage];
+
+        normalize_rows_inplace_strided<Params::C, Params::K_DIM, T>(
+            s_K, s_row_scales, valid_c, 1.0f, tid, num_threads, k_stride);
+        __syncthreads();
+
+        compute_sigmoid_prefix_products_strided<Params::C, Params::K_DIM, T>(
+            s_G, s_G_prefix, valid_c, tid, num_threads, k_stride, k_stride);
+        compute_intra_chunk_kkt_strided<Params::C, Params::K_DIM, T>(
+            s_K, s_G_prefix, s_Beta, s_M, valid_c, tid, num_threads, k_stride, k_stride, m_stride);
+        __syncthreads();
+
+        invert_lower_triangular_strided<Params::C>(
+            s_M, s_row_scales, valid_c, tid, num_threads, m_stride);
+        __syncthreads();
+
+        compute_W_and_U_local_strided<Params::C, Params::K_DIM, T>(
+            s_M, s_K, s_V, s_G, s_W, s_U, valid_c, v_local_dim, tid, num_threads, m_stride, k_stride, v_stride);
+        __syncthreads();
+
+        if (t + 1 < params.num_chunks) {
+            const int next_stage = current_stage ^ 1;
+            prefetch_chunk_stage_async<Params::C, Params::K_DIM, Params::V_DIM, T>(
+                s_K_stages[next_stage],
+                s_Q_stages[next_stage],
+                s_G_stages[next_stage],
+                s_V_stages[next_stage],
+                s_Beta_stages[next_stage],
+                params,
+                batch_idx,
+                head_idx,
+                t + 1,
+                v_begin,
+                v_local_dim,
+                tid,
+                num_threads,
+                k_stride,
+                v_stride);
+        }
+
+        normalize_rows_inplace_strided<Params::C, Params::K_DIM, T>(
+            s_Q,
+            s_row_scales,
+            valid_c,
+            rsqrtf(static_cast<float>(Params::K_DIM)),
+            tid,
+            num_threads,
+            k_stride);
+        __syncthreads();
+
+        const std::size_t o_base =
+            ((static_cast<std::size_t>(batch_idx) * params.num_heads + head_idx) * params.seq_len + start_token) *
+            Params::V_DIM;
+        const int O_elements = Params::C * v_local_dim;
+        for (int idx = tid; idx < O_elements; idx += num_threads) {
+            int row = idx / v_local_dim;
+            int v_local = idx % v_local_dim;
+            if (row >= valid_c) {
+                continue;
+            }
+
+            float o_acc = 0.0f;
+            #pragma unroll
+            for (int k = 0; k < Params::K_DIM; ++k) {
+                float q_val = static_cast<float>(s_Q[row * k_stride + k]);
+                float s_val = s_S_matrix[k * v_stride + v_local];
+                float prefix_decay = s_G_prefix[row * k_stride + k];
+                o_acc = fmaf(q_val, s_val * prefix_decay, o_acc);
+            }
+            o_acc += static_cast<float>(s_U[row * v_stride + v_local]);
+            params.o_ptr[o_base + row * Params::V_DIM + (v_begin + v_local)] = static_cast<T>(o_acc);
+        }
+        __syncthreads();
+
+        for (int idx = tid; idx < Params::K_DIM * v_local_dim; idx += num_threads) {
+            int k = idx / v_local_dim;
+            int v_local = idx % v_local_dim;
+            float decay_val = s_G_prefix[(valid_c - 1) * k_stride + k];
+            float update = 0.0f;
+            #pragma unroll
+            for (int c = 0; c < Params::C; ++c) {
+                if (c >= valid_c) {
+                    continue;
+                }
+                float w_val = static_cast<float>(s_W[c * k_stride + k]);
+                float u_val = static_cast<float>(s_U[c * v_stride + v_local]);
+                update = fmaf(w_val, u_val, update);
+            }
+            s_S_matrix[k * v_stride + v_local] =
+                s_S_matrix[k * v_stride + v_local] * decay_val + update;
+        }
+        __syncthreads();
+
+        if (t + 1 < params.num_chunks) {
+            cp_async_wait_group_0();
+            __syncthreads();
+            current_stage ^= 1;
+        }
+    }
+}
+
+} // namespace prefill
+} // namespace kernel
+} // namespace kda

--- a/include/kda_layouts.hpp
+++ b/include/kda_layouts.hpp
@@ -1,0 +1,38 @@
+// describe the "shape" and "stride".
+#pragma once
+
+#include <cstddef>
+
+#ifndef KDA_HOST_DEVICE
+#define KDA_HOST_DEVICE __forceinline__ __host__ __device__
+#endif
+
+namespace kda {
+namespace layouts {
+
+template <int Dim>
+struct FeatureLayout {
+  KDA_HOST_DEVICE static std::size_t offset(int b, int h, int t, int d, int B, int H, int T) {
+    (void)B;
+    return (((static_cast<std::size_t>(b) * H + h) * T + t) * Dim + d);
+  }
+};
+
+struct GateLayout {
+  KDA_HOST_DEVICE static std::size_t offset(int b, int h, int t, int B, int H, int T) {
+    (void)B;
+    return ((static_cast<std::size_t>(b) * H + h) * T + t);
+  }
+};
+
+template <int C>
+struct ChunkMatrixLayout {
+  KDA_HOST_DEVICE static std::size_t offset(
+      int b, int h, int cidx, int row, int col, int B, int H, int num_chunks) {
+    (void)B;
+    return ((((static_cast<std::size_t>(b) * H + h) * num_chunks + cidx) * C + row) * C + col);
+  }
+};
+
+}  // namespace layouts
+}  // namespace kda

--- a/include/kda_math.hpp
+++ b/include/kda_math.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cmath>
+#include <cuda_runtime.h>
+
+#ifndef KDA_HOST_DEVICE
+#define KDA_HOST_DEVICE __forceinline__ __host__ __device__
+#endif
+
+namespace kda {
+namespace math {
+
+using fp32 = float;
+
+KDA_HOST_DEVICE float fast_exp_f32(float x) {
+#if defined(__CUDA_ARCH__)
+  return __expf(x);
+#else
+  return std::exp(x);
+#endif
+}
+
+KDA_HOST_DEVICE float fast_log_f32(float x) {
+#if defined(__CUDA_ARCH__)
+  return __logf(x);
+#else
+  return std::log(x);
+#endif
+}
+
+template <typename T>
+KDA_HOST_DEVICE T sigmoid(T x) {
+  const float x_f = static_cast<float>(x);
+  const float res = 1.0f / (1.0f + fast_exp_f32(-x_f));
+  return static_cast<T>(res);
+}
+
+template <typename T>
+KDA_HOST_DEVICE T swish(T x) {
+  const float x_f = static_cast<float>(x);
+  return static_cast<T>(x_f * static_cast<float>(sigmoid(x_f)));
+}
+
+template <typename T>
+KDA_HOST_DEVICE T softplus(T x) {
+  const float x_f = static_cast<float>(x);
+  const float res = (x_f > 20.0f) ? x_f : fast_log_f32(1.0f + fast_exp_f32(x_f));
+  return static_cast<T>(res);
+}
+
+KDA_HOST_DEVICE fp32 warp_reduce_sum(fp32 val) {
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    val += __shfl_down_sync(0xffffffff, val, offset);
+  }
+  return __shfl_sync(0xffffffff, val, 0);
+#else
+  return val;
+#endif
+}
+
+template <typename T>
+KDA_HOST_DEVICE T fast_exp(T x) {
+  return static_cast<T>(fast_exp_f32(static_cast<float>(x)));
+}
+
+}  // namespace math
+}  // namespace kda

--- a/include/kda_params.hpp
+++ b/include/kda_params.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace kda {
+
+template <typename T, int K_DIM_SIZE, int V_DIM_SIZE, int CHUNK_SIZE>
+struct KdaPrefillParams {
+  using element_type = T;
+  static constexpr int K_DIM = K_DIM_SIZE;
+  static constexpr int V_DIM = V_DIM_SIZE;
+  static constexpr int C = CHUNK_SIZE;
+
+  // q/k/g: [B, H, T, K_DIM], v/o: [B, H, T, V_DIM], beta: [B, H, T]
+  const T* __restrict__ q_ptr;
+  const T* __restrict__ k_ptr;
+  const T* __restrict__ v_ptr;
+  const T* __restrict__ g_ptr;
+  const T* __restrict__ beta_ptr;
+
+  // Intra-chunk intermediates: [B, H, num_chunks, C, K_DIM/V_DIM]
+  T* __restrict__ w_ptr;
+  T* __restrict__ u_ptr;
+
+  // Final prefill output [B, H, T, V_DIM]
+  T* __restrict__ o_ptr;
+
+  int batch_size;
+  int num_heads;
+  int seq_len;
+  int num_chunks;
+  int inter_v_shards;
+  int inter_v_tile;
+};
+
+template <typename T, int K_DIM_SIZE, int V_DIM_SIZE, int CHUNK_SIZE>
+inline KdaPrefillParams<T, K_DIM_SIZE, V_DIM_SIZE, CHUNK_SIZE> make_prefill_params(
+    const T* q_ptr,
+    const T* k_ptr,
+    const T* v_ptr,
+    const T* g_ptr,
+    const T* beta_ptr,
+    T* w_ptr,
+    T* u_ptr,
+    T* o_ptr,
+    int batch_size,
+    int num_heads,
+    int seq_len) {
+  KdaPrefillParams<T, K_DIM_SIZE, V_DIM_SIZE, CHUNK_SIZE> params{};
+  params.q_ptr = q_ptr;
+  params.k_ptr = k_ptr;
+  params.v_ptr = v_ptr;
+  params.g_ptr = g_ptr;
+  params.beta_ptr = beta_ptr;
+  params.w_ptr = w_ptr;
+  params.u_ptr = u_ptr;
+  params.o_ptr = o_ptr;
+  params.batch_size = batch_size;
+  params.num_heads = num_heads;
+  params.seq_len = seq_len;
+  params.num_chunks = (seq_len + CHUNK_SIZE - 1) / CHUNK_SIZE;
+  params.inter_v_shards = 1;
+  params.inter_v_tile = V_DIM_SIZE;
+  return params;
+}
+
+}  // namespace kda

--- a/include/kda_prefill_io.hpp
+++ b/include/kda_prefill_io.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include <cuda_runtime.h>
+
+namespace kda {
+namespace api {
+
+// Host-side prefill IO contract (shared by CUDA launcher and PyTorch binding).
+//
+// Inputs:
+//   q/k/g: [B, H, T, K]
+//   v:     [B, H, T, V]
+//   beta:  [B, H, T]
+//
+// Intermediates:
+//   w: [B, H, num_chunks, C, K]
+//   u: [B, H, num_chunks, C, V]
+//
+// Output:
+//   o: [B, H, T, V]
+template <typename T>
+struct KdaPrefillIO {
+  const T* q_ptr = nullptr;
+  const T* k_ptr = nullptr;
+  const T* v_ptr = nullptr;
+  const T* g_ptr = nullptr;
+  const T* beta_ptr = nullptr;
+
+  T* w_ptr = nullptr;
+  T* u_ptr = nullptr;
+  T* o_ptr = nullptr;
+
+  int batch_size = 0;  // B
+  int num_heads = 0;   // H
+  int seq_len = 0;     // T
+  int head_dim = 0;    // K
+  int value_dim = 0;   // V
+  int chunk_size = 0;  // C
+  int num_chunks = 0;
+};
+
+}  // namespace api
+}  // namespace kda
+
+extern "C" cudaError_t kda_prefill_f32(
+    const kda::api::KdaPrefillIO<float>* io,
+    cudaStream_t stream);

--- a/include/kda_tensor.hpp
+++ b/include/kda_tensor.hpp
@@ -1,0 +1,82 @@
+// layout to tensor-view helpers
+#pragma once
+
+#include "kda_layouts.hpp"
+
+namespace kda {
+namespace tensor {
+
+template <typename T, int Dim>
+struct FeatureTensorView {
+  T* ptr;
+  int B, H, T_len;
+  int b, h;
+
+  KDA_HOST_DEVICE T& operator()(int t, int d) const {
+    return ptr[layouts::FeatureLayout<Dim>::offset(b, h, t, d, B, H, T_len)];
+  }
+
+  KDA_HOST_DEVICE T* data() const {
+    return ptr + layouts::FeatureLayout<Dim>::offset(b, h, 0, 0, B, H, T_len);
+  }
+};
+
+template <typename T>
+struct GateTensorView {
+  T* ptr;
+  int B, H, T_len;
+  int b, h;
+
+  KDA_HOST_DEVICE T& operator()(int t) const {
+    return ptr[layouts::GateLayout::offset(b, h, t, B, H, T_len)];
+  }
+};
+
+template <int C, int Dim, typename T>
+struct ChunkTensorView {
+  T* ptr;
+  int B, H, num_chunks;
+  int b, h;
+
+  KDA_HOST_DEVICE T& operator()(int chunk_idx, int row, int d) const {
+    const std::size_t base = (((static_cast<std::size_t>(b) * H + h) * num_chunks + chunk_idx) * C * Dim);
+    return ptr[base + row * Dim + d];
+  }
+};
+
+template <int Dim, typename T>
+KDA_HOST_DEVICE FeatureTensorView<T, Dim> get_feature_tensor(
+    T* ptr, int B, int H, int T_len, int batch_idx, int head_idx) {
+  return {ptr, B, H, T_len, batch_idx, head_idx};
+}
+
+template <typename T>
+KDA_HOST_DEVICE GateTensorView<T> get_gate_tensor(
+    T* ptr, int B, int H, int T_len, int batch_idx, int head_idx) {
+  return {ptr, B, H, T_len, batch_idx, head_idx};
+}
+
+template <int C, int Dim, typename T>
+KDA_HOST_DEVICE ChunkTensorView<C, Dim, T> get_chunk_tensor(
+    T* ptr, int B, int H, int num_chunks, int batch_idx, int head_idx) {
+  return {ptr, B, H, num_chunks, batch_idx, head_idx};
+}
+
+template <int C, int Dim, typename T>
+KDA_HOST_DEVICE T* get_chunk_slice(
+    T* ptr, int B, int H, int num_chunks, int batch_idx, int head_idx, int chunk_idx) {
+  const std::size_t base = (((static_cast<std::size_t>(batch_idx) * H + head_idx) * num_chunks + chunk_idx) * C * Dim);
+  (void)B;
+  return ptr + base;
+}
+
+template <int C, int Dim, typename T>
+KDA_HOST_DEVICE const T* get_chunk_slice(
+    const T* ptr, int B, int H, int num_chunks, int batch_idx, int head_idx, int chunk_idx) {
+  const std::size_t base = (((static_cast<std::size_t>(batch_idx) * H + head_idx) * num_chunks + chunk_idx) * C * Dim);
+  (void)B;
+  return ptr + base;
+}
+
+}  // namespace tensor
+}  // namespace kda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "nvidia-cutlass-dsl==4.4.2",
     "apache-tvm-ffi==0.1.9",
 ]
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 
 [project.optional-dependencies]
 dev = [

--- a/setup_KDA_cutlass_prefill_standalone.py
+++ b/setup_KDA_cutlass_prefill_standalone.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+
+cuda_home = os.environ.get("CUDA_HOME", "")
+nvcc = os.path.join(cuda_home, "bin", "nvcc") if cuda_home else ""
+if not cuda_home or not os.path.isfile(nvcc):
+    for candidate in ("/usr/local/cuda", "/usr/local/cuda-12.2", "/usr/local/cuda-12.8"):
+        trial = os.path.join(candidate, "bin", "nvcc")
+        if os.path.isfile(trial):
+            os.environ["CUDA_HOME"] = candidate
+            break
+
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+ROOT = Path(__file__).resolve().parent
+INCLUDE = ROOT / "include"
+
+nvcc_flags = [
+    "-O3",
+    "--use_fast_math",
+    "-gencode=arch=compute_89,code=sm_89",
+]
+
+setup(
+    name="kda_prefill_cuda",
+    version="0.1.0",
+    ext_modules=[
+        CUDAExtension(
+            name="kda_prefill_cuda",
+            sources=[
+                str(ROOT / "src" / "kda_prefill_binding.cpp"),
+                str(ROOT / "src" / "kda.cu"),
+            ],
+            include_dirs=[str(INCLUDE)],
+            extra_compile_args={"cxx": ["-O3"], "nvcc": nvcc_flags},
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+    zip_safe=False,
+)

--- a/setup_kda_prefill_cuda.py
+++ b/setup_kda_prefill_cuda.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+
+cuda_home = os.environ.get("CUDA_HOME", "")
+nvcc = os.path.join(cuda_home, "bin", "nvcc") if cuda_home else ""
+if not cuda_home or not os.path.isfile(nvcc):
+    for candidate in ("/usr/local/cuda", "/usr/local/cuda-12.2", "/usr/local/cuda-12.8"):
+        trial = os.path.join(candidate, "bin", "nvcc")
+        if os.path.isfile(trial):
+            os.environ["CUDA_HOME"] = candidate
+            break
+
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+ROOT = Path(__file__).resolve().parent
+INCLUDE = ROOT / "include"
+
+nvcc_flags = [
+    "-O3",
+    "--use_fast_math",
+    "-gencode=arch=compute_89,code=sm_89",
+]
+
+setup(
+    name="kda_prefill_cuda",
+    version="0.1.0",
+    ext_modules=[
+        CUDAExtension(
+            name="kda_prefill_cuda",
+            sources=[
+                str(ROOT / "src" / "kda_prefill_binding.cpp"),
+                str(ROOT / "src" / "kda.cu"),
+            ],
+            include_dirs=[str(INCLUDE)],
+            extra_compile_args={"cxx": ["-O3"], "nvcc": nvcc_flags},
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+    zip_safe=False,
+)

--- a/src/kda.cu
+++ b/src/kda.cu
@@ -1,0 +1,62 @@
+#include <cuda_runtime.h>
+
+#include "kda_api.hpp"
+
+namespace {
+
+template <int K_DIM, int V_DIM, int CHUNK>
+cudaError_t launch_kda_prefill_impl(
+    const kda::api::KdaPrefillIO<float>& io,
+    cudaStream_t stream) {
+  using Params = kda::KdaPrefillParams<float, K_DIM, V_DIM, CHUNK>;
+  Params params = kda::make_prefill_params<float, K_DIM, V_DIM, CHUNK>(
+      io.q_ptr,
+      io.k_ptr,
+      io.v_ptr,
+      io.g_ptr,
+      io.beta_ptr,
+      io.w_ptr,
+      io.u_ptr,
+      io.o_ptr,
+      io.batch_size,
+      io.num_heads,
+      io.seq_len);
+  kda::api::launch_kda_prefill_kernel(params, stream);
+  return cudaGetLastError();
+}
+
+}  // namespace
+
+namespace kda::api {
+
+cudaError_t launch_kda_prefill_f32(const KdaPrefillIO<float>& io,
+                                   cudaStream_t stream) {
+  if (io.head_dim == 64 && io.value_dim == 64 && io.chunk_size == 64) {
+    return launch_kda_prefill_impl<64, 64, 64>(io, stream);
+  }
+  if (io.head_dim == 64 && io.value_dim == 64 && io.chunk_size == 32) {
+    return launch_kda_prefill_impl<64, 64, 32>(io, stream);
+  }
+  if (io.head_dim == 128 && io.value_dim == 128 && io.chunk_size == 64) {
+    return launch_kda_prefill_impl<128, 128, 64>(io, stream);
+  }
+  if (io.head_dim == 128 && io.value_dim == 128 && io.chunk_size == 32) {
+    return launch_kda_prefill_impl<128, 128, 32>(io, stream);
+  }
+  return cudaErrorInvalidValue;
+}
+
+}  // namespace kda::api
+
+extern "C" cudaError_t kda_prefill_f32(
+    const kda::api::KdaPrefillIO<float>* io,
+    cudaStream_t stream) {
+  if (io == nullptr) {
+    return cudaErrorInvalidValue;
+  }
+  try {
+    return kda::api::launch_kda_prefill(*io, stream);
+  } catch (...) {
+    return cudaErrorInvalidValue;
+  }
+}

--- a/src/kda_prefill_binding.cpp
+++ b/src/kda_prefill_binding.cpp
@@ -1,0 +1,146 @@
+#include <torch/extension.h>
+
+#include <cuda_runtime.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include <tuple>
+
+#include "kda_prefill_io.hpp"
+
+namespace {
+
+void check_supported_dims(int64_t k, int64_t v, int64_t chunk) {
+  // (128,128,64) is not supported by the current device kernel configuration.
+  const bool ok =
+      (k == 64 && v == 64 && (chunk == 32 || chunk == 64)) ||
+      (k == 128 && v == 128 && chunk == 32);
+  TORCH_CHECK(
+      ok,
+      "kda_prefill: unsupported (K,V,chunk_size)=(",
+      k,
+      ",",
+      v,
+      ",",
+      chunk,
+      "); supported: (64,64,32|64), (128,128,32)");
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> kda_prefill_forward_cuda(
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& g,
+    const at::Tensor& beta,
+    int64_t chunk_size,
+    c10::optional<at::Tensor> w_opt,
+    c10::optional<at::Tensor> u_opt,
+    c10::optional<at::Tensor> o_opt) {
+  TORCH_CHECK(q.is_cuda(), "kda_prefill: q must be CUDA");
+  TORCH_CHECK(
+      q.scalar_type() == at::kFloat && k.scalar_type() == at::kFloat &&
+          v.scalar_type() == at::kFloat && g.scalar_type() == at::kFloat &&
+          beta.scalar_type() == at::kFloat,
+      "kda_prefill: all tensors must be float32");
+
+  TORCH_CHECK(q.dim() == 4, "kda_prefill: q must be [B,H,T,K]");
+  const int64_t B = q.size(0);
+  const int64_t H = q.size(1);
+  const int64_t T = q.size(2);
+  const int64_t K = q.size(3);
+  TORCH_CHECK(
+      k.sizes() == q.sizes(), "kda_prefill: k must match q shape ", q.sizes());
+  TORCH_CHECK(
+      g.sizes() == q.sizes(), "kda_prefill: g must match q shape ", q.sizes());
+  TORCH_CHECK(
+      v.size(0) == B && v.size(1) == H && v.size(2) == T,
+      "kda_prefill: v must be [B,H,T,V] with same B,H,T as q");
+  const int64_t V = v.size(3);
+  TORCH_CHECK(
+      beta.sizes() == at::IntArrayRef({B, H, T}),
+      "kda_prefill: beta must be [B,H,T]");
+
+  TORCH_CHECK(chunk_size > 0, "kda_prefill: chunk_size must be positive");
+  check_supported_dims(K, V, chunk_size);
+
+  TORCH_CHECK(q.is_contiguous(), "kda_prefill: q must be contiguous");
+  TORCH_CHECK(k.is_contiguous(), "kda_prefill: k must be contiguous");
+  TORCH_CHECK(v.is_contiguous(), "kda_prefill: v must be contiguous");
+  TORCH_CHECK(g.is_contiguous(), "kda_prefill: g must be contiguous");
+  TORCH_CHECK(beta.is_contiguous(), "kda_prefill: beta must be contiguous");
+
+  const int64_t num_chunks = (T + chunk_size - 1) / chunk_size;
+  auto opts = q.options();
+
+  at::Tensor w;
+  at::Tensor u;
+  at::Tensor o;
+  if (w_opt.has_value()) {
+    w = *w_opt;
+    TORCH_CHECK(w.is_cuda() && w.scalar_type() == at::kFloat, "kda_prefill: w");
+    TORCH_CHECK(
+        w.sizes() == at::IntArrayRef({B, H, num_chunks, chunk_size, K}),
+        "kda_prefill: w must be [B,H,num_chunks,C,K]");
+    TORCH_CHECK(w.is_contiguous(), "kda_prefill: w must be contiguous");
+  } else {
+    w = at::empty({B, H, num_chunks, chunk_size, K}, opts);
+  }
+  if (u_opt.has_value()) {
+    u = *u_opt;
+    TORCH_CHECK(u.is_cuda() && u.scalar_type() == at::kFloat, "kda_prefill: u");
+    TORCH_CHECK(
+        u.sizes() == at::IntArrayRef({B, H, num_chunks, chunk_size, V}),
+        "kda_prefill: u must be [B,H,num_chunks,C,V]");
+    TORCH_CHECK(u.is_contiguous(), "kda_prefill: u must be contiguous");
+  } else {
+    u = at::empty({B, H, num_chunks, chunk_size, V}, opts);
+  }
+  if (o_opt.has_value()) {
+    o = *o_opt;
+    TORCH_CHECK(o.is_cuda() && o.scalar_type() == at::kFloat, "kda_prefill: o");
+    TORCH_CHECK(
+        o.sizes() == at::IntArrayRef({B, H, T, V}),
+        "kda_prefill: o must be [B,H,T,V]");
+    TORCH_CHECK(o.is_contiguous(), "kda_prefill: o must be contiguous");
+  } else {
+    o = at::empty({B, H, T, V}, opts);
+  }
+
+  kda::api::KdaPrefillIO<float> io{};
+  io.q_ptr = q.data_ptr<float>();
+  io.k_ptr = k.data_ptr<float>();
+  io.v_ptr = v.data_ptr<float>();
+  io.g_ptr = g.data_ptr<float>();
+  io.beta_ptr = beta.data_ptr<float>();
+  io.w_ptr = w.data_ptr<float>();
+  io.u_ptr = u.data_ptr<float>();
+  io.o_ptr = o.data_ptr<float>();
+  io.batch_size = static_cast<int>(B);
+  io.num_heads = static_cast<int>(H);
+  io.seq_len = static_cast<int>(T);
+  io.head_dim = static_cast<int>(K);
+  io.value_dim = static_cast<int>(V);
+  io.chunk_size = static_cast<int>(chunk_size);
+  io.num_chunks = static_cast<int>(num_chunks);
+
+  cudaStream_t stream = c10::cuda::getCurrentCUDAStream(q.get_device());
+  cudaError_t err = kda_prefill_f32(&io, stream);
+  TORCH_CHECK(
+      err == cudaSuccess,
+      "kda_prefill: ",
+      cudaGetErrorString(err),
+      " (check K,V,chunk_size, GPU sm>=89, and tensor layouts)");
+  return std::make_tuple(std::move(o), std::move(w), std::move(u));
+}
+
+}  // namespace
+
+TORCH_LIBRARY(kda_prefill, m) {
+  m.def(
+      "forward(Tensor q, Tensor k, Tensor v, Tensor g, Tensor beta, int chunk_size, Tensor? w, Tensor? u, Tensor? o) -> (Tensor, Tensor, Tensor)");
+}
+
+TORCH_LIBRARY_IMPL(kda_prefill, CUDA, m) {
+  m.impl("forward", &kda_prefill_forward_cuda);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {}

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,408 @@
+import argparse
+import ctypes
+from functools import lru_cache
+from pathlib import Path
+
+
+def _import_fla_chunk_kda():
+    try:
+        from fla.ops.kda import chunk_kda
+    except Exception as exc:  # noqa: BLE001
+        return None, exc
+    return chunk_kda, None
+
+
+@lru_cache(maxsize=1)
+def _torch_modules():
+    import torch
+    import torch.nn.functional as F
+
+    return torch, F
+
+
+class _KdaPrefillIOF32(ctypes.Structure):
+    _fields_ = [
+        ("q_ptr", ctypes.c_void_p),
+        ("k_ptr", ctypes.c_void_p),
+        ("v_ptr", ctypes.c_void_p),
+        ("g_ptr", ctypes.c_void_p),
+        ("beta_ptr", ctypes.c_void_p),
+        ("w_ptr", ctypes.c_void_p),
+        ("u_ptr", ctypes.c_void_p),
+        ("o_ptr", ctypes.c_void_p),
+        ("batch_size", ctypes.c_int),
+        ("num_heads", ctypes.c_int),
+        ("seq_len", ctypes.c_int),
+        ("head_dim", ctypes.c_int),
+        ("value_dim", ctypes.c_int),
+        ("chunk_size", ctypes.c_int),
+        ("num_chunks", ctypes.c_int),
+    ]
+
+
+@lru_cache(maxsize=1)
+def _load_local_prefill_library():
+    repo_root = Path(__file__).resolve().parent.parent
+    lib_path = repo_root / "build" / "libkda_prefill_runtime.so"
+    if not lib_path.exists():
+        raise FileNotFoundError(
+            f"Expected {lib_path} after `cmake --build build`. "
+        )
+    lib = ctypes.CDLL(str(lib_path))
+    lib.kda_prefill_f32.argtypes = [ctypes.POINTER(_KdaPrefillIOF32), ctypes.c_void_p]
+    lib.kda_prefill_f32.restype = ctypes.c_int
+    return lib
+
+
+def _make_prefill_inputs(B, H, T, K, V, device="cuda", seed=42):
+    torch, _ = _torch_modules()
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed)
+    q = torch.randn(B, H, T, K, device=device, dtype=torch.float32, generator=generator)
+    k = torch.randn(B, H, T, K, device=device, dtype=torch.float32, generator=generator)
+    v = torch.randn(B, H, T, V, device=device, dtype=torch.float32, generator=generator)
+    g = torch.randn(B, H, T, K, device=device, dtype=torch.float32, generator=generator)
+    beta = torch.randn(B, H, T, device=device, dtype=torch.float32, generator=generator)
+    return q, k, v, g, beta
+
+
+def _num_chunks(seq_len, chunk_size):
+    return (seq_len + chunk_size - 1) // chunk_size
+
+
+def _run_local_prefill(q, k, v, g, beta, chunk_size, w=None, u=None, o=None):
+    torch, _ = _torch_modules()
+    if q.device.type != "cuda":
+        raise ValueError("CUDA tensors required.")
+
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    g = g.contiguous()
+    beta = beta.contiguous()
+
+    B, H, T, K = q.shape
+    V = v.shape[-1]
+    num_chunks = _num_chunks(T, chunk_size)
+    if w is None:
+        w = torch.empty((B, H, num_chunks, chunk_size, K), device=q.device, dtype=torch.float32)
+    if u is None:
+        u = torch.empty((B, H, num_chunks, chunk_size, V), device=q.device, dtype=torch.float32)
+    if o is None:
+        o = torch.empty((B, H, T, V), device=q.device, dtype=torch.float32)
+
+    io = _KdaPrefillIOF32(
+        q_ptr=ctypes.c_void_p(q.data_ptr()),
+        k_ptr=ctypes.c_void_p(k.data_ptr()),
+        v_ptr=ctypes.c_void_p(v.data_ptr()),
+        g_ptr=ctypes.c_void_p(g.data_ptr()),
+        beta_ptr=ctypes.c_void_p(beta.data_ptr()),
+        w_ptr=ctypes.c_void_p(w.data_ptr()),
+        u_ptr=ctypes.c_void_p(u.data_ptr()),
+        o_ptr=ctypes.c_void_p(o.data_ptr()),
+        batch_size=B,
+        num_heads=H,
+        seq_len=T,
+        head_dim=K,
+        value_dim=V,
+        chunk_size=chunk_size,
+        num_chunks=num_chunks,
+    )
+
+    stream = torch.cuda.current_stream(device=q.device)
+    err = _load_local_prefill_library().kda_prefill_f32(
+        ctypes.byref(io),
+        ctypes.c_void_p(stream.cuda_stream),
+    )
+    if err != 0:
+        raise RuntimeError(f"kda_prefill_f32 failed with cudaError code {err}")
+    return o, w, u
+
+
+def _local_prefill_benchmark(device, args) -> tuple[float, dict]:
+    torch, _ = _torch_modules()
+    q, k, v, g, beta = _make_prefill_inputs(
+        args.B, args.H, args.T, args.K, args.V, device=device, seed=42
+    )
+    num_chunks = _num_chunks(args.T, args.C)
+    w = torch.empty((args.B, args.H, num_chunks, args.C, args.K), device=device, dtype=torch.float32)
+    u = torch.empty((args.B, args.H, num_chunks, args.C, args.V), device=device, dtype=torch.float32)
+    out = torch.empty((args.B, args.H, args.T, args.V), device=device, dtype=torch.float32)
+
+    for _ in range(3):
+        _run_local_prefill(q, k, v, g, beta, args.C, w=w, u=u, o=out)
+    torch.cuda.synchronize(device)
+
+    ev_start = torch.cuda.Event(enable_timing=True)
+    ev_stop = torch.cuda.Event(enable_timing=True)
+    ev_start.record()
+    for _ in range(args.iters):
+        out, _, _ = _run_local_prefill(q, k, v, g, beta, args.C, w=w, u=u, o=out)
+    ev_stop.record()
+    torch.cuda.synchronize(device)
+
+    return ev_start.elapsed_time(ev_stop) / float(args.iters), {
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "beta": beta,
+        "out": out,
+    }
+
+
+def _run_fla_prefill(chunk_kda, q, k, v, g, beta):
+    torch, _ = _torch_modules()
+    B, H, T, K = q.shape
+    V = v.shape[-1]
+    scale = K**-0.5
+
+    q_fla = q.permute(0, 2, 1, 3).contiguous().to(torch.bfloat16)
+    k_fla = k.permute(0, 2, 1, 3).contiguous().to(torch.bfloat16)
+    v_fla = v.permute(0, 2, 1, 3).contiguous().to(torch.bfloat16)
+    beta_fla = beta.permute(0, 2, 1).contiguous().to(torch.bfloat16)
+    g_fla = (
+        torch.log(torch.sigmoid(g).clamp_min(1.0e-6))
+        .permute(0, 2, 1, 3)
+        .contiguous()
+        .to(torch.bfloat16)
+    )
+    h0 = torch.zeros(B, H, K, V, device=q.device, dtype=torch.float32)
+
+    result = chunk_kda(
+        q=q_fla,
+        k=k_fla,
+        v=v_fla,
+        g=g_fla,
+        beta=beta_fla,
+        scale=scale,
+        initial_state=h0,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=False,
+    )
+    out = result[0] if isinstance(result, tuple) else result
+    return out.permute(0, 2, 1, 3).contiguous().float()
+
+
+def _fla_prefill_benchmark(device, args) -> tuple[float, dict]:
+    torch, _ = _torch_modules()
+    chunk_kda, import_error = _import_fla_chunk_kda()
+    if chunk_kda is None:
+        raise RuntimeError(
+            "Need `fla` with `chunk_kda` for this benchmark: "
+            f"{import_error}"
+        )
+
+    q, k, v, g, beta = _make_prefill_inputs(
+        args.B, args.H, args.T, args.K, args.V, device=device, seed=42
+    )
+    for _ in range(3):
+        _run_fla_prefill(chunk_kda, q, k, v, g, beta)
+    torch.cuda.synchronize(device)
+
+    ev_start = torch.cuda.Event(enable_timing=True)
+    ev_stop = torch.cuda.Event(enable_timing=True)
+    ev_start.record()
+    for _ in range(args.iters):
+        out = _run_fla_prefill(chunk_kda, q, k, v, g, beta)
+    ev_stop.record()
+    torch.cuda.synchronize(device)
+
+    return ev_start.elapsed_time(ev_stop) / float(args.iters), {
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "beta": beta,
+        "out": out,
+    }
+
+
+def _prefill_reference(q, k, v, g, beta, chunk_size):
+    torch, F = _torch_modules()
+    B, H, T, K = q.shape
+    V = v.shape[-1]
+    out = torch.zeros((B, H, T, V), device=q.device, dtype=torch.float32)
+    q_scale = K**-0.5
+
+    for b in range(B):
+        for h in range(H):
+            state = torch.zeros((K, V), device=q.device, dtype=torch.float32)
+            for start in range(0, T, chunk_size):
+                end = min(start + chunk_size, T)
+                valid_c = end - start
+                if valid_c <= 0:
+                    continue
+
+                q_chunk = q[b, h, start:end].float()
+                k_chunk = k[b, h, start:end].float()
+                v_chunk = v[b, h, start:end].float()
+                g_chunk = g[b, h, start:end].float()
+                beta_chunk = beta[b, h, start:end].float()
+
+                q_normed = F.normalize(q_chunk, dim=-1) * q_scale
+                k_normed = F.normalize(k_chunk, dim=-1)
+                g_prefix = torch.cumprod(torch.sigmoid(g_chunk), dim=0)
+                M = torch.eye(valid_c, device=q.device, dtype=torch.float32)
+
+                for i in range(valid_c):
+                    for j in range(i):
+                        decay = g_prefix[i] / g_prefix[j]
+                        dot = (k_normed[i] * k_normed[j] * decay).sum()
+                        M[i, j] = dot * F.softplus(beta_chunk[i])
+
+                for i in range(1, valid_c):
+                    for j in range(i):
+                        acc = torch.zeros((), device=q.device, dtype=torch.float32)
+                        for kk in range(j, i):
+                            acc = acc + M[i, kk] * (1.0 if kk == j else M[kk, j])
+                        M[i, j] = -acc
+
+                swish_g = g_chunk * torch.sigmoid(g_chunk)
+                W = torch.zeros((valid_c, K), device=q.device, dtype=torch.float32)
+                U = torch.zeros((valid_c, V), device=q.device, dtype=torch.float32)
+                for r in range(valid_c):
+                    coeff = M[r, : r + 1].unsqueeze(-1)
+                    W[r] = (coeff * (swish_g[: r + 1] * k_normed[: r + 1])).sum(dim=0)
+                    U[r] = (coeff * v_chunk[: r + 1]).sum(dim=0)
+
+                for r in range(valid_c):
+                    out[b, h, start + r] = U[r] + (q_normed[r] * g_prefix[r]) @ state
+
+                state = state * g_prefix[valid_c - 1].unsqueeze(-1) + W.transpose(0, 1) @ U
+
+    return out
+
+
+def _summarize_diff(name, ref, actual):
+    diff = (ref.float() - actual.float()).abs()
+    return (
+        f"{name}: max_abs={diff.max().item():.6e}, "
+        f"mean_abs={diff.mean().item():.6e}"
+    )
+
+
+def _run_prefill_accuracy_compare(device, args):
+    torch, _ = _torch_modules()
+    chunk_kda, import_error = _import_fla_chunk_kda()
+    if chunk_kda is None:
+        raise RuntimeError(
+            "Need `fla` for accuracy compare: "
+            f"{import_error}"
+        )
+
+    val_B = min(args.B, 1)
+    val_H = min(args.H, 4)
+    val_T = min(args.T, 256)
+    q, k, v, g, beta = _make_prefill_inputs(
+        val_B, val_H, val_T, args.K, args.V, device=device, seed=123
+    )
+    local_out, _, _ = _run_local_prefill(q, k, v, g, beta, args.C)
+    torch.cuda.synchronize(device)
+    fla_out = _run_fla_prefill(chunk_kda, q, k, v, g, beta)
+    torch.cuda.synchronize(device)
+
+    print(
+        "Accuracy compare shape: "
+        f"B={val_B}, H={val_H}, T={val_T}, K={args.K}, V={args.V}, C={args.C}"
+    )
+    print("Reference: FLA chunk_kda")
+    print(_summarize_diff("Local vs FLA", fla_out, local_out))
+
+    return {
+        "local_out": local_out,
+        "fla_out": fla_out,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark KDA prefill (ctypes + libkda_prefill_runtime.so) vs FLA."
+    )
+    parser.add_argument("--device", default="cuda", choices=["cuda", "cpu"])
+    parser.add_argument(
+        "--suite",
+        default="fla-benchmark",
+        choices=[
+            "local-benchmark",
+            "fla-only-benchmark",
+            "fla-benchmark",
+        ],
+    )
+    parser.add_argument("--B", type=int, default=2)
+    parser.add_argument("--H", type=int, default=8)
+    parser.add_argument("--T", type=int, default=4096)
+    parser.add_argument("--K", type=int, default=64)
+    parser.add_argument("--V", type=int, default=64)
+    parser.add_argument("--C", type=int, default=32)
+    parser.add_argument("--iters", type=int, default=10)
+    return parser.parse_args()
+
+
+def run_fla_benchmark_suite(device, args) -> int:
+    print(
+        "Benchmark shapes: "
+        f"B={args.B}, H={args.H}, T={args.T}, K={args.K}, V={args.V}, C={args.C}"
+    )
+    print("\n[Time]")
+    local_ms, _ = _local_prefill_benchmark(device, args)
+    print(f"local CUDA prefill (avg {args.iters} iters): {local_ms:.4f} ms")
+
+    try:
+        fla_ms, _ = _fla_prefill_benchmark(device, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"FLA benchmark skipped: {exc}")
+        return 0
+
+    print(f"FLA chunk_kda (avg {args.iters} iters): {fla_ms:.4f} ms")
+    print(f"FLA / local: {fla_ms / local_ms:.4f}x")
+    print(f"local / FLA: {local_ms / fla_ms:.4f}x")
+    print("\n[Accuracy]")
+    _run_prefill_accuracy_compare(device, args)
+    return 0
+
+
+def run_local_benchmark_suite(args) -> int:
+    torch, _ = _torch_modules()
+    device = torch.device(args.device)
+    print(
+        "Benchmark shapes: "
+        f"B={args.B}, H={args.H}, T={args.T}, K={args.K}, V={args.V}, C={args.C}"
+    )
+    local_ms, _ = _local_prefill_benchmark(device, args)
+    print(f"local CUDA prefill (avg {args.iters} iters): {local_ms:.4f} ms")
+    return 0
+
+
+def run_fla_only_benchmark_suite(device, args) -> int:
+    print(
+        "Benchmark shapes: "
+        f"B={args.B}, H={args.H}, T={args.T}, K={args.K}, V={args.V}, C={args.C}"
+    )
+    try:
+        fla_ms, _ = _fla_prefill_benchmark(device, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"FLA benchmark unavailable: {exc}")
+        return 1
+    print(f"FLA chunk_kda (avg {args.iters} iters): {fla_ms:.4f} ms")
+    return 0
+
+
+def main() -> int:
+    args = _parse_args()
+    torch, _ = _torch_modules()
+    if args.device == "cuda" and not torch.cuda.is_available():
+        print("CUDA not available.")
+        return 1
+
+    if args.suite == "local-benchmark":
+        return run_local_benchmark_suite(args)
+    device = torch.device(args.device)
+    if args.suite == "fla-only-benchmark":
+        return run_fla_only_benchmark_suite(device, args)
+    return run_fla_benchmark_suite(device, args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,161 @@
+"""
+PyTorch entry point for KDA **prefill** (not decode).
+
+Build the CUDA extension once from the repo root (same env as PyTorch), for example:
+
+    /path/to/envs/kda_fla/bin/python setup.py build_ext --inplace
+
+This imports the compiled module `kda_prefill_cuda`, which registers
+`torch.ops.kda_prefill.forward` (CuTe-style layout: ``[B,H,T,K]`` tensors).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _ensure_extension_path() -> None:
+    root = str(_REPO_ROOT)
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+
+_ensure_extension_path()
+
+import torch
+
+try:
+    import kda_prefill_cuda  # noqa: F401 — side effect: registers torch.ops
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "kda_prefill_cuda is not built. From the repository root run:\n"
+        "  python setup.py build_ext --inplace\n"
+        "using the same Python as `import torch`."
+    ) from exc
+
+
+def kda_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    chunk_size: int,
+    w: Optional[torch.Tensor] = None,
+    u: Optional[torch.Tensor] = None,
+    o: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Fused KDA prefill (float32), matching this repo's C++/CUDA contract.
+
+    Tensor layout (same as cuLA-style KDA prefill):
+
+    - ``q``, ``k``, ``g``: ``(B, H, T, K)``
+    - ``v``: ``(B, H, T, V)``
+    - ``beta``: ``(B, H, T)``
+    - Optional chunk buffers ``w`` / ``u`` (else allocated): ``(B, H, Nc, C, K|V)``
+    - Optional output ``o`` (else allocated): ``(B, H, T, V)``
+
+    Supported ``(K, V, chunk_size)``: ``(64, 64, 32|64)``, ``(128, 128, 32)``.
+
+    Returns:
+        ``(o, w, u)`` — attention output and intra-chunk intermediates.
+    """
+    return torch.ops.kda_prefill.forward(
+        q, k, v, g, beta, chunk_size, w, u, o
+    )
+
+
+def _rand_inputs(
+    device: str,
+    B: int,
+    H: int,
+    T: int,
+    K: int,
+    V: int,
+    seed: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    g = torch.Generator(device=device)
+    g.manual_seed(seed)
+    q = torch.randn(B, H, T, K, device=device, dtype=torch.float32, generator=g)
+    k = torch.randn(B, H, T, K, device=device, dtype=torch.float32, generator=g)
+    v = torch.randn(B, H, T, V, device=device, dtype=torch.float32, generator=g)
+    gv = torch.randn(B, H, T, K, device=device, dtype=torch.float32, generator=g)
+    beta = torch.randn(B, H, T, device=device, dtype=torch.float32, generator=g)
+    return q, k, v, gv, beta
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+class TestKdaPrefillCuda(unittest.TestCase):
+    device = "cuda"
+
+    def _assert_shapes(
+        self,
+        o: torch.Tensor,
+        w: torch.Tensor,
+        u: torch.Tensor,
+        B: int,
+        H: int,
+        T: int,
+        K: int,
+        V: int,
+        C: int,
+    ) -> None:
+        nc = (T + C - 1) // C
+        self.assertEqual(o.shape, (B, H, T, V))
+        self.assertEqual(w.shape, (B, H, nc, C, K))
+        self.assertEqual(u.shape, (B, H, nc, C, V))
+        self.assertTrue(torch.isfinite(o).all().item())
+
+    def test_k64_v64_c32(self) -> None:
+        B, H, T, K, V, C = 1, 2, 128, 64, 64, 32
+        q, k, v, g, beta = _rand_inputs(self.device, B, H, T, K, V, 0)
+        o, w, u = kda_prefill(q, k, v, g, beta, C)
+        torch.cuda.synchronize()
+        self._assert_shapes(o, w, u, B, H, T, K, V, C)
+
+    def test_k64_v64_c64(self) -> None:
+        B, H, T, K, V, C = 1, 1, 96, 64, 64, 64
+        q, k, v, g, beta = _rand_inputs(self.device, B, H, T, K, V, 1)
+        o, w, u = kda_prefill(q, k, v, g, beta, C)
+        torch.cuda.synchronize()
+        self._assert_shapes(o, w, u, B, H, T, K, V, C)
+
+    def test_k128_v128_c32(self) -> None:
+        B, H, T, K, V, C = 1, 1, 64, 128, 128, 32
+        q, k, v, g, beta = _rand_inputs(self.device, B, H, T, K, V, 2)
+        o, w, u = kda_prefill(q, k, v, g, beta, C)
+        torch.cuda.synchronize()
+        self._assert_shapes(o, w, u, B, H, T, K, V, C)
+
+    def test_preallocated_buffers(self) -> None:
+        B, H, T, K, V, C = 2, 2, 77, 64, 64, 32
+        q, k, v, g, beta = _rand_inputs(self.device, B, H, T, K, V, 4)
+        nc = (T + C - 1) // C
+        w0 = torch.empty(B, H, nc, C, K, device=self.device, dtype=torch.float32)
+        u0 = torch.empty(B, H, nc, C, V, device=self.device, dtype=torch.float32)
+        o0 = torch.empty(B, H, T, V, device=self.device, dtype=torch.float32)
+        o, w, u = kda_prefill(q, k, v, g, beta, C, w=w0, u=u0, o=o0)
+        torch.cuda.synchronize()
+        self.assertIs(o, o0)
+        self.assertIs(w, w0)
+        self.assertIs(u, u0)
+        self._assert_shapes(o, w, u, B, H, T, K, V, C)
+
+    def test_torch_op_direct(self) -> None:
+        B, H, T, K, V, C = 1, 1, 32, 64, 64, 32
+        q, k, v, g, beta = _rand_inputs(self.device, B, H, T, K, V, 5)
+        o, w, u = torch.ops.kda_prefill.forward(
+            q, k, v, g, beta, C, None, None, None
+        )
+        torch.cuda.synchronize()
+        self._assert_shapes(o, w, u, B, H, T, K, V, C)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
# KDA prefill (CUDA)

Fused-style **KDA (Kimi Delta Attention) prefill** for **float32**: intra-chunk (KKT / W–U) plus inter-chunk recurrence. Tensor layout matches [cuLA](https://github.com/inclusionAI/cuLA) KDA prefill conventions (`[B,H,T,K]` / `[B,H,T,V]`). This repo ships:

- **CUDA** kernels under `include/` + `src/kda.cu`
- **C ABI** `kda_prefill_f32` via CMake (`libkda_prefill_runtime.so`)
- **PyTorch** custom op `torch.ops.kda_prefill` (`src/kda_prefill_binding.cpp` + `setup.py`)
- **ctypes** benchmark harness: `src/main.py`
- **Unit tests**: `src/test.py` (`unittest`, CUDA required)

---

## GPU / architecture (`sm_89`)

- **Minimum:** NVIDIA **Ada Lovelace (`sm_89`)** or newer, as enforced in `include/kda_api.hpp` (`check_sm89_or_newer`).
- **Build default:** `CMAKE_CUDA_ARCHITECTURES=89` and PyTorch extension NVCC flags use **`arch=compute_89,code=sm_89`**.
- **Examples:** RTX 4090 / 4080 / 4070 (Ada). Older GPUs (e.g. `sm_80`) are not supported by this kernel path.

---

## Interfaces

### 1) PyTorch (recommended for integration)

After building the extension (see [How to run](#how-to-run)), import registers the op:

```python
import kda_prefill_cuda  # noqa: F401 — registers torch.ops.kda_prefill
import torch

o, w, u = torch.ops.kda_prefill.forward(
    q, k, v, g, beta, chunk_size, w_opt, u_opt, o_opt
)
```

Or use the thin wrapper from `src/test.py`:

```python
from pathlib import Path
import sys
sys.path.insert(0, str(Path("path/to/repo").resolve()))
from test import kda_prefill  # when running from src/ with PYTHONPATH=repo_root

o, w, u = kda_prefill(q, k, v, g, beta, chunk_size, w=None, u=None, o=None)
```

**Signature (Python):**

| Argument | Type | Shape / notes |
|----------|------|----------------|
| `q`, `k`, `g` | `torch.Tensor` | `(B, H, T, K)`, **float32**, CUDA, contiguous |
| `v` | `torch.Tensor` | `(B, H, T, V)`, float32, contiguous |
| `beta` | `torch.Tensor` | `(B, H, T)`, float32, contiguous |
| `chunk_size` | `int` | Chunk length `C` |
| `w`, `u`, `o` | optional `Tensor` | If omitted, allocated internally. Shapes: `w` `(B,H,Nc,C,K)`, `u` `(B,H,Nc,C,V)`, `o` `(B,H,T,V)` with `Nc = ceil(T / C)` |

**Returns:** `(o, w, u)` — output attention `o` and intra-chunk buffers `w`, `u`.

**Supported `(K, V, chunk_size)` for the PyTorch entry point** (enforced in `src/kda_prefill_binding.cpp`):

- `(64, 64, 32)` and `(64, 64, 64)`
- `(128, 128, 32)` only — `(128, 128, 64)` is not exposed via this binding (runtime issues on current kernel config).

**Registered op name:** `kda_prefill::forward` → Python: `torch.ops.kda_prefill.forward(...)`.

### 2) C ABI (shared library from CMake)

```c
extern "C" cudaError_t kda_prefill_f32(
    const kda::api::KdaPrefillIO<float>* io,
    cudaStream_t stream);
```

`KdaPrefillIO<float>` is defined in `include/kda_prefill_io.hpp` (pointer fields + `B,H,T,K,V,C,num_chunks`). See `src/main.py` for a ctypes layout mirror.

### 3) C++ launch (inside CUDA translation unit)

`kda::api::launch_kda_prefill` / `launch_kda_prefill_f32` in `include/kda_api.hpp` + `src/kda.cu` (used by the PyTorch binding via `kda_prefill_f32`).

---

## How to run

### A. CMake + shared library (C / ctypes)

```bash
cmake -S . -B build -DCMAKE_CUDA_ARCHITECTURES=89
cmake --build build
```

Artifacts: `build/libkda_prefill.a`, `build/libkda_prefill_runtime.so` (`kda_prefill_f32`).

### B. PyTorch CUDA extension + tests

Use the **same** Python environment as `import torch` (same CUDA / PyTorch ABI):

```bash
python setup.py build_ext --inplace
python src/test.py
```

`src/test.py` adds the repo root to `sys.path` and loads `kda_prefill_cuda*.so` from the root after `inplace` build.

### C. Optional benchmark vs FLA (`src/main.py`)

Requires PyTorch; for FLA comparison install [flash-linear-attention](https://github.com/sustcsonglin/flash-linear-attention) (`fla`).

```bash
python src/main.py --suite fla-benchmark --B 2 --H 8 --T 4096 --K 64 --V 64 --C 32
```

- `local-benchmark` — CUDA only  
- `fla-only-benchmark` — FLA only  
- `fla-benchmark` — both + quick accuracy check vs `chunk_kda`

### Tuning env (optional)

| Variable | Role |
|----------|------|
| `KDA_INTRA_THREADS` | Block size for intra-chunk kernel |
| `KDA_INTER_THREADS` | Block size for inter-chunk kernel |
| `KDA_INTER_SHARDS` | V-way sharding for inter kernel (must divide `V`) |

---

## Pull request text (for cuLA / upstream)

When you open a PR on **cuLA** (or another monorepo), paste the block below into the description. It mirrors `.github/pull_request_template.md` style.

### Title (suggestion)

`feat: KDA prefill CUDA (sm_89) + PyTorch kda_prefill op`

### Description

```markdown
## Description

Adds **KDA prefill** (Kimi Delta Attention, **prefill** path — not decode): float32 fused intra-chunk + inter-chunk CUDA kernels, optional **PyTorch** custom op `torch.ops.kda_prefill.forward`, and ctypes / unittest harness. Layout aligns with cuLA KDA tensor conventions `[B,H,T,K]` / `[B,H,T,V]`.

**GPU:** requires **sm_89+** (Ada); build targets `sm_89`.

**Interfaces:**
- PyTorch: `torch.ops.kda_prefill.forward(q,k,v,g,beta,chunk_size,w?,u?,o?) -> (o,w,u)` after `import kda_prefill_cuda`; wrapper `kda_prefill(...)` in `src/test.py`.
- C: `kda_prefill_f32(KdaPrefillIO<float>*, cudaStream_t)` in `include/kda_prefill_io.hpp`.

**How to verify:**
1. `python setup.py build_ext --inplace` (or repo-specific `setup_kda_prefill_cuda.py` if merged under cuLA).
2. `python src/test.py` — 5 CUDA `unittest` cases (K/V/chunk coverage + preallocated buffers + direct `torch.ops` call).

## Related Issues

<!-- e.g. Closes #123 -->

## Pull Request Checklist

### Pre-commit

- [ ] `pre-commit install` and `pre-commit run --all-files` (if contributing to cuLA main tree).

### Tests

- [ ] `python src/test.py` passes on **sm_89** GPU with built `kda_prefill_cuda`.

### Performance

<!-- Optional: NCU / ms vs FLA; local harness in src/main.py -->

## Reviewer Notes

- Host `.cpp` binding must **not** include `kda_kernel.hpp`; use `kda_prefill_io.hpp` + `kda_prefill_f32` only.
- PyTorch binding currently restricts `(128,128,64)` even though `kda.cu` instantiates that template — document if re-enabled after kernel fix.
```

---

## Benchmark vs FLA (flash-linear-attention)

**Hardware:** NVIDIA **RTX 4070**, **`sm_89`** (Ada). CMake built with `CMAKE_CUDA_ARCHITECTURES=89`.

**Setup:** `K=V=64`, chunk `C=32`. Local path is **float32**; FLA `chunk_kda` in `src/main.py` runs **bf16** — timing is not strictly dtype-matched but useful as a baseline.

Latest sweep (machine‑logged) is under [`analysis/ncu/20260409-193656-large-shape-compare/`](analysis/ncu/20260409-193656-large-shape-compare/README.md): summary table in that folder’s README, raw CSV [`benchmark_results.csv`](analysis/ncu/20260409-193656-large-shape-compare/benchmark_results.csv), console captures under `benchmarks/` in that tree.

| Shape (B,H,T) | iters | Local ms | FLA ms | Local / FLA |
|---------------|------:|---------:|-------:|------------:|
| (2,8,4096) | 10 | 1.8884 | 1.1918 | 1.58× |
| (2,8,8192) | 10 | 3.6517 | 3.1311 | 1.17× |
| (4,8,4096) | 10 | 3.8848 | 3.0597 | 1.27× |
| (2,16,4096) | 10 | 3.8868 | 3.1079 | 1.25× |
| (2,8,16384) | 5 | 7.2716 | 6.5675 | 1.11× |

Quick accuracy line from the same harness (local fp32 vs FLA bf16): `max_abs ≈ 4.09`, `mean_abs ≈ 0.80` on the small validation shape inside `src/main.py` (see folder README).

## Profiling artifacts

`analysis/ncu/20260409-193656-large-shape-compare/` holds the FLA comparison CSV, console logs, and a short README. Optional for builds.

## Kernel template instantiations (`src/kda.cu`)

`(K,V,C)` dispatched in `launch_kda_prefill_f32`: `(64,64,64)`, `(64,64,32)`, `(128,128,64)`, `(128,128,32)`. The **PyTorch** binding validates a **subset** (see [Interfaces](#1-pytorch-recommended-for-integration)).
