### PR TITLE
[KDA] SM90 prefill: support multi-value GQA

### DIFF
--- a/benchmarks/bench_kda_fused_fwd_gqa.py
+++ b/benchmarks/bench_kda_fused_fwd_gqa.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+bench_kda_fused_fwd_gqa.py — Benchmark: cuLA fully-fused KDA forward in the
+"multi-value" GQA flavor (Q and K share fewer physical heads than V/state).
+
+This benchmark targets the multi-value grouped variant used by e.g.
+Qwen3.5-A3B Gated DeltaNet (linear_num_key_heads=16, linear_num_value_heads=32).
+Three paths are compared, all producing the same output:
+
+  1. cuLA GQA native    — Q: [L,num_k_heads,D], V: [L,num_heads,D] passed
+                          straight through. Kernel indexes each state head's
+                          Q/K via q_head_idx / k_group_size.
+  2. cuLA MHA expanded  — Host-side repeat_interleave on Q/K to match
+                          num_heads, then call the existing MHA path of the
+                          same fused kernel. This is the workaround users
+                          have today without native GQA support.
+  3. FLA Triton expanded — Upstream flash-linear-attention's chunk_kda is
+                           MHA-only, so the same host-side Q/K expansion is
+                           required to run Qwen3.5 shapes through it.
+
+Modes:
+  - Fixed-length: various (B, T) configs
+  - Varlen: sequences with 2-3x length variation
+
+Usage:
+  python bench_kda_fused_fwd_gqa.py [--mode fixed|varlen|both] [--ncu]
+"""
+
+import argparse
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+os.environ.setdefault("FLA_USE_FAST_OPS", os.getenv("CULA_USE_FAST_MATH", "1"))  # Enable fast ops in FLA for fair comparison
+
+import torch
+from fla.ops.kda import chunk_kda as fla_chunk_kda
+
+from benchmarks.utils import (
+    SEED,
+    build_varlen_configs,
+    exclusive_cumsum,
+    prepare_safe_gate_inputs_gqa,
+    set_seed,
+)
+from cula.utils import get_device_sm_version, get_kda_fused_fwd
+
+# ============================================================
+# Resolve cuLA fully-fused implementation at import time
+# ============================================================
+_device = torch.device("cuda")
+_major, _minor = get_device_sm_version(_device)
+_SM_TAG = f"sm{_major}{_minor}"
+cula_kda_fused_fwd = get_kda_fused_fwd(_device)
+
+# ============================================================
+# Constants — Qwen3.5-A3B Gated DeltaNet shape by default
+# ============================================================
+H = 32        # linear_num_value_heads (= state head count, grid dim)
+HK = 16       # linear_num_key_heads   (Q and K share this)
+D = 128       # head_k_dim == head_v_dim
+WARMUP = 25
+N_ITERS = 100
+NCU_MODE = False
+SANITIZER_MODE = False
+HAS_INIT_STATE = False
+
+
+# ============================================================
+# Helpers
+# ============================================================
+def time_kernel(fn, warmup=None, n_iters=None):
+    if warmup is None:
+        warmup = 1 if (NCU_MODE or SANITIZER_MODE) else WARMUP
+    if n_iters is None:
+        n_iters = 1 if (NCU_MODE or SANITIZER_MODE) else N_ITERS
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start_evt = torch.cuda.Event(enable_timing=True)
+    end_evt = torch.cuda.Event(enable_timing=True)
+    start_evt.record()
+    for _ in range(n_iters):
+        fn()
+    end_evt.record()
+    torch.cuda.synchronize()
+    return start_evt.elapsed_time(end_evt) / n_iters
+
+
+def accuracy_stats(ref, out):
+    """Compute RMSE, relative max diff, and mean absolute difference."""
+    ref_f = ref.float()
+    out_f = out.float()
+    diff = (ref_f - out_f).abs()
+    rmse = diff.pow(2).mean().sqrt().item()
+    max_diff = diff.max().item()
+    denom = ref_f.abs().max().item()
+    rel_max = max_diff / denom if denom > 0 else 0.0
+    mean_diff = diff.mean().item()
+    return rmse, rel_max, mean_diff
+
+
+def run_cula_gqa(q, k, v, g, beta, scale, A_log, dt_bias, init_state, cu_seqlens, lower_bound):
+    return cula_kda_fused_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        initial_state=init_state,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens,
+        use_gate_in_kernel=True,
+        safe_gate=True,
+        lower_bound=lower_bound,
+    )
+
+
+def run_cula_mha_expanded(q, k, v, g, beta, scale, A_log, dt_bias, init_state, cu_seqlens, lower_bound, k_group_size):
+    # Real user-facing cost: callers arrive with GQA-shaped q/k and must
+    # materialise an MHA-shaped copy before hitting a MHA-only kernel. Time
+    # the expansion together with the kernel so the "workaround" path shows
+    # its true end-to-end cost.
+    q_exp = q.repeat_interleave(k_group_size, dim=-2).contiguous()
+    k_exp = k.repeat_interleave(k_group_size, dim=-2).contiguous()
+    return cula_kda_fused_fwd(
+        q=q_exp,
+        k=k_exp,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        initial_state=init_state,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens,
+        use_gate_in_kernel=True,
+        safe_gate=True,
+        lower_bound=lower_bound,
+    )
+
+
+def run_fla_expanded(q, k, v, g, beta, scale, A_log, dt_bias, init_state, cu_seqlens, lower_bound, k_group_size):
+    # Upstream FLA's chunk_kda requires q/k/v to share a head count, so the
+    # same host-side expansion is on the critical path here.
+    q_exp = q.repeat_interleave(k_group_size, dim=-2).contiguous()
+    k_exp = k.repeat_interleave(k_group_size, dim=-2).contiguous()
+    return fla_chunk_kda(
+        q=q_exp,
+        k=k_exp,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        initial_state=init_state,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens,
+        use_gate_in_kernel=True,
+        safe_gate=True,
+        lower_bound=lower_bound,
+        transpose_state_layout=True,
+    )
+
+
+# ============================================================
+# Fixed-length benchmark
+# ============================================================
+def bench_fixed(configs):
+    print("\n" + "=" * 120)
+    print(f" Fixed-Length GQA Benchmark: cuLA fully-fused ({_SM_TAG}) native GQA vs MHA-expanded paths")
+    print("=" * 120)
+    results = []
+
+    k_group_size = H // HK
+    for B, T in configs:
+        set_seed(SEED)
+        device = torch.device("cuda")
+        torch.cuda.empty_cache()
+
+        seq_lens = [T] * B
+        cu_seqlens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int32, device=device)
+
+        inputs = prepare_safe_gate_inputs_gqa(
+            B, T, H, HK, D, device, cu_seqlens=cu_seqlens, has_init_state=HAS_INIT_STATE,
+        )
+        q, k, v, g, beta = inputs["q"], inputs["k"], inputs["v"], inputs["g"], inputs["beta"]
+        A_log, dt_bias = inputs["A_log"], inputs["dt_bias"]
+        scale, init_state, lower_bound = inputs["scale"], inputs["init_state"], inputs["lower_bound"]
+
+        gqa_kwargs = dict(
+            q=q, k=k, v=v, g=g, beta=beta, scale=scale,
+            A_log=A_log, dt_bias=dt_bias, init_state=init_state,
+            cu_seqlens=cu_seqlens, lower_bound=lower_bound,
+        )
+        expanded_kwargs = dict(
+            **gqa_kwargs,
+            k_group_size=k_group_size,
+        )
+
+        # Accuracy — all three should produce the same output up to dtype rounding.
+        # The MHA/FLA runners materialise the host-side expansion inside the
+        # call, so the timed measurement reflects what an end-user pays when
+        # they have GQA-shaped tensors and hit a MHA-only kernel.
+        o_gqa, _ = run_cula_gqa(**gqa_kwargs)
+        o_mha, _ = run_cula_mha_expanded(**expanded_kwargs)
+        o_fla, _ = run_fla_expanded(**expanded_kwargs)
+        torch.cuda.synchronize()
+
+        rmse_mha, rel_mha, _ = accuracy_stats(o_mha, o_gqa)
+        rmse_fla, rel_fla, _ = accuracy_stats(o_fla, o_gqa)
+
+        # Performance
+        ms_gqa = time_kernel(lambda: run_cula_gqa(**gqa_kwargs))
+        ms_mha = time_kernel(lambda: run_cula_mha_expanded(**expanded_kwargs))
+        ms_fla = time_kernel(lambda: run_fla_expanded(**expanded_kwargs))
+        sp_vs_mha = ms_mha / ms_gqa if ms_gqa > 0 else float("inf")
+        sp_vs_fla = ms_fla / ms_gqa if ms_gqa > 0 else float("inf")
+
+        results.append(
+            {
+                "B": B,
+                "T": T,
+                "rmse_mha": rmse_mha,
+                "rel_mha": rel_mha,
+                "rmse_fla": rmse_fla,
+                "rel_fla": rel_fla,
+                "ms_gqa": ms_gqa,
+                "ms_mha": ms_mha,
+                "ms_fla": ms_fla,
+                "sp_vs_mha": sp_vs_mha,
+                "sp_vs_fla": sp_vs_fla,
+            }
+        )
+
+        del o_gqa, o_mha, o_fla, q, k, v, g, beta, A_log, dt_bias, inputs
+        torch.cuda.empty_cache()
+
+    return results
+
+
+# ============================================================
+# Varlen benchmark
+# ============================================================
+def bench_varlen(configs):
+    print("\n" + "=" * 120)
+    print(f" Varlen GQA Benchmark: cuLA fully-fused ({_SM_TAG}) native GQA vs MHA-expanded paths")
+    print("=" * 120)
+    results = []
+
+    k_group_size = H // HK
+    for seq_lens, total_len, dist in configs:
+        set_seed(SEED)
+        device = torch.device("cuda")
+        torch.cuda.empty_cache()
+
+        T = total_len
+        cu_seqlens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int32, device=device)
+
+        inputs = prepare_safe_gate_inputs_gqa(
+            1, T, H, HK, D, device, cu_seqlens=cu_seqlens, has_init_state=HAS_INIT_STATE,
+        )
+        q, k, v, g, beta = inputs["q"], inputs["k"], inputs["v"], inputs["g"], inputs["beta"]
+        A_log, dt_bias = inputs["A_log"], inputs["dt_bias"]
+        scale, init_state, lower_bound = inputs["scale"], inputs["init_state"], inputs["lower_bound"]
+
+        gqa_kwargs = dict(
+            q=q, k=k, v=v, g=g, beta=beta, scale=scale,
+            A_log=A_log, dt_bias=dt_bias, init_state=init_state,
+            cu_seqlens=cu_seqlens, lower_bound=lower_bound,
+        )
+        expanded_kwargs = dict(
+            **gqa_kwargs,
+            k_group_size=k_group_size,
+        )
+
+        # Accuracy
+        o_gqa, _ = run_cula_gqa(**gqa_kwargs)
+        o_mha, _ = run_cula_mha_expanded(**expanded_kwargs)
+        o_fla, _ = run_fla_expanded(**expanded_kwargs)
+        torch.cuda.synchronize()
+
+        rmse_mha, rel_mha, _ = accuracy_stats(o_mha, o_gqa)
+        rmse_fla, rel_fla, _ = accuracy_stats(o_fla, o_gqa)
+
+        # Performance
+        ms_gqa = time_kernel(lambda: run_cula_gqa(**gqa_kwargs))
+        ms_mha = time_kernel(lambda: run_cula_mha_expanded(**expanded_kwargs))
+        ms_fla = time_kernel(lambda: run_fla_expanded(**expanded_kwargs))
+        sp_vs_mha = ms_mha / ms_gqa if ms_gqa > 0 else float("inf")
+        sp_vs_fla = ms_fla / ms_gqa if ms_gqa > 0 else float("inf")
+
+        n_seqs = len(seq_lens)
+        min_l, max_l = min(seq_lens), max(seq_lens)
+        avg_l = T // n_seqs
+        tag = f"{dist:>7s} {n_seqs:>2d}seqs T={T} [{min_l}..{max_l}] avg={avg_l}"
+
+        results.append(
+            {
+                "tag": tag,
+                "dist": dist,
+                "T_total": T,
+                "n_seqs": n_seqs,
+                "rmse_mha": rmse_mha,
+                "rel_mha": rel_mha,
+                "rmse_fla": rmse_fla,
+                "rel_fla": rel_fla,
+                "ms_gqa": ms_gqa,
+                "ms_mha": ms_mha,
+                "ms_fla": ms_fla,
+                "sp_vs_mha": sp_vs_mha,
+                "sp_vs_fla": sp_vs_fla,
+            }
+        )
+
+        del o_gqa, o_mha, o_fla, q, k, v, g, beta, A_log, dt_bias, inputs
+        torch.cuda.empty_cache()
+
+    return results
+
+
+# ============================================================
+# Report
+# ============================================================
+def print_report(fixed_results, varlen_results):
+    sep = "=" * 120
+    print(f"\n\n{sep}")
+    print("                 BENCHMARK REPORT: cula_kda_fused_fwd multi-value GQA")
+    print(f"                 cuLA {_SM_TAG} native GQA  vs  cuLA MHA + host expand  vs  FLA Triton + host expand")
+    print(f"                 H={H}  HK={HK}  D={D}  dtype=bf16  safe_gate=True  has_init_state={HAS_INIT_STATE}")
+    wu = 1 if (NCU_MODE or SANITIZER_MODE) else WARMUP
+    ni = 1 if (NCU_MODE or SANITIZER_MODE) else N_ITERS
+    mode_tag = "  [NCU mode]" if NCU_MODE else ("  [Sanitizer mode]" if SANITIZER_MODE else "")
+    print(f"                 Warmup={wu}  Iters={ni}{mode_tag}")
+    print(sep)
+
+    if fixed_results:
+        print("\n  [Fixed-Length]")
+        print(f"  {'─' * 115}")
+        print(
+            f"  {'B':>3s}  {'T':>6s}  │  "
+            f"{'RMSE(mha)':>10s}  {'rel(mha)':>10s}  {'RMSE(fla)':>10s}  {'rel(fla)':>10s}  │  "
+            f"{'GQA(ms)':>9s}  {'MHA(ms)':>9s}  {'FLA(ms)':>9s}  │  "
+            f"{'GQA↑MHA':>8s}  {'GQA↑FLA':>8s}"
+        )
+        print(f"  {'─' * 115}")
+        for r in fixed_results:
+            print(
+                f"  {r['B']:3d}  {r['T']:6d}  │  "
+                f"{r['rmse_mha']:10.6f}  {r['rel_mha']:10.6f}  {r['rmse_fla']:10.6f}  {r['rel_fla']:10.6f}  │  "
+                f"{r['ms_gqa']:9.4f}  {r['ms_mha']:9.4f}  {r['ms_fla']:9.4f}  │  "
+                f"{r['sp_vs_mha']:7.2f}x  {r['sp_vs_fla']:7.2f}x"
+            )
+        print(f"  {'─' * 115}")
+
+    if varlen_results:
+        print("\n  [Varlen]")
+        print(f"  {'─' * 130}")
+        print(
+            f"  {'Config':>45s}  │  "
+            f"{'RMSE(mha)':>10s}  {'rel(mha)':>10s}  {'RMSE(fla)':>10s}  {'rel(fla)':>10s}  │  "
+            f"{'GQA(ms)':>9s}  {'MHA(ms)':>9s}  {'FLA(ms)':>9s}  │  "
+            f"{'GQA↑MHA':>8s}  {'GQA↑FLA':>8s}"
+        )
+        print(f"  {'─' * 130}")
+        for r in varlen_results:
+            print(
+                f"  {r['tag']:>45s}  │  "
+                f"{r['rmse_mha']:10.6f}  {r['rel_mha']:10.6f}  {r['rmse_fla']:10.6f}  {r['rel_fla']:10.6f}  │  "
+                f"{r['ms_gqa']:9.4f}  {r['ms_mha']:9.4f}  {r['ms_fla']:9.4f}  │  "
+                f"{r['sp_vs_mha']:7.2f}x  {r['sp_vs_fla']:7.2f}x"
+            )
+        print(f"  {'─' * 130}")
+
+    print(f"\n{sep}\n")
+
+
+# ============================================================
+# Main
+# ============================================================
+def main():
+    parser = argparse.ArgumentParser(description="bench_kda_fused_fwd_gqa: multi-value GQA KDA forward benchmark")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="both",
+        choices=["fixed", "varlen", "both"],
+        help="Which benchmark mode to run (default: both)",
+    )
+    parser.add_argument(
+        "--ncu",
+        action="store_true",
+        help="NCU profiling mode: warmup=1, iters=1",
+    )
+    parser.add_argument(
+        "--sanitizer",
+        action="store_true",
+        help="Sanitizer mode: warmup=1, iters=1",
+    )
+    parser.add_argument(
+        "--init_state",
+        action="store_true",
+        help="Use non-zero initial state (default: False)",
+    )
+    args = parser.parse_args()
+
+    global NCU_MODE, SANITIZER_MODE, HAS_INIT_STATE
+    if args.ncu:
+        NCU_MODE = True
+        print("[NCU mode] warmup=1, iters=1")
+    if args.sanitizer:
+        SANITIZER_MODE = True
+        print("[Sanitizer mode] warmup=1, iters=1")
+    if args.init_state:
+        HAS_INIT_STATE = True
+        print("[init_state] using non-zero initial state")
+
+    print(
+        f"[Device] {torch.cuda.get_device_name(0)}  compute capability {_SM_TAG}  →  using {cula_kda_fused_fwd.__module__}.{cula_kda_fused_fwd.__name__}"
+    )
+
+    fixed_configs = [
+        # (B, T)
+        (1, 512),
+        (1, 1024),
+        (1, 4096),
+        (1, 8192),
+        (1, 16384),
+        (2, 1024),
+        (2, 4096),
+        (2, 8192),
+    ]
+
+    varlen_configs = build_varlen_configs(
+        num_seqs_list=(10, 20),
+        total_lens=(4096, 8192, 16384),
+        dists=("uniform", "random", "skewed"),
+    )
+
+    fixed_res, varlen_res = [], []
+
+    if args.mode in ("fixed", "both"):
+        fixed_res = bench_fixed(fixed_configs)
+
+    if args.mode in ("varlen", "both"):
+        varlen_res = bench_varlen(varlen_configs)
+
+    print_report(fixed_res, varlen_res)
+
+    return fixed_res, varlen_res
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_kda_fused_fwd_gqa.py
+++ b/benchmarks/bench_kda_fused_fwd_gqa.py
@@ -75,7 +75,7 @@ cula_kda_fused_fwd = get_kda_fused_fwd(_device)
 # the V / state head count (= grid dim). num_k_heads is Q and K's shared
 # physical head count. k_group_size = num_heads / num_k_heads.
 MODEL_CONFIGS = [
-    ("Qwen3.5-35B-A3B",   32, 16, 128),  # k_group_size = 2
+    ("Qwen3.5-35B-A3B", 32, 16, 128),  # k_group_size = 2
     ("Qwen3.5-122B-A10B", 64, 16, 128),  # k_group_size = 4
 ]
 WARMUP = 25
@@ -210,16 +210,31 @@ def bench_fixed(configs, model_tag, H, HK, D):
         cu_seqlens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int32, device=device)
 
         inputs = prepare_safe_gate_inputs_gqa(
-            B, T, H, HK, D, device, cu_seqlens=cu_seqlens, has_init_state=HAS_INIT_STATE,
+            B,
+            T,
+            H,
+            HK,
+            D,
+            device,
+            cu_seqlens=cu_seqlens,
+            has_init_state=HAS_INIT_STATE,
         )
         q, k, v, g, beta = inputs["q"], inputs["k"], inputs["v"], inputs["g"], inputs["beta"]
         A_log, dt_bias = inputs["A_log"], inputs["dt_bias"]
         scale, init_state, lower_bound = inputs["scale"], inputs["init_state"], inputs["lower_bound"]
 
         gqa_kwargs = dict(
-            q=q, k=k, v=v, g=g, beta=beta, scale=scale,
-            A_log=A_log, dt_bias=dt_bias, init_state=init_state,
-            cu_seqlens=cu_seqlens, lower_bound=lower_bound,
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            init_state=init_state,
+            cu_seqlens=cu_seqlens,
+            lower_bound=lower_bound,
         )
         expanded_kwargs = dict(
             **gqa_kwargs,
@@ -287,16 +302,31 @@ def bench_varlen(configs, model_tag, H, HK, D):
         cu_seqlens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int32, device=device)
 
         inputs = prepare_safe_gate_inputs_gqa(
-            1, T, H, HK, D, device, cu_seqlens=cu_seqlens, has_init_state=HAS_INIT_STATE,
+            1,
+            T,
+            H,
+            HK,
+            D,
+            device,
+            cu_seqlens=cu_seqlens,
+            has_init_state=HAS_INIT_STATE,
         )
         q, k, v, g, beta = inputs["q"], inputs["k"], inputs["v"], inputs["g"], inputs["beta"]
         A_log, dt_bias = inputs["A_log"], inputs["dt_bias"]
         scale, init_state, lower_bound = inputs["scale"], inputs["init_state"], inputs["lower_bound"]
 
         gqa_kwargs = dict(
-            q=q, k=k, v=v, g=g, beta=beta, scale=scale,
-            A_log=A_log, dt_bias=dt_bias, init_state=init_state,
-            cu_seqlens=cu_seqlens, lower_bound=lower_bound,
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            init_state=init_state,
+            cu_seqlens=cu_seqlens,
+            lower_bound=lower_bound,
         )
         expanded_kwargs = dict(
             **gqa_kwargs,
@@ -356,7 +386,9 @@ def print_report(fixed_results, varlen_results, model_tag, H, HK, D):
     print(f"\n\n{sep}")
     print(f"                 BENCHMARK REPORT [{model_tag}]: cula_kda_fused_fwd multi-value GQA")
     print(f"                 cuLA {_SM_TAG} native GQA  vs  cuLA MHA + host expand  vs  FLA Triton + host expand")
-    print(f"                 H={H}  HK={HK}  k_group_size={H // HK}  D={D}  dtype=bf16  safe_gate=True  has_init_state={HAS_INIT_STATE}")
+    print(
+        f"                 H={H}  HK={HK}  k_group_size={H // HK}  D={D}  dtype=bf16  safe_gate=True  has_init_state={HAS_INIT_STATE}"
+    )
     wu = 1 if (NCU_MODE or SANITIZER_MODE) else WARMUP
     ni = 1 if (NCU_MODE or SANITIZER_MODE) else N_ITERS
     mode_tag = "  [NCU mode]" if NCU_MODE else ("  [Sanitizer mode]" if SANITIZER_MODE else "")

--- a/benchmarks/bench_kda_fused_fwd_gqa.py
+++ b/benchmarks/bench_kda_fused_fwd_gqa.py
@@ -69,11 +69,15 @@ _SM_TAG = f"sm{_major}{_minor}"
 cula_kda_fused_fwd = get_kda_fused_fwd(_device)
 
 # ============================================================
-# Constants — Qwen3.5-A3B Gated DeltaNet shape by default
+# Constants — Qwen3.5 Gated DeltaNet shapes
 # ============================================================
-H = 32        # linear_num_value_heads (= state head count, grid dim)
-HK = 16       # linear_num_key_heads   (Q and K share this)
-D = 128       # head_k_dim == head_v_dim
+# Each entry is (model_tag, num_heads, num_k_heads, head_dim). num_heads is
+# the V / state head count (= grid dim). num_k_heads is Q and K's shared
+# physical head count. k_group_size = num_heads / num_k_heads.
+MODEL_CONFIGS = [
+    ("Qwen3.5-35B-A3B",   32, 16, 128),  # k_group_size = 2
+    ("Qwen3.5-122B-A10B", 64, 16, 128),  # k_group_size = 4
+]
 WARMUP = 25
 N_ITERS = 100
 NCU_MODE = False
@@ -189,9 +193,10 @@ def run_fla_expanded(q, k, v, g, beta, scale, A_log, dt_bias, init_state, cu_seq
 # ============================================================
 # Fixed-length benchmark
 # ============================================================
-def bench_fixed(configs):
+def bench_fixed(configs, model_tag, H, HK, D):
     print("\n" + "=" * 120)
-    print(f" Fixed-Length GQA Benchmark: cuLA fully-fused ({_SM_TAG}) native GQA vs MHA-expanded paths")
+    print(f" Fixed-Length GQA Benchmark [{model_tag}]: cuLA fully-fused ({_SM_TAG}) native GQA vs MHA-expanded paths")
+    print(f" H={H}  HK={HK}  k_group_size={H // HK}  D={D}")
     print("=" * 120)
     results = []
 
@@ -265,9 +270,10 @@ def bench_fixed(configs):
 # ============================================================
 # Varlen benchmark
 # ============================================================
-def bench_varlen(configs):
+def bench_varlen(configs, model_tag, H, HK, D):
     print("\n" + "=" * 120)
-    print(f" Varlen GQA Benchmark: cuLA fully-fused ({_SM_TAG}) native GQA vs MHA-expanded paths")
+    print(f" Varlen GQA Benchmark [{model_tag}]: cuLA fully-fused ({_SM_TAG}) native GQA vs MHA-expanded paths")
+    print(f" H={H}  HK={HK}  k_group_size={H // HK}  D={D}")
     print("=" * 120)
     results = []
 
@@ -345,12 +351,12 @@ def bench_varlen(configs):
 # ============================================================
 # Report
 # ============================================================
-def print_report(fixed_results, varlen_results):
+def print_report(fixed_results, varlen_results, model_tag, H, HK, D):
     sep = "=" * 120
     print(f"\n\n{sep}")
-    print("                 BENCHMARK REPORT: cula_kda_fused_fwd multi-value GQA")
+    print(f"                 BENCHMARK REPORT [{model_tag}]: cula_kda_fused_fwd multi-value GQA")
     print(f"                 cuLA {_SM_TAG} native GQA  vs  cuLA MHA + host expand  vs  FLA Triton + host expand")
-    print(f"                 H={H}  HK={HK}  D={D}  dtype=bf16  safe_gate=True  has_init_state={HAS_INIT_STATE}")
+    print(f"                 H={H}  HK={HK}  k_group_size={H // HK}  D={D}  dtype=bf16  safe_gate=True  has_init_state={HAS_INIT_STATE}")
     wu = 1 if (NCU_MODE or SANITIZER_MODE) else WARMUP
     ni = 1 if (NCU_MODE or SANITIZER_MODE) else N_ITERS
     mode_tag = "  [NCU mode]" if NCU_MODE else ("  [Sanitizer mode]" if SANITIZER_MODE else "")
@@ -460,17 +466,20 @@ def main():
         dists=("uniform", "random", "skewed"),
     )
 
-    fixed_res, varlen_res = [], []
+    all_results = []
+    for model_tag, H, HK, D in MODEL_CONFIGS:
+        fixed_res, varlen_res = [], []
 
-    if args.mode in ("fixed", "both"):
-        fixed_res = bench_fixed(fixed_configs)
+        if args.mode in ("fixed", "both"):
+            fixed_res = bench_fixed(fixed_configs, model_tag, H, HK, D)
 
-    if args.mode in ("varlen", "both"):
-        varlen_res = bench_varlen(varlen_configs)
+        if args.mode in ("varlen", "both"):
+            varlen_res = bench_varlen(varlen_configs, model_tag, H, HK, D)
 
-    print_report(fixed_res, varlen_res)
+        print_report(fixed_res, varlen_res, model_tag, H, HK, D)
+        all_results.append((model_tag, fixed_res, varlen_res))
 
-    return fixed_res, varlen_res
+    return all_results
 
 
 if __name__ == "__main__":

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -303,6 +303,69 @@ def prepare_safe_gate_inputs(
     )
 
 
+def prepare_safe_gate_inputs_gqa(
+    batch_size, T, num_heads, num_k_heads, D, device,
+    cu_seqlens=None, chunk_size=CHUNK_SIZE, seed=SEED, has_init_state=False,
+):
+    """Prepare inputs for the "multi-value" GQA flavor of safe_gate KDA.
+
+    Q and K use ``num_k_heads`` physical heads while V, g, beta, and state
+    use the larger ``num_heads`` (= num_value_heads = state heads). This
+    matches Qwen3.5-A3B Gated DeltaNet.
+
+    Also returns host-expanded Q and K (``q_exp``, ``k_exp``) under
+    ``repeat_interleave`` so MHA-only kernels can be run against the same
+    logical inputs.
+    """
+    assert num_heads % num_k_heads == 0, \
+        f"num_heads ({num_heads}) must be a multiple of num_k_heads ({num_k_heads})"
+    dtype = torch.bfloat16
+    scale = D ** (-0.5)
+    set_seed(seed)
+
+    q = torch.randn(batch_size, T, num_k_heads, D, dtype=dtype, device=device).requires_grad_(False)
+    k = torch.randn(batch_size, T, num_k_heads, D, dtype=dtype, device=device).requires_grad_(False)
+    v = torch.randn(batch_size, T, num_heads, D, dtype=dtype, device=device).requires_grad_(False)
+    g = torch.randn(batch_size, T, num_heads, D, dtype=dtype, device=device).requires_grad_(False)
+    beta = torch.randn(batch_size, T, num_heads, dtype=torch.float, device=device).sigmoid().requires_grad_(False)
+
+    A_log = torch.randn(num_heads, dtype=torch.float, device=device).requires_grad_(False)
+    dt_bias = torch.randn(num_heads * D, dtype=torch.float, device=device).requires_grad_(False)
+
+    if batch_size != 1:
+        q, k, v, g, beta = map(lambda x: rearrange(x, "b t ... -> 1 (b t) ..."), (q, k, v, g, beta))
+
+    # Host-expanded Q/K, matching V's head count. This is what users have to
+    # construct today to call a MHA-only fused KDA prefill kernel.
+    k_group_size = num_heads // num_k_heads
+    q_exp = q.repeat_interleave(k_group_size, dim=2).contiguous()
+    k_exp = k.repeat_interleave(k_group_size, dim=2).contiguous()
+
+    chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size) if cu_seqlens is not None else None
+
+    init_state = None
+    if has_init_state:
+        num_seqs = cu_seqlens.shape[0] - 1 if cu_seqlens is not None else batch_size
+        init_state = torch.randn(num_seqs, num_heads, D, D, dtype=torch.float, device=device).requires_grad_(False)
+
+    return dict(
+        q=q,
+        k=k,
+        q_exp=q_exp,
+        k_exp=k_exp,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        init_state=init_state,
+        lower_bound=-5.0,
+    )
+
+
 def prepare_intra_inputs(batch_size, T, H, D, device, cu_seqlens=None, chunk_size=CHUNK_SIZE, seed=SEED):
     """Prepare preprocessed inputs ready for chunk_kda_fwd_intra.
 

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -304,8 +304,16 @@ def prepare_safe_gate_inputs(
 
 
 def prepare_safe_gate_inputs_gqa(
-    batch_size, T, num_heads, num_k_heads, D, device,
-    cu_seqlens=None, chunk_size=CHUNK_SIZE, seed=SEED, has_init_state=False,
+    batch_size,
+    T,
+    num_heads,
+    num_k_heads,
+    D,
+    device,
+    cu_seqlens=None,
+    chunk_size=CHUNK_SIZE,
+    seed=SEED,
+    has_init_state=False,
 ):
     """Prepare inputs for the "multi-value" GQA flavor of safe_gate KDA.
 
@@ -317,8 +325,7 @@ def prepare_safe_gate_inputs_gqa(
     ``repeat_interleave`` so MHA-only kernels can be run against the same
     logical inputs.
     """
-    assert num_heads % num_k_heads == 0, \
-        f"num_heads ({num_heads}) must be a multiple of num_k_heads ({num_k_heads})"
+    assert num_heads % num_k_heads == 0, f"num_heads ({num_heads}) must be a multiple of num_k_heads ({num_k_heads})"
     dtype = torch.bfloat16
     scale = D ** (-0.5)
     set_seed(seed)

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -319,11 +319,10 @@ def prepare_safe_gate_inputs_gqa(
 
     Q and K use ``num_k_heads`` physical heads while V, g, beta, and state
     use the larger ``num_heads`` (= num_value_heads = state heads). This
-    matches Qwen3.5-A3B Gated DeltaNet.
-
-    Also returns host-expanded Q and K (``q_exp``, ``k_exp``) under
-    ``repeat_interleave`` so MHA-only kernels can be run against the same
-    logical inputs.
+    matches Qwen3.5-A3B Gated DeltaNet. Callers that need to compare
+    against an MHA-only kernel are expected to ``repeat_interleave`` Q and
+    K on their side — this helper intentionally does not pre-materialise
+    the expansion so the cost stays visible in their timed block.
     """
     assert num_heads % num_k_heads == 0, f"num_heads ({num_heads}) must be a multiple of num_k_heads ({num_k_heads})"
     dtype = torch.bfloat16
@@ -342,12 +341,6 @@ def prepare_safe_gate_inputs_gqa(
     if batch_size != 1:
         q, k, v, g, beta = map(lambda x: rearrange(x, "b t ... -> 1 (b t) ..."), (q, k, v, g, beta))
 
-    # Host-expanded Q/K, matching V's head count. This is what users have to
-    # construct today to call a MHA-only fused KDA prefill kernel.
-    k_group_size = num_heads // num_k_heads
-    q_exp = q.repeat_interleave(k_group_size, dim=2).contiguous()
-    k_exp = k.repeat_interleave(k_group_size, dim=2).contiguous()
-
     chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size) if cu_seqlens is not None else None
 
     init_state = None
@@ -358,8 +351,6 @@ def prepare_safe_gate_inputs_gqa(
     return dict(
         q=q,
         k=k,
-        q_exp=q_exp,
-        k_exp=k_exp,
         v=v,
         g=g,
         beta=beta,

--- a/csrc/api/kda_sm90.cu
+++ b/csrc/api/kda_sm90.cu
@@ -35,24 +35,41 @@ kda_fwd_prefill(
     torch::Tensor workspace_buffer,
     float scale,
     bool safe_gate) {
-    // Q, K, V: [packed_seq, H, D] (already packed by Python layer)
+    // Layouts:
+    //   Q: [packed_seq, num_k_heads, head_size]
+    //   K: [packed_seq, num_k_heads, head_size]
+    //   V: [packed_seq, num_heads,   head_size]
+    // In plain MHA num_k_heads == num_heads. In KDA's "multi-value"
+    // flavor (e.g. Qwen3.5 Gated DeltaNet) num_k_heads < num_heads and
+    // k_group_size = num_heads / num_k_heads state heads share each
+    // physical Q/K head. Output O and state always use num_heads.
     auto packed_seq = q.size(0);
-    auto num_heads = q.size(1);
+    auto num_k_heads = q.size(1);
+    auto num_heads = v.size(1);
     auto head_size = q.size(2);
     auto num_seqs = cu_seqlens.size(0) - 1;
 
-    // KDA constraint: all head counts must be the same
-    TORCH_CHECK(num_heads == k.size(1), "KDA requires num_q_heads == num_k_heads, got ", num_heads, " vs ", k.size(1));
-    TORCH_CHECK(num_heads == v.size(1), "KDA requires num_q_heads == num_v_heads, got ", num_heads, " vs ", v.size(1));
-    TORCH_CHECK(head_size == v.size(2), "KDA requires Q and V head dim to match, got ", head_size, " vs ", v.size(2));
+    // Q and K share a head count in KDA (they meet in Q*K^T).
+    TORCH_CHECK(num_k_heads == k.size(1),
+                "KDA requires q.size(1) == k.size(1), got ", num_k_heads, " vs ", k.size(1));
+    // V's head dim must match Q/K (same hidden per-head projection width).
+    TORCH_CHECK(head_size == k.size(2),
+                "KDA requires q and k head dim to match, got ", head_size, " vs ", k.size(2));
+    TORCH_CHECK(head_size == v.size(2),
+                "KDA requires q and v head dim to match, got ", head_size, " vs ", v.size(2));
+    // num_heads must be a multiple of num_k_heads so k_group_size is integer.
+    TORCH_CHECK(num_heads % num_k_heads == 0,
+                "KDA requires num_heads % num_k_heads == 0 (num_heads=",
+                num_heads, ", num_k_heads=", num_k_heads, ")");
 
-    // Allocate output if not provided
+    // Allocate output if not provided. Shape is [packed_seq, num_heads, head_size]
+    // because O carries one value-stream per state/V head.
     torch::Tensor output = output_.has_value() ? output_.value()
                                                : torch::empty(
                                                      {packed_seq, num_heads, head_size},
                                                      torch::TensorOptions().dtype(q.dtype()).device(q.device()));
 
-    // Allocate output state if not provided
+    // State has one [head_size, head_size] K×V matrix per state head.
     torch::Tensor output_state = output_state_.has_value()
                                      ? output_state_.value()
                                      : torch::zeros(
@@ -136,7 +153,8 @@ kda_fwd_prefill(
             static_cast<int64_t>(packed_seq),
             scale,
             safe_gate,
-            static_cast<int32_t>(sm_count));
+            static_cast<int32_t>(sm_count),
+            static_cast<int32_t>(num_k_heads));
     } else {
         float const* beta_ptr = beta_.has_value() ? beta_.value().data_ptr<float>() : nullptr;
         kda::sm90::launch_kda_fwd_prefill_kernel<Sm90, bf16, bf16, float, float>(
@@ -157,7 +175,8 @@ kda_fwd_prefill(
             static_cast<int64_t>(packed_seq),
             scale,
             safe_gate,
-            static_cast<int32_t>(sm_count));
+            static_cast<int32_t>(sm_count),
+            static_cast<int32_t>(num_k_heads));
     }
 
     return {output, output_state};

--- a/csrc/api/kda_sm90.cu
+++ b/csrc/api/kda_sm90.cu
@@ -50,17 +50,18 @@ kda_fwd_prefill(
     auto num_seqs = cu_seqlens.size(0) - 1;
 
     // Q and K share a head count in KDA (they meet in Q*K^T).
-    TORCH_CHECK(num_k_heads == k.size(1),
-                "KDA requires q.size(1) == k.size(1), got ", num_k_heads, " vs ", k.size(1));
+    TORCH_CHECK(num_k_heads == k.size(1), "KDA requires q.size(1) == k.size(1), got ", num_k_heads, " vs ", k.size(1));
     // V's head dim must match Q/K (same hidden per-head projection width).
-    TORCH_CHECK(head_size == k.size(2),
-                "KDA requires q and k head dim to match, got ", head_size, " vs ", k.size(2));
-    TORCH_CHECK(head_size == v.size(2),
-                "KDA requires q and v head dim to match, got ", head_size, " vs ", v.size(2));
+    TORCH_CHECK(head_size == k.size(2), "KDA requires q and k head dim to match, got ", head_size, " vs ", k.size(2));
+    TORCH_CHECK(head_size == v.size(2), "KDA requires q and v head dim to match, got ", head_size, " vs ", v.size(2));
     // num_heads must be a multiple of num_k_heads so k_group_size is integer.
-    TORCH_CHECK(num_heads % num_k_heads == 0,
-                "KDA requires num_heads % num_k_heads == 0 (num_heads=",
-                num_heads, ", num_k_heads=", num_k_heads, ")");
+    TORCH_CHECK(
+        num_heads % num_k_heads == 0,
+        "KDA requires num_heads % num_k_heads == 0 (num_heads=",
+        num_heads,
+        ", num_k_heads=",
+        num_k_heads,
+        ")");
 
     // Allocate output if not provided. Shape is [packed_seq, num_heads, head_size]
     // because O carries one value-stream per state/V head.

--- a/csrc/kda/sm90/collective/load_tma.hpp
+++ b/csrc/kda/sm90/collective/load_tma.hpp
@@ -85,11 +85,11 @@ struct CollectiveLoadTma {
         constexpr auto HeadSize = decltype(get<2>(tile_shape))::value;
 
         // KDA's multi-value flavor: Q and K share num_k_heads physical heads
-        // while V (and state/alpha/beta) use num_heads. num_k_heads == 0 is
-        // treated as num_k_heads == num_heads (plain MHA) by the host side,
-        // but we guard again here for safety on device paths that may bypass
-        // the scheduler wiring.
-        int32_t num_k_heads = problem_size.num_k_heads > 0 ? problem_size.num_k_heads : problem_size.num_heads;
+        // while V (and state/alpha/beta) use num_heads. The host entry point
+        // already normalises a sentinel 0 to `num_heads` before packing the
+        // launcher Arguments, so `problem_size.num_k_heads` is guaranteed
+        // positive here (== num_heads in plain MHA).
+        int32_t num_k_heads = problem_size.num_k_heads;
         Tensor g = [&] {
             if constexpr (kind == LoadKind::kQ) {
                 DPRINTF0_W(

--- a/csrc/kda/sm90/collective/load_tma.hpp
+++ b/csrc/kda/sm90/collective/load_tma.hpp
@@ -84,6 +84,14 @@ struct CollectiveLoadTma {
         constexpr auto BlkSeqKV = decltype(get<1>(tile_shape))::value;
         constexpr auto HeadSize = decltype(get<2>(tile_shape))::value;
 
+        // KDA's multi-value flavor: Q and K share num_k_heads physical heads
+        // while V (and state/alpha/beta) use num_heads. num_k_heads == 0 is
+        // treated as num_k_heads == num_heads (plain MHA) by the host side,
+        // but we guard again here for safety on device paths that may bypass
+        // the scheduler wiring.
+        int32_t num_k_heads = problem_size.num_k_heads > 0
+            ? problem_size.num_k_heads
+            : problem_size.num_heads;
         Tensor g = [&] {
             if constexpr (kind == LoadKind::kQ) {
                 DPRINTF0_W(
@@ -95,26 +103,27 @@ struct CollectiveLoadTma {
                 Tensor m_varlen_head = tma_load.get_tma_tensor(make_shape(
                     problem_size.total_seqlen,
                     problem_size.head_size,
-                    problem_size.num_heads));  // global view to the packed varlen sequence
-                Tensor m_varlen = m_varlen_head(_, _, work_desc.q_head_idx());  // slice into current head_idx
+                    num_k_heads));  // Q tensor has num_k_heads along the head axis
+                Tensor m_varlen = m_varlen_head(_, _, work_desc.q_head_idx());  // slice into current Q head
                 Tensor m_offset = domain_offset(
                     make_coord(work_desc.tok_offset, _0{}),
                     m_varlen);  // offset to start of the current sequence
                 Tensor g_full =
                     local_tile(m_offset, make_tile(BlkSeqQ, HeadSize), make_coord(_, _0{}));  // (blk, d, iter_blk)
                 return g_full;
-            } else if constexpr (kind == LoadKind::kAlpha) {  // same as Q currently
+            } else if constexpr (kind == LoadKind::kAlpha) {
+                // Alpha is per state head (num_heads), NOT per Q/K head.
                 DPRINTF0_W(
                     "slice view GMEM %s: seq_idx:%d head_idx:%d tok_offset:%lld\n",
                     to_string(kind),
                     work_desc.seq_idx,
-                    work_desc.q_head_idx(),
+                    work_desc.o_head_idx(),
                     work_desc.tok_offset);
                 Tensor m_varlen_head = tma_load.get_tma_tensor(make_shape(
                     problem_size.total_seqlen,
                     problem_size.head_size,
-                    problem_size.num_heads));  // global view to the packed varlen sequence
-                Tensor m_varlen = m_varlen_head(_, _, work_desc.q_head_idx());  // slice into current head_idx
+                    problem_size.num_heads));  // alpha has num_heads along head axis
+                Tensor m_varlen = m_varlen_head(_, _, work_desc.o_head_idx());  // slice per state head
                 Tensor m_offset = domain_offset(
                     make_coord(work_desc.tok_offset, _0{}),
                     m_varlen);  // offset to start of the current sequence
@@ -122,7 +131,16 @@ struct CollectiveLoadTma {
                     local_tile(m_offset, make_tile(BlkSeqQ, HeadSize), make_coord(_, _0{}));  // (blk, d, iter_blk)
                 return g_full;
             } else {
-                auto head_idx = (kind == LoadKind::kK ? work_desc.k_head_idx() : work_desc.v_head_idx());
+                // K uses num_k_heads (shared with Q). V uses num_heads.
+                int32_t head_idx;
+                int32_t tensor_heads;
+                if constexpr (kind == LoadKind::kK) {
+                    head_idx = work_desc.k_head_idx();
+                    tensor_heads = num_k_heads;
+                } else {  // kV
+                    head_idx = work_desc.v_head_idx();
+                    tensor_heads = problem_size.num_heads;
+                }
                 DPRINTF0_W(
                     "slice view GMEM %s: seq_idx:%d head_idx:%d tok_offset:%lld\n",
                     to_string(kind),
@@ -132,8 +150,8 @@ struct CollectiveLoadTma {
                 Tensor m_varlen_head = tma_load.get_tma_tensor(make_shape(
                     problem_size.head_size,
                     problem_size.total_seqlen,
-                    problem_size.num_heads));                     // global view to the packed varlen sequence
-                Tensor m_varlen = m_varlen_head(_, _, head_idx);  // slice into current head_idx
+                    tensor_heads));                               // global view to the packed varlen sequence
+                Tensor m_varlen = m_varlen_head(_, _, head_idx);  // slice into current head
                 Tensor m_offset = domain_offset(
                     make_coord(_0{}, work_desc.tok_offset),
                     m_varlen);  // offset to start of the current sequence

--- a/csrc/kda/sm90/collective/load_tma.hpp
+++ b/csrc/kda/sm90/collective/load_tma.hpp
@@ -89,9 +89,7 @@ struct CollectiveLoadTma {
         // treated as num_k_heads == num_heads (plain MHA) by the host side,
         // but we guard again here for safety on device paths that may bypass
         // the scheduler wiring.
-        int32_t num_k_heads = problem_size.num_k_heads > 0
-            ? problem_size.num_k_heads
-            : problem_size.num_heads;
+        int32_t num_k_heads = problem_size.num_k_heads > 0 ? problem_size.num_k_heads : problem_size.num_heads;
         Tensor g = [&] {
             if constexpr (kind == LoadKind::kQ) {
                 DPRINTF0_W(
@@ -122,7 +120,7 @@ struct CollectiveLoadTma {
                 Tensor m_varlen_head = tma_load.get_tma_tensor(make_shape(
                     problem_size.total_seqlen,
                     problem_size.head_size,
-                    problem_size.num_heads));  // alpha has num_heads along head axis
+                    problem_size.num_heads));                                   // alpha has num_heads along head axis
                 Tensor m_varlen = m_varlen_head(_, _, work_desc.o_head_idx());  // slice per state head
                 Tensor m_offset = domain_offset(
                     make_coord(work_desc.tok_offset, _0{}),

--- a/csrc/kda/sm90/collective/mainloop_kda_fwd.hpp
+++ b/csrc/kda/sm90/collective/mainloop_kda_fwd.hpp
@@ -505,16 +505,27 @@ struct FlatMainloopTmaWarpSpecializedKdaFwd {
         int64_t s = problem_size.total_seqlen;
         int64_t t = problem_size.total_seqlen;
         int32_t d = problem_size.head_size;
+        // num_k_heads == 0 means "same as num_heads" (plain MHA). Q and K
+        // physical heads always share a single count in KDA.
+        int32_t num_k_heads = problem_size.num_k_heads > 0
+            ? problem_size.num_k_heads
+            : problem_size.num_heads;
 
+        // Q TMA (operand A of QK^T). Q has num_k_heads along its head axis
+        // (Q shares its physical head count with K in KDA). The K operand
+        // constructed here is a dummy whose TMA is thrown away — only
+        // params_qk.tma_load_a for Q is read out below, so passing
+        // num_k_heads as L here is correct for the live TMA.
         auto params_qk = CollectiveMmaQK::to_underlying_arguments(
-            make_shape(s, t, d, problem_size.num_heads),
+            make_shape(s, t, d, num_k_heads),
             typename CollectiveMmaQK::Arguments{
                 args.ptr_Q, args.dQ, args.ptr_K, args.dK,  // never used, dummy
             },
             /*workspace=*/nullptr);
 
+        // K TMA (operand B of this collective). num_k_heads along L.
         auto params_kv_k = CollectiveMmaKV_G2S::to_underlying_arguments(
-            make_shape(d, d, s, problem_size.num_heads),
+            make_shape(d, d, s, num_k_heads),
             typename CollectiveMmaKV_G2S::Arguments{
                 args.ptr_V,
                 select<1, 0, 2>(args.dV),  // not used
@@ -523,6 +534,7 @@ struct FlatMainloopTmaWarpSpecializedKdaFwd {
             },
             /*workspace=*/nullptr);
 
+        // Alpha is per state/V head — uses num_heads along the head axis.
         auto alpha_shape = make_shape(s, d, problem_size.num_heads);
         auto alpha_stride = make_stride(
             get<0>(args.dAlpha),  // seqlen stride
@@ -537,6 +549,8 @@ struct FlatMainloopTmaWarpSpecializedKdaFwd {
             select<1, 2>(TileShapeQK{}),
             size<0>(ClusterShape{}));
 
+        // V TMA (operand A of this collective). V has num_heads along L —
+        // in KDA V matches the state/grid head count, NOT the Q/K count.
         auto params_kv_v = CollectiveMmaKV_G2S::to_underlying_arguments(
             make_shape(d, d, s, problem_size.num_heads),
             typename CollectiveMmaKV_G2S::Arguments{

--- a/csrc/kda/sm90/collective/mainloop_kda_fwd.hpp
+++ b/csrc/kda/sm90/collective/mainloop_kda_fwd.hpp
@@ -505,9 +505,11 @@ struct FlatMainloopTmaWarpSpecializedKdaFwd {
         int64_t s = problem_size.total_seqlen;
         int64_t t = problem_size.total_seqlen;
         int32_t d = problem_size.head_size;
-        // num_k_heads == 0 means "same as num_heads" (plain MHA). Q and K
-        // physical heads always share a single count in KDA.
-        int32_t num_k_heads = problem_size.num_k_heads > 0 ? problem_size.num_k_heads : problem_size.num_heads;
+        // Q and K physical heads always share a single count in KDA. The
+        // host entry point normalises a sentinel 0 to `num_heads` before
+        // constructing the launcher Arguments, so `problem_size.num_k_heads`
+        // is guaranteed positive here (== num_heads in plain MHA).
+        int32_t num_k_heads = problem_size.num_k_heads;
 
         // Q TMA (operand A of QK^T). Q has num_k_heads along its head axis
         // (Q shares its physical head count with K in KDA). The K operand

--- a/csrc/kda/sm90/collective/mainloop_kda_fwd.hpp
+++ b/csrc/kda/sm90/collective/mainloop_kda_fwd.hpp
@@ -507,9 +507,7 @@ struct FlatMainloopTmaWarpSpecializedKdaFwd {
         int32_t d = problem_size.head_size;
         // num_k_heads == 0 means "same as num_heads" (plain MHA). Q and K
         // physical heads always share a single count in KDA.
-        int32_t num_k_heads = problem_size.num_k_heads > 0
-            ? problem_size.num_k_heads
-            : problem_size.num_heads;
+        int32_t num_k_heads = problem_size.num_k_heads > 0 ? problem_size.num_k_heads : problem_size.num_heads;
 
         // Q TMA (operand A of QK^T). Q has num_k_heads along its head axis
         // (Q shares its physical head count with K in KDA). The K operand

--- a/csrc/kda/sm90/kda_fwd_sm90.cu
+++ b/csrc/kda/sm90/kda_fwd_sm90.cu
@@ -52,7 +52,8 @@ launch_kda_fwd_prefill_kernel_gbai(
     int32_t head_size,
     int64_t total_seqlen,
     float scale,
-    int32_t sm_count);
+    int32_t sm_count,
+    int32_t num_k_heads = 0);
 
 template <
     typename ArchTag,  // TODO: hide this
@@ -79,7 +80,8 @@ launch_kda_fwd_prefill_kernel(
     int64_t total_seqlen,
     float scale,
     bool safe_gate,
-    int32_t sm_count = 0) {
+    int32_t sm_count = 0,
+    int32_t num_k_heads = 0) {
     bool needs_beta = beta != nullptr;
     bool needs_alpha = alpha != nullptr;
     bool init_state = input_state != nullptr;
@@ -102,7 +104,8 @@ launch_kda_fwd_prefill_kernel(
         head_size,                                                                               \
         total_seqlen,                                                                            \
         scale,                                                                                   \
-        sm_count);
+        sm_count,                                                                                \
+        num_k_heads);
     if (init_state) {
         if (needs_beta && needs_alpha && safe_gate) {
             LAUNCH(true, true, true, true);
@@ -142,7 +145,8 @@ launch_kda_fwd_prefill_kernel<cutlass::arch::Sm90, bf16, bf16, float, float>(
     int64_t total_seqlen,
     float scale,
     bool safe_gate,
-    int32_t sm_count);
+    int32_t sm_count,
+    int32_t num_k_heads);
 
 // TBeta=bf16
 template void
@@ -164,6 +168,7 @@ launch_kda_fwd_prefill_kernel<cutlass::arch::Sm90, bf16, bf16, float, bf16>(
     int64_t total_seqlen,
     float scale,
     bool safe_gate,
-    int32_t sm_count);
+    int32_t sm_count,
+    int32_t num_k_heads);
 
 }  // namespace kda::sm90

--- a/csrc/kda/sm90/kda_fwd_sm90_safe_gate.cu
+++ b/csrc/kda/sm90/kda_fwd_sm90_safe_gate.cu
@@ -42,6 +42,7 @@ launch_kda_fwd_prefill_kernel_gbai<true, true, false, true, cutlass::arch::Sm90,
     int32_t,
     int64_t,
     float,
+    int32_t,
     int32_t);
 
 // SafeGate=true, InitState=true
@@ -63,6 +64,7 @@ launch_kda_fwd_prefill_kernel_gbai<true, true, true, true, cutlass::arch::Sm90, 
     int32_t,
     int64_t,
     float,
+    int32_t,
     int32_t);
 
 // SafeGate=true, InitState=false, BetaBF16
@@ -84,6 +86,7 @@ launch_kda_fwd_prefill_kernel_gbai<true, true, false, true, cutlass::arch::Sm90,
     int32_t,
     int64_t,
     float,
+    int32_t,
     int32_t);
 
 // SafeGate=true, InitState=true, BetaBF16
@@ -105,6 +108,7 @@ launch_kda_fwd_prefill_kernel_gbai<true, true, true, true, cutlass::arch::Sm90, 
     int32_t,
     int64_t,
     float,
+    int32_t,
     int32_t);
 
 }  // namespace kda::sm90

--- a/csrc/kda/sm90/kernel/kernel_kda_fwd.hpp
+++ b/csrc/kda/sm90/kernel/kernel_kda_fwd.hpp
@@ -135,8 +135,18 @@ struct FlatKernelTmaWarpSpecializedKdaFwd {
         int32_t const* cu_seqlens;
         int64_t total_seqlen;
         int32_t num_seqs;
-        int32_t num_heads;  // Q, K, V, O all share the same head count in KDA
+        int32_t num_heads;  // Number of V heads, state heads, grid dim.
+                            // Also the head count for O, alpha, and beta.
         int32_t head_size;  // d
+        int32_t num_k_heads = 0;
+        // Number of Q/K heads (Q and K always share a head count in KDA because
+        // they interact in the Q*K^T matmul). When num_k_heads == num_heads (or
+        // 0, the default), the kernel behaves as plain MHA. When num_heads >
+        // num_k_heads and num_heads % num_k_heads == 0, the kernel runs as
+        // "multi-value" attention: k_group_size = num_heads / num_k_heads
+        // V/state heads share each physical Q/K head. This matches e.g.
+        // Qwen3.5-A3B's Gated DeltaNet (linear_num_key_heads=16,
+        // linear_num_value_heads=32).
     };
     using ProblemShape = VarlenProblemShape;
 

--- a/csrc/kda/sm90/kernel/tile_scheduler.hpp
+++ b/csrc/kda/sm90/kernel/tile_scheduler.hpp
@@ -25,7 +25,10 @@ using namespace cute;
 struct WorkDesc {
     // coord
     int32_t seq_idx;
-    int32_t head_idx;
+    int32_t head_idx;          // state/V head index in [0, num_heads)
+    int32_t k_group_size = 1;  // num_heads / num_k_heads. Q and K share the
+                               // same physical head = head_idx / k_group_size.
+                               // k_group_size == 1 is plain MHA.
     int64_t tok_offset;  // offset to the start of the start
 
     // shape
@@ -40,13 +43,17 @@ struct WorkDesc {
         return seq_idx >= 0 && seq_idx < params.num_seqs;
     }
 
+    // Q and K share one physical head count in KDA. In the "multi-value"
+    // flavor (Qwen3.5-style), k_group_size > 1 state heads share each
+    // physical Q/K head; in plain MHA k_group_size == 1 and every state head
+    // gets its own Q and K head.
     CUTE_DEVICE int32_t
     q_head_idx() const {
-        return head_idx;
+        return head_idx / k_group_size;
     }
     CUTE_DEVICE int32_t
     k_head_idx() const {
-        return head_idx;
+        return head_idx / k_group_size;
     }
     CUTE_DEVICE int32_t
     v_head_idx() const {
@@ -69,6 +76,7 @@ struct IndividualTileScheduler {
         dim3 grid;
         int32_t num_seqs;
         int32_t num_heads;
+        int32_t k_group_size;  // num_heads / num_k_heads (>=1, ==1 for MHA)
     };
 
     bool scheduled = false;  // a once flag
@@ -86,17 +94,26 @@ struct IndividualTileScheduler {
         TileShape const& tile_shape) {
         dim3 grid(0, 1, 1);
         grid.x = problem_size.num_seqs * problem_size.num_heads;
+        // num_k_heads == 0 means "same as num_heads" (MHA). The host wrapper
+        // can leave num_k_heads unset and the kernel behaves exactly as before.
+        int32_t effective_num_k_heads =
+            problem_size.num_k_heads > 0 ? problem_size.num_k_heads : problem_size.num_heads;
+        int32_t k_group_size = problem_size.num_heads / effective_num_k_heads;
         DPRINTF(
-            "to_underlying_arguments: grid:{.x:%d, .y:%d, .z:%d}, num_seqs:%d, num_heads:%d\n",
+            "to_underlying_arguments: grid:{.x:%d, .y:%d, .z:%d}, num_seqs:%d, "
+            "num_heads:%d, num_k_heads:%d, k_group_size:%d\n",
             grid.x,
             grid.y,
             grid.z,
             problem_size.num_seqs,
-            problem_size.num_heads);
+            problem_size.num_heads,
+            effective_num_k_heads,
+            k_group_size);
         return {
             .grid = grid,
             .num_seqs = problem_size.num_seqs,
             .num_heads = problem_size.num_heads,
+            .k_group_size = k_group_size,
         };
     }
 
@@ -130,6 +147,7 @@ struct IndividualTileScheduler {
         return {
             .seq_idx = seq_idx,
             .head_idx = head_idx,
+            .k_group_size = params.k_group_size,
             .tok_offset = s,
             .seq_len = seq_len,
         };

--- a/csrc/kda/sm90/kernel/tile_scheduler.hpp
+++ b/csrc/kda/sm90/kernel/tile_scheduler.hpp
@@ -94,11 +94,11 @@ struct IndividualTileScheduler {
         TileShape const& tile_shape) {
         dim3 grid(0, 1, 1);
         grid.x = problem_size.num_seqs * problem_size.num_heads;
-        // num_k_heads == 0 means "same as num_heads" (MHA). The host wrapper
-        // can leave num_k_heads unset and the kernel behaves exactly as before.
-        int32_t effective_num_k_heads =
-            problem_size.num_k_heads > 0 ? problem_size.num_k_heads : problem_size.num_heads;
-        int32_t k_group_size = problem_size.num_heads / effective_num_k_heads;
+        // The host entry point normalises a sentinel num_k_heads==0 to
+        // `num_heads` before building the launcher Arguments, so
+        // `problem_size.num_k_heads` is guaranteed positive here (== num_heads
+        // in plain MHA). Dividing is therefore always safe.
+        int32_t k_group_size = problem_size.num_heads / problem_size.num_k_heads;
         DPRINTF(
             "to_underlying_arguments: grid:{.x:%d, .y:%d, .z:%d}, num_seqs:%d, "
             "num_heads:%d, num_k_heads:%d, k_group_size:%d\n",
@@ -107,7 +107,7 @@ struct IndividualTileScheduler {
             grid.z,
             problem_size.num_seqs,
             problem_size.num_heads,
-            effective_num_k_heads,
+            problem_size.num_k_heads,
             k_group_size);
         return {
             .grid = grid,

--- a/csrc/kda/sm90/kernel/tile_scheduler.hpp
+++ b/csrc/kda/sm90/kernel/tile_scheduler.hpp
@@ -29,7 +29,7 @@ struct WorkDesc {
     int32_t k_group_size = 1;  // num_heads / num_k_heads. Q and K share the
                                // same physical head = head_idx / k_group_size.
                                // k_group_size == 1 is plain MHA.
-    int64_t tok_offset;  // offset to the start of the start
+    int64_t tok_offset;        // offset to the start of the start
 
     // shape
     int64_t seq_len;

--- a/csrc/kda/sm90/prefill_kernel.hpp
+++ b/csrc/kda/sm90/prefill_kernel.hpp
@@ -45,6 +45,16 @@ launch_kda_fwd_prefill_kernel(
     int64_t total_seqlen,
     float scale,
     bool safe_gate,
-    int32_t sm_count = 0);
+    int32_t sm_count = 0,
+    /// Number of physical Q/K heads. Q and K always share one head count in
+    /// KDA because they interact in the Q*K^T matmul. When 0 (default) or
+    /// equal to num_heads the kernel runs as plain MHA. When num_heads >
+    /// num_k_heads and num_heads % num_k_heads == 0, the kernel runs as KDA's
+    /// "multi-value" attention flavor: k_group_size = num_heads / num_k_heads
+    /// V/state heads share each physical Q/K head. Q and K tensors are
+    /// expected to be laid out as [total_seqlen, num_k_heads, head_size]; V
+    /// and O keep the [total_seqlen, num_heads, head_size] layout. This
+    /// matches e.g. Qwen3.5-A3B's Gated DeltaNet.
+    int32_t num_k_heads = 0);
 
 }  // namespace kda::sm90

--- a/csrc/kda/sm90/prefill_kernel_kda_fwd_sm90.cuh
+++ b/csrc/kda/sm90/prefill_kernel_kda_fwd_sm90.cuh
@@ -57,7 +57,8 @@ launch_kda_fwd_prefill_kernel_gbai(
     int32_t head_size,
     int64_t total_seqlen,
     float scale,
-    int32_t sm_count) {
+    int32_t sm_count,
+    int32_t num_k_heads = 0) {
 #if defined(CULA_SM90A_ENABLED)
     constexpr bool HopperSupported = true;
 #else
@@ -104,9 +105,15 @@ launch_kda_fwd_prefill_kernel_gbai(
             Options>::Kernel>;
         using Arguments = typename Operation::Arguments;
 
-        // NOTE: LayoutQ/K/V in (seq, head_size, (b,h)) coordinate semantics
-
-        int32_t tok_stride = num_heads * head_size;
+        // NOTE: LayoutQ/K/V in (seq, head_size, (b,h)) coordinate semantics.
+        //
+        // KDA's "multi-value" GQA flavor: Q and K share a single physical
+        // head count (num_k_heads), while V matches num_heads (the state/grid
+        // head count). When num_k_heads==0 (default) or ==num_heads, the
+        // kernel runs as plain MHA and nothing visible to the caller changes.
+        int32_t effective_num_k_heads = num_k_heads > 0 ? num_k_heads : num_heads;
+        int32_t tok_stride_qk = effective_num_k_heads * head_size;  // Q, K
+        int32_t tok_stride_v = num_heads * head_size;               // V, O, alpha
         int32_t head_stride = head_size;
 
         Operation op;
@@ -118,15 +125,16 @@ launch_kda_fwd_prefill_kernel_gbai(
                     .num_seqs = num_seqs,
                     .num_heads = num_heads,
                     .head_size = head_size,
+                    .num_k_heads = effective_num_k_heads,
                 },
             .mainloop =
                 {
                     // clang-format off
-                .ptr_Q = (T*)q,      .dQ = {tok_stride, _1{}, head_stride},
-                .ptr_K = (T*)k,      .dK = {tok_stride, _1{}, head_stride},
-                .ptr_V = (T*)v,      .dV = {tok_stride, _1{}, head_stride},
-                .ptr_O = (T*)output, .dO = {tok_stride, _1{}, head_stride},
-                .ptr_Alpha = alpha,  .dAlpha = {tok_stride, _1{}, head_stride},
+                .ptr_Q = (T*)q,      .dQ = {tok_stride_qk, _1{}, head_stride},
+                .ptr_K = (T*)k,      .dK = {tok_stride_qk, _1{}, head_stride},
+                .ptr_V = (T*)v,      .dV = {tok_stride_v,  _1{}, head_stride},
+                .ptr_O = (T*)output, .dO = {tok_stride_v,  _1{}, head_stride},
+                .ptr_Alpha = alpha,  .dAlpha = {tok_stride_v, _1{}, head_stride},
                 .ptr_output_state = (float*)output_state,
                 .ptr_input_state  = (float*)input_state,
                 .scale = scale,

--- a/cula/kda/hopper_fused_fwd.py
+++ b/cula/kda/hopper_fused_fwd.py
@@ -49,9 +49,17 @@ class HopperChunkKDAFunction(torch.autograd.Function):
         chunk_indices: torch.IntTensor | None = None,
     ):
         chunk_size = 64
-        assert q.shape[-2] == v.shape[-2] == k.shape[-2], "Number of heads must be the same for q, k, v."
+        # KDA: Q and K always share a physical head count. V (and state,
+        # alpha/g, beta, O) use num_heads which may be larger — the
+        # "multi-value" flavor. When num_k_heads == num_heads this is MHA.
+        assert q.shape[-2] == k.shape[-2], "q and k must have the same head count"
+        assert q.shape[-1] == k.shape[-1] == v.shape[-1], "q, k, v must share head dim"
+        num_heads = v.shape[-2]
+        num_k_heads = q.shape[-2]
+        assert num_heads % num_k_heads == 0, \
+            f"num_heads ({num_heads}) must be a multiple of num_k_heads ({num_k_heads})"
 
-        batch_size, seq_len, num_heads, head_dim = q.shape
+        batch_size, seq_len, _, head_dim = v.shape
 
         if cu_seqlens is None:
             cu_seqlens = prepare_uniform_cu_seqlens(batch_size, seq_len, q.device, torch.int32)
@@ -88,10 +96,14 @@ class HopperChunkKDAFunction(torch.autograd.Function):
             q, q_rstd = l2norm_fwd(q)
             k, k_rstd = l2norm_fwd(k)
 
-        # reshape to packed [T, H, K] for the C++ kernel
+        # reshape to packed layouts for the C++ kernel:
+        #   Q, K  -> [T, num_k_heads, head_dim]
+        #   V     -> [T, num_heads,   head_dim]
+        #   g     -> [T, num_heads,   head_dim]   (alpha, per state head)
+        #   beta  -> [T, num_heads]                (per state head)
         packed_seq = batch_size * seq_len
-        q = q.reshape(packed_seq, num_heads, head_dim).contiguous()
-        k = k.reshape(packed_seq, num_heads, head_dim).contiguous()
+        q = q.reshape(packed_seq, num_k_heads, head_dim).contiguous()
+        k = k.reshape(packed_seq, num_k_heads, head_dim).contiguous()
         v = v.reshape(packed_seq, num_heads, head_dim).contiguous()
         g = g.reshape(packed_seq, num_heads, head_dim).contiguous()
         beta = beta.reshape(packed_seq, num_heads).contiguous()
@@ -151,25 +163,36 @@ def cula_kda_prefill(
     r"""
     Hopper (SM90) fully-fused KDA forward prefill using CUTLASS TMA warp-specialized kernel.
 
+    Supports both plain multi-head attention (MHA) and KDA's "multi-value"
+    grouped variant, where Q and K share `num_k_heads` physical heads and V
+    (together with the recurrent state, `g`, `beta`, and output) has the
+    larger `num_heads`. `num_heads` must be a multiple of `num_k_heads`;
+    each group of `num_heads / num_k_heads` consecutive state heads shares
+    one physical Q/K head. `num_k_heads == num_heads` is MHA, which is the
+    default when Q/V have the same head count.
+
     Args:
         q (torch.Tensor):
-            queries of shape `[B, T, H, K]`.
+            queries of shape `[B, T, num_k_heads, head_dim]`.
         k (torch.Tensor):
-            keys of shape `[B, T, H, K]`.
+            keys of shape `[B, T, num_k_heads, head_dim]`.
         v (torch.Tensor):
-            values of shape `[B, T, H, V]`.
+            values of shape `[B, T, num_heads, head_dim]`.
         g (torch.Tensor):
-            (forget) gating tensor (in log space!) of shape `[B, T, H, K]`.
+            (forget) gating tensor (in log space!) of shape
+            `[B, T, num_heads, head_dim]` — per state head.
         beta (torch.Tensor):
-            betas of shape `[B, T, H]`.
+            betas of shape `[B, T, num_heads]` — per state head.
         scale (Optional[float]):
             Scale factor for the KDA attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
         initial_state (Optional[torch.Tensor]):
-            Initial state of shape `[N, H, K, V]` for `N` input sequences.
+            Initial state of shape `[N, num_heads, head_dim, head_dim]` for
+            `N` input sequences — one state matrix per state head.
             Default: `None`.
         output_final_state (Optional[bool]):
-            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+            Whether to output the final state of shape
+            `[N, num_heads, head_dim, head_dim]`. Default: `False`.
         use_qk_l2norm_in_kernel (bool):
             Whether to apply L2norm to the q,k tensor internally. Default: `False`.
         use_gate_in_kernel (bool):
@@ -217,12 +240,22 @@ def cula_kda_prefill(
             if not (-5 <= lower_bound < 0):
                 raise ValueError(f"`lower_bound` must be in the safe range [-5, 0), got {lower_bound}.")
 
-    assert q.shape == k.shape == g.shape, "q, k, g must have the same shape."
-    assert beta.shape == q.shape[:3], "beta must be of shape (batch size, seq len, num of head)."
-    assert v.shape == (*q.shape[:3], v.shape[-1]), "v must be of shape (batch size, seq len, num of head, head dim)."
+    # Shapes:
+    #   q, k: [B, T, num_k_heads, head_dim]  (Q and K share num_k_heads)
+    #   v:    [B, T, num_heads,   head_dim]  (num_heads is also state head count)
+    #   g:    [B, T, num_heads,   head_dim]  (per state/V head)
+    #   beta: [B, T, num_heads]              (per state/V head)
+    # num_k_heads == num_heads is plain MHA. num_k_heads < num_heads with
+    # num_heads % num_k_heads == 0 is the "multi-value" GQA flavor.
+    assert q.shape == k.shape, "q and k must have the same shape."
+    assert q.shape[:2] == v.shape[:2], "q and v must share (batch_size, seq_len)."
+    assert v.shape[:3] == g.shape[:3], "v and g must share (batch_size, seq_len, num_heads)."
+    assert beta.shape == v.shape[:3], "beta must be of shape (batch size, seq len, num_heads)."
     assert q.dtype == k.dtype == v.dtype == torch.bfloat16, "q, k, v must be in bfloat16."
     assert beta.dtype == torch.bfloat16 or beta.dtype == torch.float32, "beta must be in bfloat16 or float32."
     assert q.shape[-1] == k.shape[-1] == v.shape[-1] == 128, "Currently we only support head dim of 128 for KDA"
+    assert v.shape[-2] % q.shape[-2] == 0, \
+        f"num_heads (v.shape[-2]={v.shape[-2]}) must be divisible by num_k_heads (q.shape[-2]={q.shape[-2]})"
     if scale is None:
         scale = k.shape[-1] ** -0.5
     o, final_state = HopperChunkKDAFunction.apply(

--- a/cula/kda/hopper_fused_fwd.py
+++ b/cula/kda/hopper_fused_fwd.py
@@ -248,7 +248,9 @@ def cula_kda_prefill(
     # num_heads % num_k_heads == 0 is the "multi-value" GQA flavor.
     assert q.shape == k.shape, "q and k must have the same shape."
     assert q.shape[:2] == v.shape[:2], "q and v must share (batch_size, seq_len)."
-    assert v.shape[:3] == g.shape[:3], "v and g must share (batch_size, seq_len, num_heads)."
+    # g is per state/V head with shape [B, T, num_heads, head_dim] — same as v
+    # because KDA pins head_k_dim == head_v_dim.
+    assert v.shape == g.shape, "v and g must have the same shape."
     assert beta.shape == v.shape[:3], "beta must be of shape (batch size, seq len, num_heads)."
     assert q.dtype == k.dtype == v.dtype == torch.bfloat16, "q, k, v must be in bfloat16."
     assert beta.dtype == torch.bfloat16 or beta.dtype == torch.float32, "beta must be in bfloat16 or float32."

--- a/cula/kda/hopper_fused_fwd.py
+++ b/cula/kda/hopper_fused_fwd.py
@@ -56,8 +56,7 @@ class HopperChunkKDAFunction(torch.autograd.Function):
         assert q.shape[-1] == k.shape[-1] == v.shape[-1], "q, k, v must share head dim"
         num_heads = v.shape[-2]
         num_k_heads = q.shape[-2]
-        assert num_heads % num_k_heads == 0, \
-            f"num_heads ({num_heads}) must be a multiple of num_k_heads ({num_k_heads})"
+        assert num_heads % num_k_heads == 0, f"num_heads ({num_heads}) must be a multiple of num_k_heads ({num_k_heads})"
 
         batch_size, seq_len, _, head_dim = v.shape
 
@@ -254,8 +253,9 @@ def cula_kda_prefill(
     assert q.dtype == k.dtype == v.dtype == torch.bfloat16, "q, k, v must be in bfloat16."
     assert beta.dtype == torch.bfloat16 or beta.dtype == torch.float32, "beta must be in bfloat16 or float32."
     assert q.shape[-1] == k.shape[-1] == v.shape[-1] == 128, "Currently we only support head dim of 128 for KDA"
-    assert v.shape[-2] % q.shape[-2] == 0, \
+    assert v.shape[-2] % q.shape[-2] == 0, (
         f"num_heads (v.shape[-2]={v.shape[-2]}) must be divisible by num_k_heads (q.shape[-2]={q.shape[-2]})"
+    )
     if scale is None:
         scale = k.shape[-1] ** -0.5
     o, final_state = HopperChunkKDAFunction.apply(

--- a/tests/test_kda_fused_fwd.py
+++ b/tests/test_kda_fused_fwd.py
@@ -188,6 +188,7 @@ def test_safe_gate_chunk(
 # in both paths — they are already per-state-head.
 
 
+@pytest.mark.parametrize("beta_dtype", [torch.float32, torch.bfloat16], ids=["beta_fp32", "beta_bf16"])
 @pytest.mark.parametrize(
     ("B", "T", "num_heads", "num_k_heads", "D", "use_qk_l2norm_in_kernel", "dtype"),
     [
@@ -215,6 +216,7 @@ def test_multi_value_gqa(
     D: int,
     use_qk_l2norm_in_kernel: bool,
     dtype: torch.dtype,
+    beta_dtype: torch.dtype,
 ):
     """GQA output must match MHA output on repeat_interleave'd Q/K."""
     assert num_heads % num_k_heads == 0, "num_heads must be a multiple of num_k_heads"
@@ -229,7 +231,7 @@ def test_multi_value_gqa(
     v = torch.rand(B, T, num_heads, D, dtype=dtype)
     # g and beta are per state/V head in both paths
     g = F.logsigmoid(torch.randn(B, T, num_heads, D, dtype=torch.float)).clamp(-5, 0)
-    beta = torch.randn(B, T, num_heads, dtype=torch.float32).sigmoid().to(torch.float32)
+    beta = torch.randn(B, T, num_heads, dtype=torch.float32).sigmoid().to(beta_dtype)
     h0 = torch.randn(B, num_heads, D, D, dtype=torch.float32)
     h0_vk = h0.transpose(-1, -2).contiguous()
 

--- a/tests/test_kda_fused_fwd.py
+++ b/tests/test_kda_fused_fwd.py
@@ -173,6 +173,101 @@ def test_safe_gate_chunk(
     assert_close("ht", ref_ht_fla_trans, tri_ht, 0.005)
 
 
+# ─── Multi-Value GQA tests ─────────────────────────────────────────────
+#
+# KDA's "multi-value" flavor: Q and K share a single physical head count
+# (num_k_heads) while V (and state, alpha/g, beta, O) use the larger
+# num_heads. `num_heads / num_k_heads` consecutive state heads share one
+# physical Q/K head. This matches e.g. Qwen3.5-A3B Gated DeltaNet
+# (linear_num_key_heads=16, linear_num_value_heads=32).
+#
+# Equivalence check: running the GQA kernel on (Q=[T,num_k_heads,D],
+# K=[T,num_k_heads,D], V=[T,num_heads,D]) must produce the same output as
+# running the existing MHA kernel on Q and K expanded via repeat_interleave
+# to [T,num_heads,D]. The rest of the setup (g, beta, state) is identical
+# in both paths — they are already per-state-head.
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "num_heads", "num_k_heads", "D", "use_qk_l2norm_in_kernel", "dtype"),
+    [
+        pytest.param(
+            *test,
+            id="B{}-T{}-H{}-Hk{}-D{}-l2norm{}-{}".format(*test),
+        )
+        for test in [
+            # Qwen3.5-A3B DeltaNet shape
+            (1, 128, 32, 16, 128, False, torch.bfloat16),
+            (2, 256, 32, 16, 128, False, torch.bfloat16),
+            (2, 1024, 32, 16, 128, True, torch.bfloat16),
+            (1, 2048, 32, 16, 128, False, torch.bfloat16),
+            # Other plausible GQA ratios
+            (2, 512, 16, 8, 128, False, torch.bfloat16),
+            (2, 512, 32, 8, 128, False, torch.bfloat16),  # k_group_size=4
+        ]
+    ],
+)
+def test_multi_value_gqa(
+    B: int,
+    T: int,
+    num_heads: int,
+    num_k_heads: int,
+    D: int,
+    use_qk_l2norm_in_kernel: bool,
+    dtype: torch.dtype,
+):
+    """GQA output must match MHA output on repeat_interleave'd Q/K."""
+    assert num_heads % num_k_heads == 0, "num_heads must be a multiple of num_k_heads"
+    k_group_size = num_heads // num_k_heads
+
+    cula_kda_fused_fwd = get_kda_fused_fwd(device)
+
+    torch.manual_seed(42)
+    # GQA-shaped inputs
+    q_gqa = torch.rand(B, T, num_k_heads, D, dtype=dtype)
+    k_gqa = torch.rand(B, T, num_k_heads, D, dtype=dtype)
+    v = torch.rand(B, T, num_heads, D, dtype=dtype)
+    # g and beta are per state/V head in both paths
+    g = F.logsigmoid(torch.randn(B, T, num_heads, D, dtype=torch.float)).clamp(-5, 0)
+    beta = torch.randn(B, T, num_heads, dtype=torch.float32).sigmoid().to(torch.float32)
+    h0 = torch.randn(B, num_heads, D, D, dtype=torch.float32)
+    h0_vk = h0.transpose(-1, -2).contiguous()
+
+    q_gqa, k_gqa, v, g, beta, h0_vk = map(
+        lambda x: x.to(device).requires_grad_(False),
+        (q_gqa, k_gqa, v, g, beta, h0_vk),
+    )
+
+    # MHA reference: repeat Q and K heads to num_heads so they match V. The
+    # MHA kernel then runs the same math on a strictly-larger tensor and the
+    # result per state head should be bit-equivalent to the GQA path.
+    q_mha_ref = q_gqa.repeat_interleave(k_group_size, dim=2)
+    k_mha_ref = k_gqa.repeat_interleave(k_group_size, dim=2)
+
+    def call_fused(q, k):
+        q_in = F.normalize(q.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else q.clone()
+        k_in = F.normalize(k.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else k.clone()
+        return cula_kda_fused_fwd(
+            q=q_in,
+            k=k_in,
+            v=v.clone(),
+            g=g.clone(),
+            beta=beta.clone(),
+            initial_state=h0_vk.clone(),
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            use_gate_in_kernel=False,
+            safe_gate=True,
+            lower_bound=-5.0,
+        )
+
+    o_gqa, ht_gqa = call_fused(q_gqa, k_gqa)
+    o_mha, ht_mha = call_fused(q_mha_ref, k_mha_ref)
+
+    assert_close("o (gqa vs mha-repeat)", o_mha, o_gqa, 0.005)
+    assert_close("ht (gqa vs mha-repeat)", ht_mha, ht_gqa, 0.005)
+
+
 @pytest.mark.parametrize("beta_dtype", [torch.float32, torch.bfloat16], ids=["beta_fp32", "beta_bf16"])
 @pytest.mark.parametrize(
     ("H", "D", "mask_p", "cu_seqlens", "dtype", "safe_gate"),


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Add optional grouped-query support to the Hopper (SM90) fused KDA forward prefill kernel. Today the kernel assumes Q, K, V, O all have the same head count and `TORCH_CHECK`s it at the wrapper. Models like **Qwen3.5-A3B** (`linear_num_key_heads=16`, `linear_num_value_heads=32`) and **Qwen3.5-122B-A10B** (`linear_num_key_heads=16`, `linear_num_value_heads=64`) use a "multi-value" layout where Q/K physically share `num_k_heads` heads and `k_group_size = num_heads / num_k_heads` state heads bind to each physical Q/K head. To use the existing MHA-only kernel, callers have to `repeat_interleave` Q/K on the host to match V on every forward — this PR lets the kernel read the compressed Q/K directly.


changes:

- `VarlenProblemShape` gains a `num_k_heads` field (defaults to `0` = MHA).
- `WorkDesc` / `IndividualTileScheduler` carry `k_group_size`; `q_head_idx()` / `k_head_idx()` divide by it, `v_head_idx()` / `o_head_idx()` keep returning the state head. This leverages the already-split getters that were in `tile_scheduler.hpp` waiting to be used.
- `CollectiveLoadTma` in `load_tma.hpp`: Q and K branches now use `num_k_heads` as the TMA tensor's head extent; V, alpha, O, beta keep `num_heads`.
- `mainloop_kda_fwd.hpp::to_underlying_arguments`: `params_qk` (Q TMA) and `params_kv_k` (K TMA) are built with `L = num_k_heads`; `params_kv_v` (V TMA), `alpha`, `params_o`, and `beta_layout` keep `L = num_heads`.
- `prefill_kernel_kda_fwd_sm90.cuh` computes separate `tok_stride_qk = num_k_heads * head_size` and `tok_stride_v = num_heads * head_size` so the Q/K and V/O strides reflect their actual packed layouts.
- `csrc/api/kda_sm90.cu` drops the MHA `TORCH_CHECK`, derives `num_k_heads` from `q.size(1)`, keeps the Q/K head-count equality check, and requires `num_heads % num_k_heads == 0`.
- `cula/kda/hopper_fused_fwd.py` relaxes its shape asserts accordingly and its docstring documents the new layout.

## 🔍 Related Issues

None

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] \`pre-commit install\` + \`pre-commit run --all-files\` clean (clang-format + ruff-format applied in its own commit).

## 🧪 Tests

- [x] New: \`tests/test_kda_fused_fwd.py::test_multi_value_gqa\` — 6 parametrised cases including the Qwen3.5-A3B shape \`(H=32, Hk=16)\`, a 4:1 ratio \`(H=32, Hk=8)\`, and a smaller GQA \`(H=16, Hk=8)\`, both with and without \`use_qk_l2norm_in_kernel\`. Each case runs the kernel once in GQA mode on \`[B,T,num_k_heads,D]\` Q/K and \`[B,T,num_heads,D]\` V, runs it a second time with Q/K host-expanded to \`num_heads\`, and asserts the outputs match within 0.005.
- [x] All pre-existing MHA tests still pass:


**Reproduce** (correctness, SM90, any Hopper GPU):

```bash
# build sm90 only
CULA_DISABLE_SM100=1 CULA_DISABLE_SM103=1 pip install -e .

# new GQA cases + full existing MHA suite
pytest tests/test_kda_fused_fwd.py -x --tb=line
```

On H200 this prints \`40 passed\`.

## ⚡ Performance

New benchmark: `benchmarks/bench_kda_fused_fwd_gqa.py`. Three paths, all producing the same output:

1. **GQA** — cuLA native (this PR).
2. **MHA** — cuLA MHA with host-side `repeat_interleave` on Q/K (the pre-PR workaround).
3. **FLA** — upstream flash-linear-attention's `chunk_kda`, also fed host-expanded Q/K (it's MHA-only too).

**Reproduce** (benchmark):

```bash
python benchmarks/bench_kda_fused_fwd_gqa.py --mode both
```

**Headline numbers on H200 (sm90, bf16, safe_gate=True):**

Qwen3.5-35B-A3B  (H=32, Hk=16, **k_group_size=2**) — fixed-length:

| B | T | GQA (ms) | MHA (ms) | FLA (ms) | GQA↑MHA | GQA↑FLA |
|---|---|---|---|---|---|---|
| 1 | 512 | 0.116 | 0.142 | 0.224 | **1.22x** | **1.93x** |
| 1 | 4096 | 0.813 | 0.901 | 0.652 | **1.11x** | 0.80x |
| 1 | 16384 | 3.185 | 3.525 | 2.398 | **1.11x** | 0.75x |
| 2 | 4096 | 0.888 | 1.043 | 1.173 | **1.18x** | **1.32x** |
| 2 | 8192 | 1.716 | 2.049 | 2.273 | **1.19x** | **1.33x** |

Qwen3.5-122B-A10B  (H=64, Hk=16, **k_group_size=4**) — fixed-length:

| B | T | GQA (ms) | MHA (ms) | FLA (ms) | GQA↑MHA | GQA↑FLA |
|---|---|---|---|---|---|---|
| 1 | 512 | 0.135 | 0.163 | 0.227 | **1.21x** | **1.68x** |
| 1 | 4096 | 0.856 | 1.041 | 1.064 | **1.22x** | **1.24x** |
| 1 | 16384 | 3.533 | 4.350 | 4.053 | **1.23x** | **1.15x** |
| 2 | 4096 | 0.954 | 1.409 | 2.058 | **1.48x** | **2.16x** |
| 2 | 8192 | 1.904 | 2.869 | 4.057 | **1.51x** | **2.13x** |

Varlen (10/20 seqs, uniform/random/skewed, T=4096..16384):

| Config | GQA↑MHA range | GQA↑FLA range |
|---|---|---|
| Qwen3.5-35B-A3B | **1.17–1.30x** | **1.26–2.08x** |
| Qwen3.5-122B-A10B | **1.26–1.37x** | **1.42–2.08x** |


### Summary

- No regression for MHA callers.
- Consistent speedup vs the MHA + host-expand workaround: 1.10–1.30x on 35B, 1.11–1.51x on 122B. Savings come from both (a) skipping the host-side K/Q copy and (b) ~k_group_size× less K traffic through DRAM.
- Speedup scales with k_group_size. 122B (group=4) wins more than 35B (group=2) — the MHA workaround has to materialise 4× the K data on the host.

## Reviewer Notes

- Naming: I used \`num_k_heads\` (matching HF's \`linear_num_key_heads\`) rather than \`num_kv_heads\` on purpose — in this KDA flavour V does not share K's head count, so \`num_kv_heads\` would be misleading. Happy to rename if you have a preferred convention.
- SM100 side is untouched.