### PR TITLE
[KDA] Adapt recompute_wu and delta_h for backward

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ See [REPO_LAYOUT.md](REPO_LAYOUT.md) for the full directory structure and a summ
 * [x] Modular KDA Forward (SM10X, compatible with [Kimi CP](https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/cp/README.md))
   * [x] kda chunk intra
   * [x] chunk gated delta h
-  * [ ] recompute wu
+  * [x] recompute wu
   * [x] chunk fwd o
 
 * [ ] Modular GDN Forward / Backward Kernels (compatible with [Kimi CP](https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/cp/README.md))

--- a/benchmarks/bench_kda_fwd_bwd_e2e.py
+++ b/benchmarks/bench_kda_fwd_bwd_e2e.py
@@ -53,6 +53,7 @@ from benchmarks.utils import (
     exclusive_cumsum,
     prepare_safe_gate_inputs,
     set_seed,
+    generate_random_seq_lens,
 )
 from cula.kda import chunk_kda as cula_chunk_kda
 
@@ -179,6 +180,41 @@ def run_kda_e2e_with_grads(q, k, v, g, beta, scale, A_log, dt_bias, init_state, 
         dbeta=b_c.grad,
         dh0=h_c.grad,
     )
+
+
+# ============================================================
+# Determinism check
+# ============================================================
+def check_determinism(num_seqs=5, T=512, iters=20):
+    """Verify that cuLA chunk_kda produces identical outputs across repeated runs."""
+    device = torch.device("cuda")
+    set_seed(SEED)
+
+    seq_lens = generate_random_seq_lens(num_seqs, T, 63, seed=SEED)
+    cu_seqlens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int32, device=device)
+
+    inputs = prepare_safe_gate_inputs(1, T, H, D, device, cu_seqlens=cu_seqlens, has_init_state=True)
+    q, k, v, g, beta = inputs["q"], inputs["k"], inputs["v"], inputs["g"], inputs["beta"]
+    A_log, dt_bias = inputs["A_log"], inputs["dt_bias"]
+    scale, init_state, lower_bound = inputs["scale"], inputs["init_state"], inputs["lower_bound"]
+
+    set_seed(SEED + 1)
+    do = torch.randn_like(v)
+    dht = torch.randn_like(init_state)
+
+    common = dict(
+        q=q, k=k, v=v, g=g, beta=beta,
+        scale=scale, A_log=A_log, dt_bias=dt_bias,
+        init_state=init_state, cu_seqlens=cu_seqlens,
+        lower_bound=lower_bound, do=do, dht=dht,
+    )
+
+    ref = run_kda_e2e_with_grads(**common, fn=cula_chunk_kda)
+    for i in range(iters):
+        out = run_kda_e2e_with_grads(**common, fn=cula_chunk_kda)
+        for name in ("o", "ht", "dq", "dk", "dv", "dg", "dbeta", "dh0"):
+            assert torch.equal(out[name], ref[name]), f"[determinism] cuLA {name} mismatch at iter {i}"
+    return True
 
 
 # ============================================================
@@ -514,6 +550,11 @@ def main():
         action="store_true",
         help="Disable recompute in both FLA and cuLA (pre-compute QG)",
     )
+    parser.add_argument(
+        "--check_determinism",
+        action="store_true",
+        help="Run determinism check: verify cuLA produces identical outputs across repeated runs",
+    )
     args = parser.parse_args()
 
     global NCU_MODE, SANITIZER_MODE, DISABLE_RECOMPUTE, PHASE
@@ -527,6 +568,15 @@ def main():
         DISABLE_RECOMPUTE = True
         print("[Disable recompute] pre-compute QG in forward")
     PHASE = args.phase
+
+    if args.check_determinism:
+        det_configs = [(5, 1024), (10, 4096), (10, 8192), (10, 16384)]
+        print("\n[Determinism Check] cuLA chunk_kda E2E ...")
+        for num_seqs, T in det_configs:
+            result = check_determinism(num_seqs=num_seqs, T=T, iters=20)
+            print(f"  num_seqs={num_seqs}  T={T:5d}  iters=20  {'PASS' if result else 'FAIL'}")
+        print("[Determinism Check] All passed.\n")
+        return
 
     fixed_configs = [
         # (B, T)

--- a/benchmarks/bench_kda_fwd_bwd_e2e.py
+++ b/benchmarks/bench_kda_fwd_bwd_e2e.py
@@ -51,9 +51,9 @@ from benchmarks.utils import (
     SEED,
     build_varlen_configs,
     exclusive_cumsum,
+    generate_random_seq_lens,
     prepare_safe_gate_inputs,
     set_seed,
-    generate_random_seq_lens,
 )
 from cula.kda import chunk_kda as cula_chunk_kda
 
@@ -203,10 +203,19 @@ def check_determinism(num_seqs=5, T=512, iters=20):
     dht = torch.randn_like(init_state)
 
     common = dict(
-        q=q, k=k, v=v, g=g, beta=beta,
-        scale=scale, A_log=A_log, dt_bias=dt_bias,
-        init_state=init_state, cu_seqlens=cu_seqlens,
-        lower_bound=lower_bound, do=do, dht=dht,
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        init_state=init_state,
+        cu_seqlens=cu_seqlens,
+        lower_bound=lower_bound,
+        do=do,
+        dht=dht,
     )
 
     ref = run_kda_e2e_with_grads(**common, fn=cula_chunk_kda)

--- a/benchmarks/bench_kda_fwd_bwd_e2e.py
+++ b/benchmarks/bench_kda_fwd_bwd_e2e.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+bench_kda_fwd_bwd_e2e.py — Benchmark: cuLA CuTe DSL vs FLA Triton baseline
+                            for chunk_kda forward + backward (end-to-end)
+
+Compares:
+  - Accuracy: err_ratio, relative max diff between cuLA and FLA outputs & gradients
+  - Performance: kernel execution time (ms) with CUDA events
+
+Modes:
+  - Fixed-length: B=1, B=2 with various T
+  - Varlen: ~20 seqs with 2-3x length variation
+
+Phases:
+  - forward: forward pass only
+  - e2e: forward + backward (end-to-end)
+
+Usage:
+  python bench_kda_fwd_bwd_e2e.py [--mode fixed|varlen|both] [--phase forward|e2e] [--ncu]
+
+With --ncu, warmup=1 and iters=1 for ncu profiling:
+  ncu --set full -o report python bench_kda_fwd_bwd_e2e.py --mode varlen --ncu
+"""
+
+import argparse
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+os.environ.setdefault("FLA_USE_FAST_OPS", os.getenv("CULA_USE_FAST_MATH", "1"))
+
+import torch
+from fla.ops.kda import chunk_kda as fla_chunk_kda
+
+from benchmarks.utils import (
+    SEED,
+    build_varlen_configs,
+    exclusive_cumsum,
+    prepare_safe_gate_inputs,
+    set_seed,
+)
+from cula.kda import chunk_kda as cula_chunk_kda
+
+# ============================================================
+# Constants
+# ============================================================
+H, D = 64, 128
+WARMUP = 25
+N_ITERS = 100
+NCU_MODE = False
+SANITIZER_MODE = False
+DISABLE_RECOMPUTE = False
+PHASE = "e2e"  # "forward" or "e2e"
+
+
+# ============================================================
+# Helpers
+# ============================================================
+def time_kernel(fn, warmup=None, n_iters=None):
+    if warmup is None:
+        warmup = 1 if (NCU_MODE or SANITIZER_MODE) else WARMUP
+    if n_iters is None:
+        n_iters = 1 if (NCU_MODE or SANITIZER_MODE) else N_ITERS
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start_evt = torch.cuda.Event(enable_timing=True)
+    end_evt = torch.cuda.Event(enable_timing=True)
+    start_evt.record()
+    for _ in range(n_iters):
+        fn()
+    end_evt.record()
+    torch.cuda.synchronize()
+    return start_evt.elapsed_time(end_evt) / n_iters
+
+
+def accuracy_stats(ref, out):
+    """Compute err_ratio, relative max diff, and mean absolute difference."""
+    ref_f = ref.float()
+    out_f = out.float()
+    diff = (ref_f - out_f).abs()
+    err = diff.flatten().pow(2).mean().sqrt().item()
+    base = ref_f.flatten().pow(2).mean().sqrt().item()
+    err_ratio = err / (base + 1e-8)
+    max_diff = diff.max().item()
+    denom = ref_f.abs().max().item()
+    rel_max = max_diff / denom if denom > 0 else 0.0
+    mean_diff = diff.mean().item()
+    return err_ratio, rel_max, mean_diff
+
+
+def run_kda_e2e(q, k, v, g, beta, scale, A_log, dt_bias, init_state, cu_seqlens, lower_bound, do, dht, fn):
+    """Run KDA forward (+ backward if PHASE == 'e2e').
+
+    Clears gradients, runs forward, optionally backward.
+    """
+    q.grad = None
+    k.grad = None
+    v.grad = None
+    g.grad = None
+    beta.grad = None
+    init_state.grad = None
+
+    out, ht = fn(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        initial_state=init_state,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens,
+        use_gate_in_kernel=True,
+        safe_gate=True,
+        lower_bound=lower_bound,
+        disable_recompute=DISABLE_RECOMPUTE,
+    )
+    if PHASE == "e2e":
+        out.backward(do)
+    return out, ht
+
+
+def run_kda_e2e_with_grads(q, k, v, g, beta, scale, A_log, dt_bias, init_state, cu_seqlens, lower_bound, do, dht, fn):
+    """Run KDA forward + backward and return outputs + gradients for accuracy check."""
+    q_c = q.detach().clone().requires_grad_(True)
+    k_c = k.detach().clone().requires_grad_(True)
+    v_c = v.detach().clone().requires_grad_(True)
+    g_c = g.detach().clone().requires_grad_(True)
+    b_c = beta.detach().clone().requires_grad_(True)
+    h_c = init_state.detach().clone().requires_grad_(True)
+
+    out, ht = fn(
+        q=q_c,
+        k=k_c,
+        v=v_c,
+        g=g_c,
+        beta=b_c,
+        scale=scale,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        initial_state=h_c,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens,
+        use_gate_in_kernel=True,
+        safe_gate=True,
+        lower_bound=lower_bound,
+        disable_recompute=DISABLE_RECOMPUTE,
+    )
+    loss = (out * do).sum() + (ht * dht).sum()
+    loss.backward()
+
+    return dict(
+        o=out,
+        ht=ht,
+        dq=q_c.grad,
+        dk=k_c.grad,
+        dv=v_c.grad,
+        dg=g_c.grad,
+        dbeta=b_c.grad,
+        dh0=h_c.grad,
+    )
+
+
+# ============================================================
+# Fixed-length benchmark
+# ============================================================
+def bench_fixed(configs):
+    print("\n" + "=" * 120)
+    print(f" Fixed-Length E2E Benchmark: cuLA vs FLA  phase={PHASE}  disable_recompute={DISABLE_RECOMPUTE}")
+    print("=" * 120)
+    results = []
+
+    for B, T in configs:
+        set_seed(SEED)
+        device = torch.device("cuda")
+        torch.cuda.empty_cache()
+
+        seq_lens = [T] * B
+        cu_seqlens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int32, device=device)
+
+        inputs = prepare_safe_gate_inputs(B, T, H, D, device, cu_seqlens=cu_seqlens, has_init_state=True)
+        q, k, v, g, beta = inputs["q"], inputs["k"], inputs["v"], inputs["g"], inputs["beta"]
+        A_log, dt_bias = inputs["A_log"], inputs["dt_bias"]
+        scale, init_state, lower_bound = inputs["scale"], inputs["init_state"], inputs["lower_bound"]
+
+        # Generate do, dht for backward
+        set_seed(SEED + 1)
+        do = torch.randn_like(v)
+        dht = torch.randn_like(init_state)
+
+        common = dict(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            init_state=init_state,
+            cu_seqlens=cu_seqlens,
+            lower_bound=lower_bound,
+            do=do,
+            dht=dht,
+        )
+
+        # Accuracy: compare outputs and gradients
+        acc = {}
+        if PHASE == "e2e":
+            fla_results = run_kda_e2e_with_grads(**common, fn=fla_chunk_kda)
+            cula_results = run_kda_e2e_with_grads(**common, fn=cula_chunk_kda)
+            torch.cuda.synchronize()
+
+            for name in ("o", "ht", "dq", "dk", "dv", "dg", "dbeta", "dh0"):
+                err_ratio, rel_max, mean_diff = accuracy_stats(fla_results[name], cula_results[name])
+                acc[name] = {"err_ratio": err_ratio, "rel_max": rel_max, "mean_diff": mean_diff}
+        else:
+            # forward-only accuracy
+            o_fla, ht_fla = run_kda_e2e(**common, fn=fla_chunk_kda)
+            o_cula, ht_cula = run_kda_e2e(**common, fn=cula_chunk_kda)
+            torch.cuda.synchronize()
+            for name, ref, out in [("o", o_fla, o_cula), ("ht", ht_fla, ht_cula)]:
+                err_ratio, rel_max, mean_diff = accuracy_stats(ref, out)
+                acc[name] = {"err_ratio": err_ratio, "rel_max": rel_max, "mean_diff": mean_diff}
+
+        # For timing, use leaf tensors with requires_grad
+        q_t = q.detach().clone().requires_grad_(True)
+        k_t = k.detach().clone().requires_grad_(True)
+        v_t = v.detach().clone().requires_grad_(True)
+        g_t = g.detach().clone().requires_grad_(True)
+        beta_t = beta.detach().clone().requires_grad_(True)
+        h0_t = init_state.detach().clone().requires_grad_(True)
+
+        timing_common = dict(
+            q=q_t,
+            k=k_t,
+            v=v_t,
+            g=g_t,
+            beta=beta_t,
+            scale=scale,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            init_state=h0_t,
+            cu_seqlens=cu_seqlens,
+            lower_bound=lower_bound,
+            do=do,
+            dht=dht,
+        )
+
+        def fn_fla(**kw):
+            return lambda: run_kda_e2e(**kw, fn=fla_chunk_kda)
+
+        def fn_cula(**kw):
+            return lambda: run_kda_e2e(**kw, fn=cula_chunk_kda)
+
+        ms_fla = time_kernel(fn_fla(**timing_common))
+        ms_cula = time_kernel(fn_cula(**timing_common))
+        speedup = ms_fla / ms_cula if ms_cula > 0 else float("inf")
+
+        r = {
+            "B": B,
+            "T": T,
+            "accuracy": acc,
+            "ms_fla": ms_fla,
+            "ms_cula": ms_cula,
+            "speedup": speedup,
+        }
+        results.append(r)
+
+        del q, k, v, g, beta, A_log, dt_bias, inputs, do, dht
+        torch.cuda.empty_cache()
+
+    return results
+
+
+# ============================================================
+# Varlen benchmark
+# ============================================================
+def bench_varlen(configs):
+    print("\n" + "=" * 120)
+    print(f" Varlen E2E Benchmark: cuLA vs FLA  phase={PHASE}  disable_recompute={DISABLE_RECOMPUTE}")
+    print("=" * 120)
+    results = []
+
+    for seq_lens, total_len, dist in configs:
+        set_seed(SEED)
+        device = torch.device("cuda")
+        torch.cuda.empty_cache()
+
+        T = total_len
+        cu_seqlens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int32, device=device)
+
+        inputs = prepare_safe_gate_inputs(1, T, H, D, device, cu_seqlens=cu_seqlens, has_init_state=True)
+        q, k, v, g, beta = inputs["q"], inputs["k"], inputs["v"], inputs["g"], inputs["beta"]
+        A_log, dt_bias = inputs["A_log"], inputs["dt_bias"]
+        scale, init_state, lower_bound = inputs["scale"], inputs["init_state"], inputs["lower_bound"]
+
+        # Generate do, dht for backward
+        set_seed(SEED + 1)
+        do = torch.randn_like(v)
+        dht = torch.randn_like(init_state)
+
+        common = dict(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            init_state=init_state,
+            cu_seqlens=cu_seqlens,
+            lower_bound=lower_bound,
+            do=do,
+            dht=dht,
+        )
+
+        # Accuracy: compare outputs and gradients
+        acc = {}
+        if PHASE == "e2e":
+            fla_results = run_kda_e2e_with_grads(**common, fn=fla_chunk_kda)
+            cula_results = run_kda_e2e_with_grads(**common, fn=cula_chunk_kda)
+            torch.cuda.synchronize()
+
+            for name in ("o", "ht", "dq", "dk", "dv", "dg", "dbeta", "dh0"):
+                err_ratio, rel_max, mean_diff = accuracy_stats(fla_results[name], cula_results[name])
+                acc[name] = {"err_ratio": err_ratio, "rel_max": rel_max, "mean_diff": mean_diff}
+        else:
+            o_fla, ht_fla = run_kda_e2e(**common, fn=fla_chunk_kda)
+            o_cula, ht_cula = run_kda_e2e(**common, fn=cula_chunk_kda)
+            torch.cuda.synchronize()
+            for name, ref, out in [("o", o_fla, o_cula), ("ht", ht_fla, ht_cula)]:
+                err_ratio, rel_max, mean_diff = accuracy_stats(ref, out)
+                acc[name] = {"err_ratio": err_ratio, "rel_max": rel_max, "mean_diff": mean_diff}
+
+        # For timing, use leaf tensors with requires_grad
+        q_t = q.detach().clone().requires_grad_(True)
+        k_t = k.detach().clone().requires_grad_(True)
+        v_t = v.detach().clone().requires_grad_(True)
+        g_t = g.detach().clone().requires_grad_(True)
+        beta_t = beta.detach().clone().requires_grad_(True)
+        h0_t = init_state.detach().clone().requires_grad_(True)
+
+        timing_common = dict(
+            q=q_t,
+            k=k_t,
+            v=v_t,
+            g=g_t,
+            beta=beta_t,
+            scale=scale,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            init_state=h0_t,
+            cu_seqlens=cu_seqlens,
+            lower_bound=lower_bound,
+            do=do,
+            dht=dht,
+        )
+
+        def fn_fla(**kw):
+            return lambda: run_kda_e2e(**kw, fn=fla_chunk_kda)
+
+        def fn_cula(**kw):
+            return lambda: run_kda_e2e(**kw, fn=cula_chunk_kda)
+
+        ms_fla = time_kernel(fn_fla(**timing_common))
+        ms_cula = time_kernel(fn_cula(**timing_common))
+        speedup = ms_fla / ms_cula if ms_cula > 0 else float("inf")
+
+        n_seqs = len(seq_lens)
+        min_l, max_l = min(seq_lens), max(seq_lens)
+        avg_l = T // n_seqs
+        tag = f"{dist:>7s} {n_seqs:>2d}seqs T={T} [{min_l}..{max_l}] avg={avg_l}"
+
+        r = {
+            "tag": tag,
+            "dist": dist,
+            "T_total": T,
+            "n_seqs": n_seqs,
+            "accuracy": acc,
+            "ms_fla": ms_fla,
+            "ms_cula": ms_cula,
+            "speedup": speedup,
+        }
+        results.append(r)
+
+        del q, k, v, g, beta, A_log, dt_bias, inputs, do, dht
+        torch.cuda.empty_cache()
+
+    return results
+
+
+# ============================================================
+# Report
+# ============================================================
+def print_report(fixed_results, varlen_results):
+    sep = "=" * 130
+    print(f"\n\n{sep}")
+    print("                       BENCHMARK REPORT: chunk_kda forward+backward (E2E)")
+    print("                       cuLA CuTe DSL vs FLA Triton")
+    print(
+        f"                       H={H}  D={D}  dtype=bf16  safe_gate=True  phase={PHASE}  disable_recompute={DISABLE_RECOMPUTE}"
+    )
+    wu = 1 if (NCU_MODE or SANITIZER_MODE) else WARMUP
+    ni = 1 if (NCU_MODE or SANITIZER_MODE) else N_ITERS
+    mode_tag = "  [NCU mode]" if NCU_MODE else ("  [Sanitizer mode]" if SANITIZER_MODE else "")
+    print(f"                       Warmup={wu}  Iters={ni}{mode_tag}")
+    print(sep)
+
+    # Determine which accuracy keys to show
+    if PHASE == "e2e":
+        acc_keys = ["o", "ht", "dq", "dk", "dv", "dg", "dbeta", "dh0"]
+    else:
+        acc_keys = ["o", "ht"]
+
+    acc_header = "  ".join(f"{k:>10s}" for k in acc_keys)
+
+    if fixed_results:
+        print("\n  [Fixed-Length]")
+        print(f"  {'─' * 125}")
+
+        # Header
+        print(f"  {'B':>3s}  {'T':>5s}  │  {'FLA(ms)':>9s}  {'cuLA(ms)':>11s}  {'Speedup':>8s}  │  {'':>10s}{acc_header}")
+        print(f"  {'─' * 125}")
+
+        for r in fixed_results:
+            rel_max_vals = "  ".join(f"{r['accuracy'].get(k, {}).get('rel_max', 0.0):10.6f}" for k in acc_keys)
+            err_ratio_vals = "  ".join(f"{r['accuracy'].get(k, {}).get('err_ratio', 0.0):10.6f}" for k in acc_keys)
+            # Line 1: timing + rel_max
+            print(
+                f"  {r['B']:3d}  {r['T']:5d}  │  "
+                f"{r['ms_fla']:9.4f}  {r['ms_cula']:11.4f}  {r['speedup']:7.2f}x  │  "
+                f"{'rel_max:':>10s}{rel_max_vals}"
+            )
+            # Line 2: err_ratio (no timing columns)
+            print(f"  {'':3s}  {'':5s}  │  {'':9s}  {'':11s}  {'':8s}  │  {'err_ratio:':>10s}{err_ratio_vals}")
+        print(f"  {'─' * 125}")
+
+    if varlen_results:
+        print("\n  [Varlen]")
+        print(f"  {'─' * 140}")
+
+        print(f"  {'Config':>45s}  │  {'FLA(ms)':>9s}  {'cuLA(ms)':>11s}  {'Speedup':>8s}  │  {'':>10s}{acc_header}")
+        print(f"  {'─' * 140}")
+
+        for r in varlen_results:
+            rel_max_vals = "  ".join(f"{r['accuracy'].get(k, {}).get('rel_max', 0.0):10.6f}" for k in acc_keys)
+            err_ratio_vals = "  ".join(f"{r['accuracy'].get(k, {}).get('err_ratio', 0.0):10.6f}" for k in acc_keys)
+            # Line 1: timing + rel_max
+            print(
+                f"  {r['tag']:>45s}  │  "
+                f"{r['ms_fla']:9.4f}  {r['ms_cula']:11.4f}  {r['speedup']:7.2f}x  │  "
+                f"{'rel_max:':>10s}{rel_max_vals}"
+            )
+            # Line 2: err_ratio (no config/timing columns)
+            print(f"  {'':>45s}  │  {'':9s}  {'':11s}  {'':8s}  │  {'err_ratio:':>10s}{err_ratio_vals}")
+        print(f"  {'─' * 140}")
+
+    print(f"\n{sep}\n")
+
+
+# ============================================================
+# Main
+# ============================================================
+def main():
+    parser = argparse.ArgumentParser(description="bench_kda_fwd_bwd_e2e: cuLA vs FLA (forward + backward)")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="both",
+        choices=["fixed", "varlen", "both"],
+        help="Which benchmark mode to run (default: both)",
+    )
+    parser.add_argument(
+        "--phase",
+        type=str,
+        default="e2e",
+        choices=["forward", "e2e"],
+        help="Benchmark phase: forward only or end-to-end (default: e2e)",
+    )
+    parser.add_argument(
+        "--ncu",
+        action="store_true",
+        help="NCU profiling mode: warmup=1, iters=1",
+    )
+    parser.add_argument(
+        "--sanitizer",
+        action="store_true",
+        help="Sanitizer mode: warmup=1, iters=1 (avoid Triton memory leak under compute-sanitizer)",
+    )
+    parser.add_argument(
+        "--disable_recompute",
+        action="store_true",
+        help="Disable recompute in both FLA and cuLA (pre-compute QG)",
+    )
+    args = parser.parse_args()
+
+    global NCU_MODE, SANITIZER_MODE, DISABLE_RECOMPUTE, PHASE
+    if args.ncu:
+        NCU_MODE = True
+        print("[NCU mode] warmup=1, iters=1")
+    if args.sanitizer:
+        SANITIZER_MODE = True
+        print("[Sanitizer mode] warmup=1, iters=1")
+    if args.disable_recompute:
+        DISABLE_RECOMPUTE = True
+        print("[Disable recompute] pre-compute QG in forward")
+    PHASE = args.phase
+
+    fixed_configs = [
+        # (B, T)
+        (1, 512),
+        (1, 1024),
+        (1, 4096),
+        (1, 8192),
+        (1, 16384),
+        (2, 512),
+        (2, 1024),
+        (2, 4096),
+        (2, 8192),
+        (2, 16384),
+    ]
+
+    varlen_configs = build_varlen_configs(
+        num_seqs_list=(10, 20),
+        total_lens=(4096, 8192, 16384),
+        dists=("uniform", "random", "skewed"),
+    )
+
+    fixed_res, varlen_res = [], []
+
+    if args.mode in ("fixed", "both"):
+        fixed_res = bench_fixed(fixed_configs)
+
+    if args.mode in ("varlen", "both"):
+        varlen_res = bench_varlen(varlen_configs)
+
+    print_report(fixed_res, varlen_res)
+    return fixed_res, varlen_res
+
+
+if __name__ == "__main__":
+    main()

--- a/cula/kda/chunk.py
+++ b/cula/kda/chunk.py
@@ -18,10 +18,10 @@
 import torch
 from fla.modules.l2norm import l2norm_bwd, l2norm_fwd
 from fla.ops.cp import FLACPContext
-from fla.ops.kda.chunk_bwd import chunk_kda_bwd
 from fla.ops.utils.index import prepare_chunk_indices
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
 
+from cula.kda.chunk_bwd import chunk_kda_bwd
 from cula.kda.chunk_fwd import chunk_kda_fwd
 
 

--- a/cula/kda/chunk_bwd.py
+++ b/cula/kda/chunk_bwd.py
@@ -1,0 +1,611 @@
+# Copyright 2025-2026 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import importlib
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.common.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
+from fla.ops.cp import FLACPContext
+from fla.ops.cp.chunk_delta_h import (
+    chunk_gated_delta_rule_bwd_dhu_pre_process,
+    expand_h0,
+)
+from fla.ops.kda.gate import kda_gate_bwd, kda_gate_chunk_cumsum
+from fla.ops.utils import chunk_local_cumsum, prepare_chunk_indices
+from fla.ops.utils.constant import RCP_LN2
+from fla.ops.utils.op import exp2
+from fla.utils import (
+    IS_NVIDIA_HOPPER,
+    autotune_cache_kwargs,
+    check_shared_mem,
+)
+
+import cula.cudac as cula_cuda
+from cula.kda.chunk_intra import chunk_kda_bwd_intra
+from cula.utils import prepare_uniform_cu_seqlens
+
+_delta_h_mod = importlib.import_module("cula.ops.chunk_delta_h")
+chunk_gated_delta_rule_fwd_h = _delta_h_mod.chunk_gated_delta_rule_fwd_h
+
+BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
+BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
+NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in NUM_WARPS
+        for num_stages in [2, 3, 4]
+    ],
+    key=['H', 'K', 'V', 'BT', 'BK', 'BV'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_kda_bwd_kernel_dAv(
+    q,
+    k,
+    v,
+    A,
+    do,
+    dv,
+    dA,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    # offset calculation
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+    do += (bos * H + i_h) * V
+    dv += (bos * H + i_h) * V
+    dA += (bos * H + i_h) * BT
+
+    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
+    b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
+
+    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(v, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
+        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        # [BV, BT]
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        # [BT, BV]
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+        # [BT, BT]
+        b_dA += tl.dot(b_do, b_v)
+        # [BT, BV]
+        b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+    p_dA = tl.make_block_ptr(dA, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    b_dA = tl.where(o_t[:, None] >= o_t, b_dA * scale, 0.)
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in BK_LIST
+        for BV in BV_LIST
+        for num_warps in NUM_WARPS
+        for num_stages in [2, 3, 4]
+    ],
+    key=['BT', 'TRANSPOSE_STATE'],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=['T'])
+def chunk_kda_bwd_kernel_wy_dqkg_fused(
+    q,
+    k,
+    v,
+    v_new,
+    g,
+    beta,
+    A,
+    h,
+    do,
+    dh,
+    dq,
+    dk,
+    dv,
+    dv2,
+    dg,
+    db,
+    dA,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    TRANSPOSE_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_tg = i_t.to(tl.int64)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = (eos - bos).to(tl.int32)
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = (i_b * NT + i_t).to(tl.int64)
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_last = (o_t == min(T, i_t * BT + BT) - 1)
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+    v_new += (bos * H + i_h) * V
+    g += (bos * H + i_h) * K
+    beta += bos * H + i_h
+    A += (bos * H + i_h) * BT
+    h += (i_tg * H + i_h) * K*V
+    do += (bos * H + i_h) * V
+    dh += (i_tg * H + i_h) * K*V
+    dq += (bos * H + i_h) * K
+    dk += (bos * H + i_h) * K
+    dv += (bos * H + i_h) * V
+    dv2 += (bos * H + i_h) * V
+    dg += (bos * H + i_h) * K
+    db += bos * H + i_h
+    dA += (bos * H + i_h) * BT
+
+    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    b_beta = tl.load(p_beta, boundary_check=(0,))
+
+    p_A = tl.make_block_ptr(A, (BT, T), (1, H * BT), (0, i_t * BT), (BT, BT), (0, 1))
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+
+    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+    b_db = tl.zeros([BT], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+
+        p_gn = g + (min(T, i_t * BT + BT) - 1).to(tl.int64) * H*K + o_k
+        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
+
+        b_dq = tl.zeros([BT, BK], dtype=tl.float32)
+        b_dk = tl.zeros([BT, BK], dtype=tl.float32)
+        b_dw = tl.zeros([BT, BK], dtype=tl.float32)
+        b_dgk = tl.zeros([BK], dtype=tl.float32)
+
+        for i_v in range(tl.cdiv(V, BV)):
+            p_v_new = tl.make_block_ptr(v_new, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            if TRANSPOSE_STATE:
+                p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+                p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
+            else:
+                p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+                p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
+            p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            # [BT, BV]
+            b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
+            b_do = tl.load(p_do, boundary_check=(0, 1))
+            # [BV, BK]
+            b_h = tl.load(p_h, boundary_check=(0, 1))
+            b_dh = tl.load(p_dh, boundary_check=(0, 1))
+            # [BT, BV]
+            b_dv = tl.load(p_dv, boundary_check=(0, 1))
+
+            b_dgk += tl.sum(b_h * b_dh, axis=0)
+            b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
+            b_dk += tl.dot(b_v_new, b_dh.to(b_v_new.dtype))
+            b_dw += tl.dot(b_dv.to(b_v_new.dtype), b_h.to(b_v_new.dtype))
+            tl.debug_barrier()  # DO NOT REMOVE THIS LINE!
+            if i_k == 0:
+                p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_dv2 = tl.make_block_ptr(dv2, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+
+                b_v = tl.load(p_v, boundary_check=(0, 1))
+
+                b_dA += tl.dot(b_dv, tl.trans(b_v))
+
+                b_dvb = tl.dot(b_A, b_dv)
+                b_dv2 = b_dvb * b_beta[:, None]
+                b_db += tl.sum(b_dvb * b_v, 1)
+
+                tl.store(p_dv2, b_dv2.to(p_dv2.dtype.element_ty), boundary_check=(0, 1))
+
+        b_gk_exp = exp2(b_g)
+        b_gb = b_gk_exp * b_beta[:, None]
+        b_dgk *= exp2(b_gn)
+        b_dq = b_dq * b_gk_exp * scale
+        b_dk = b_dk * tl.where(m_t[:, None], exp2(b_gn[None, :] - b_g), 0)
+
+        b_kg = b_k * b_gk_exp
+
+        b_dw = -b_dw.to(b_A.dtype)
+        b_dA += tl.dot(b_dw, tl.trans(b_kg.to(b_A.dtype)))
+
+        b_dkgb = tl.dot(b_A, b_dw)
+        b_db += tl.sum(b_dkgb * b_kg, 1)
+
+        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_kdk = b_k * b_dk
+        b_dgk += tl.sum(b_kdk, axis=0)
+        b_dg = b_q * b_dq - b_kdk + m_last[:, None] * b_dgk + b_kg * b_dkgb * b_beta[:, None]
+        b_dk = b_dk + b_dkgb * b_gb
+
+        p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+
+    m_A = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
+    b_dA = tl.where(m_A, b_dA * b_beta[None, :], 0)
+    b_dA = tl.dot(b_dA.to(b_A.dtype), b_A)
+    b_dA = tl.dot(b_A, b_dA.to(b_A.dtype))
+    b_dA = tl.where(m_A, -b_dA, 0)
+
+    p_dA = tl.make_block_ptr(dA, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    p_db = tl.make_block_ptr(db, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+
+
+def chunk_kda_bwd_dAv(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    A: torch.Tensor | None = None,
+    scale: float = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, do.shape[-1]
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    # H100 can have larger block size
+    if check_shared_mem('hopper', k.device.index):
+        CONST_TILING = 128
+    elif check_shared_mem:
+        CONST_TILING = 64
+    else:
+        CONST_TILING = 32
+    BK = min(max(triton.next_power_of_2(K), 16), CONST_TILING)
+    BV = min(max(triton.next_power_of_2(V), 16), CONST_TILING)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    dA = v.new_empty(B, T, H, BT, dtype=torch.float)
+    dv = torch.empty_like(do)
+    grid = (NT, B * H)
+    chunk_kda_bwd_kernel_dAv[grid](
+        q=q,
+        k=k,
+        v=v,
+        A=A,
+        do=do,
+        dv=dv,
+        dA=dA,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+    )
+    return dA, dv
+
+
+def chunk_kda_bwd_wy_dqkg_fused(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    v_new: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    h: torch.Tensor,
+    do: torch.Tensor,
+    dh: torch.Tensor,
+    dv: torch.Tensor,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+    transpose_state_layout: bool = False,
+):
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    dq = torch.empty_like(q, dtype=torch.float)
+    dk = torch.empty_like(k, dtype=torch.float)
+    dv2 = torch.empty_like(v)
+    dg = torch.empty_like(g, dtype=torch.float)
+    db = torch.empty_like(beta, dtype=torch.float)
+    dA = torch.empty_like(A, dtype=torch.float)
+
+    grid = (NT, B * H)
+    chunk_kda_bwd_kernel_wy_dqkg_fused[grid](
+        q=q,
+        k=k,
+        v=v,
+        v_new=v_new,
+        g=g,
+        beta=beta,
+        A=A,
+        h=h,
+        do=do,
+        dh=dh,
+        dq=dq,
+        dk=dk,
+        dv=dv,
+        dv2=dv2,
+        dg=dg,
+        db=db,
+        dA=dA,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        TRANSPOSE_STATE=transpose_state_layout,
+    )
+    dv = dv2
+    return dq, dk, dv, db, dg, dA
+
+
+def chunk_kda_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    Aqk: torch.Tensor,
+    Akk: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    do: torch.Tensor,
+    dht: torch.Tensor,
+    g: torch.Tensor | None = None,
+    g_org: torch.Tensor | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    safe_gate: bool = False,
+    lower_bound: float | None = None,
+    use_gate_in_kernel: bool = False,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    disable_recompute: bool = False,
+    cp_context: FLACPContext | None = None,
+    transpose_state_layout: bool = False,
+    **kwargs,
+):
+    assert transpose_state_layout is False, "transpose_state_layout=True is not supported for training."
+    if disable_recompute is False:
+        B, T, _, _ = k.shape
+        if use_gate_in_kernel:
+            g = kda_gate_chunk_cumsum(
+                g=g_org,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                scale=RCP_LN2,
+                chunk_size=chunk_size,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+                lower_bound=lower_bound
+            )
+        reset_cu_seqlens = False
+        if cu_seqlens is None:
+            reset_cu_seqlens = True
+            cu_seqlens = prepare_uniform_cu_seqlens(B, T, q.device, torch.int32)
+        if chunk_indices is None and cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+        w = torch.empty_like(k)
+        u = torch.empty_like(v)
+        qg = torch.empty_like(q) if q is not None else None
+        kg = torch.empty_like(k) if g is not None else None
+        cula_cuda.recompute_w_u_cuda(
+            k, v, beta, Akk, g, cu_seqlens, chunk_indices, w, u, kg, chunk_size, q, qg
+        )
+        if cp_context is not None:
+            # Restore the full initial_state tensor from the compressed version.
+            # Only the first sequence's state is non-zero as it's the only one that could be cross-rank.
+            initial_state = expand_h0(initial_state, context=cp_context)
+        if reset_cu_seqlens:
+            cu_seqlens = None
+            chunk_indices = None
+        # TODO: update to support only varlen (1,T,H,D) format
+        h, v_new, _ = chunk_gated_delta_rule_fwd_h(
+            k=kg,
+            w=w,
+            u=u,
+            gk=g,
+            initial_state=initial_state,
+            output_final_state=False,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+    else:
+        w, u, qg, kg, v_new, h = kwargs["w"], kwargs["u"], kwargs["qg"], kwargs["kg"], kwargs["v_new"], kwargs["h"]
+        if cp_context is not None:
+            # Restore the full initial_state tensor from the compressed version.
+            # Only the first sequence's state is non-zero as it's the only one that could be cross-rank.
+            initial_state = expand_h0(initial_state, context=cp_context)
+
+    # dAqk = do @ v.T
+    # dv = A @ do
+    dAqk, dv = chunk_kda_bwd_dAv(
+        q=q,
+        k=k,
+        v=v_new,
+        do=do,
+        A=Aqk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+    )
+
+    if cp_context is not None:
+        # initial_state is None in the CP mode
+        # We only need to compute dht of current rank and pass it to the backward kernel
+        dht, initial_state = chunk_gated_delta_rule_bwd_dhu_pre_process(
+            q=qg,
+            k=kg,
+            w=w,
+            do=do,
+            dv=dv,
+            gk=g,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            dht=dht,
+            initial_state=initial_state,
+            use_exp2=True,
+            context=cp_context,
+            transpose_state_layout=transpose_state_layout,
+        )
+
+    dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(
+        q=qg,
+        k=kg,
+        w=w,
+        gk=g,
+        h0=initial_state,
+        dht=dht,
+        do=do,
+        dv=dv,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        use_exp2=True,
+        transpose_state_layout=transpose_state_layout,
+    )
+
+    dq, dk, dv, db, dg, dAkk = chunk_kda_bwd_wy_dqkg_fused(
+        q=q,
+        k=k,
+        v=v,
+        v_new=v_new,
+        g=g,
+        beta=beta,
+        A=Akk,
+        h=h,
+        do=do,
+        dh=dh,
+        dv=dv,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        transpose_state_layout=transpose_state_layout,
+    )
+
+    dq, dk, db, dg = chunk_kda_bwd_intra(
+        q=q,
+        k=k,
+        g=g,
+        beta=beta,
+        dAqk=dAqk,
+        dAkk=dAkk,
+        dq=dq,
+        dk=dk,
+        db=db,
+        dg=dg,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        safe_gate=safe_gate
+    )
+
+    dA, dbias = None, None
+    dg = chunk_local_cumsum(
+        dg,
+        chunk_size=chunk_size,
+        reverse=True,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    if use_gate_in_kernel:
+        dg, dA, dbias = kda_gate_bwd(
+            g=g_org,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            dyg=dg,
+            lower_bound=lower_bound
+        )
+
+    return dq, dk, dv, db, dg, dh0, dA, dbias

--- a/cula/kda/chunk_bwd.py
+++ b/cula/kda/chunk_bwd.py
@@ -331,7 +331,7 @@ def chunk_kda_bwd_dAv(
     # H100 can have larger block size
     if check_shared_mem("hopper", k.device.index):
         CONST_TILING = 128
-    elif check_shared_mem:
+    elif check_shared_mem():
         CONST_TILING = 64
     else:
         CONST_TILING = 32

--- a/cula/kda/chunk_bwd.py
+++ b/cula/kda/chunk_bwd.py
@@ -19,8 +19,7 @@ import importlib
 import torch
 import triton
 import triton.language as tl
-
-from fla.ops.common.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
+from fla.ops.common.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu
 from fla.ops.cp import FLACPContext
 from fla.ops.cp.chunk_delta_h import (
     chunk_gated_delta_rule_bwd_dhu_pre_process,
@@ -44,23 +43,23 @@ _delta_h_mod = importlib.import_module("cula.ops.chunk_delta_h")
 chunk_gated_delta_rule_fwd_h = _delta_h_mod.chunk_gated_delta_rule_fwd_h
 
 BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
-BV_LIST = [64, 128] if check_shared_mem('ampere') else [16, 32]
+BV_LIST = [64, 128] if check_shared_mem("ampere") else [16, 32]
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
 @triton.autotune(
     configs=[
-        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in NUM_WARPS
-        for num_stages in [2, 3, 4]
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages) for num_warps in NUM_WARPS for num_stages in [2, 3, 4]
     ],
-    key=['H', 'K', 'V', 'BT', 'BK', 'BV'],
+    key=["H", "K", "V", "BT", "BK", "BV"],
     **autotune_cache_kwargs,
 )
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T"])
 def chunk_kda_bwd_kernel_dAv(
     q,
     k,
@@ -98,7 +97,7 @@ def chunk_kda_bwd_kernel_dAv(
     dv += (bos * H + i_h) * V
     dA += (bos * H + i_h) * BT
 
-    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (BT, T), (1, H*BT), (0, i_t * BT), (BT, BT), (0, 1))
+    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (BT, T), (1, H * BT), (0, i_t * BT), (BT, BT), (0, 1))
     b_A = tl.load(p_A, boundary_check=(0, 1))
 
     o_t = i_t * BT + tl.arange(0, BT)
@@ -108,9 +107,9 @@ def chunk_kda_bwd_kernel_dAv(
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (V, T), (1, H*V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
-        p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_v = tl.make_block_ptr(v, (V, T), (1, H * V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
+        p_do = tl.make_block_ptr(do, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_dv = tl.make_block_ptr(dv, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
         # [BV, BT]
         b_v = tl.load(p_v, boundary_check=(0, 1))
         # [BT, BV]
@@ -121,26 +120,28 @@ def chunk_kda_bwd_kernel_dAv(
         b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
         tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
 
-    p_dA = tl.make_block_ptr(dA, (T, BT), (H*BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_dA = tl.where(o_t[:, None] >= o_t, b_dA * scale, 0.)
+    p_dA = tl.make_block_ptr(dA, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    b_dA = tl.where(o_t[:, None] >= o_t, b_dA * scale, 0.0)
     tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.heuristics({
-    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
-})
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
 @triton.autotune(
     configs=[
-        triton.Config({'BK': BK, 'BV': BV}, num_warps=num_warps, num_stages=num_stages)
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
         for BK in BK_LIST
         for BV in BV_LIST
         for num_warps in NUM_WARPS
         for num_stages in [2, 3, 4]
     ],
-    key=['BT', 'TRANSPOSE_STATE'],
+    key=["BT", "TRANSPOSE_STATE"],
     **autotune_cache_kwargs,
 )
-@triton.jit(do_not_specialize=['T'])
+@triton.jit(do_not_specialize=["T"])
 def chunk_kda_bwd_kernel_wy_dqkg_fused(
     q,
     k,
@@ -188,7 +189,7 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
 
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
-    m_last = (o_t == min(T, i_t * BT + BT) - 1)
+    m_last = o_t == min(T, i_t * BT + BT) - 1
 
     q += (bos * H + i_h) * K
     k += (bos * H + i_h) * K
@@ -197,9 +198,9 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
     g += (bos * H + i_h) * K
     beta += bos * H + i_h
     A += (bos * H + i_h) * BT
-    h += (i_tg * H + i_h) * K*V
+    h += (i_tg * H + i_h) * K * V
     do += (bos * H + i_h) * V
-    dh += (i_tg * H + i_h) * K*V
+    dh += (i_tg * H + i_h) * K * V
     dq += (bos * H + i_h) * K
     dk += (bos * H + i_h) * K
     dv += (bos * H + i_h) * V
@@ -221,12 +222,12 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
         o_k = i_k * BK + tl.arange(0, BK)
         m_k = o_k < K
 
-        p_k = tl.make_block_ptr(k, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_g = tl.make_block_ptr(g, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_g = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         b_k = tl.load(p_k, boundary_check=(0, 1))
         b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
 
-        p_gn = g + (min(T, i_t * BT + BT) - 1).to(tl.int64) * H*K + o_k
+        p_gn = g + (min(T, i_t * BT + BT) - 1).to(tl.int64) * H * K + o_k
         b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)
 
         b_dq = tl.zeros([BT, BK], dtype=tl.float32)
@@ -235,15 +236,15 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
         b_dgk = tl.zeros([BK], dtype=tl.float32)
 
         for i_v in range(tl.cdiv(V, BV)):
-            p_v_new = tl.make_block_ptr(v_new, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-            p_do = tl.make_block_ptr(do, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_v_new = tl.make_block_ptr(v_new, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_do = tl.make_block_ptr(do, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
             if TRANSPOSE_STATE:
                 p_h = tl.make_block_ptr(h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
                 p_dh = tl.make_block_ptr(dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0))
             else:
                 p_h = tl.make_block_ptr(h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
                 p_dh = tl.make_block_ptr(dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1))
-            p_dv = tl.make_block_ptr(dv, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            p_dv = tl.make_block_ptr(dv, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
             # [BT, BV]
             b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
             b_do = tl.load(p_do, boundary_check=(0, 1))
@@ -259,8 +260,8 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
             b_dw += tl.dot(b_dv.to(b_v_new.dtype), b_h.to(b_v_new.dtype))
             tl.debug_barrier()  # DO NOT REMOVE THIS LINE!
             if i_k == 0:
-                p_v = tl.make_block_ptr(v, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-                p_dv2 = tl.make_block_ptr(dv2, (T, V), (H*V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_v = tl.make_block_ptr(v, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+                p_dv2 = tl.make_block_ptr(dv2, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
 
                 b_v = tl.load(p_v, boundary_check=(0, 1))
 
@@ -286,16 +287,16 @@ def chunk_kda_bwd_kernel_wy_dqkg_fused(
         b_dkgb = tl.dot(b_A, b_dw)
         b_db += tl.sum(b_dkgb * b_kg, 1)
 
-        p_q = tl.make_block_ptr(q, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         b_q = tl.load(p_q, boundary_check=(0, 1))
         b_kdk = b_k * b_dk
         b_dgk += tl.sum(b_kdk, axis=0)
         b_dg = b_q * b_dq - b_kdk + m_last[:, None] * b_dgk + b_kg * b_dkgb * b_beta[:, None]
         b_dk = b_dk + b_dkgb * b_gb
 
-        p_dq = tl.make_block_ptr(dq, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dk = tl.make_block_ptr(dk, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
-        p_dg = tl.make_block_ptr(dg, (T, K), (H*K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dq = tl.make_block_ptr(dq, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dk = tl.make_block_ptr(dk, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_dg = tl.make_block_ptr(dg, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
         tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
@@ -328,7 +329,7 @@ def chunk_kda_bwd_dAv(
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     # H100 can have larger block size
-    if check_shared_mem('hopper', k.device.index):
+    if check_shared_mem("hopper", k.device.index):
         CONST_TILING = 128
     elif check_shared_mem:
         CONST_TILING = 64
@@ -466,7 +467,7 @@ def chunk_kda_bwd(
                 chunk_size=chunk_size,
                 cu_seqlens=cu_seqlens,
                 chunk_indices=chunk_indices,
-                lower_bound=lower_bound
+                lower_bound=lower_bound,
             )
         reset_cu_seqlens = False
         if cu_seqlens is None:
@@ -478,9 +479,7 @@ def chunk_kda_bwd(
         u = torch.empty_like(v)
         qg = torch.empty_like(q) if q is not None else None
         kg = torch.empty_like(k) if g is not None else None
-        cula_cuda.recompute_w_u_cuda(
-            k, v, beta, Akk, g, cu_seqlens, chunk_indices, w, u, kg, chunk_size, q, qg
-        )
+        cula_cuda.recompute_w_u_cuda(k, v, beta, Akk, g, cu_seqlens, chunk_indices, w, u, kg, chunk_size, q, qg)
         if cp_context is not None:
             # Restore the full initial_state tensor from the compressed version.
             # Only the first sequence's state is non-zero as it's the only one that could be cross-rank.
@@ -588,7 +587,7 @@ def chunk_kda_bwd(
         cu_seqlens=cu_seqlens,
         chunk_size=chunk_size,
         chunk_indices=chunk_indices,
-        safe_gate=safe_gate
+        safe_gate=safe_gate,
     )
 
     dA, dbias = None, None
@@ -600,12 +599,6 @@ def chunk_kda_bwd(
         chunk_indices=chunk_indices,
     )
     if use_gate_in_kernel:
-        dg, dA, dbias = kda_gate_bwd(
-            g=g_org,
-            A_log=A_log,
-            dt_bias=dt_bias,
-            dyg=dg,
-            lower_bound=lower_bound
-        )
+        dg, dA, dbias = kda_gate_bwd(g=g_org, A_log=A_log, dt_bias=dt_bias, dyg=dg, lower_bound=lower_bound)
 
     return dq, dk, dv, db, dg, dh0, dA, dbias


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

- Adapt recompute_wu and delta_h optimized kernel to backward when disable_recompute=False
- Add fwd-bwd e2e benchmark
- About 4% speedup for e2e benchmark

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to cuLA! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing. 

## ⚡ Performance

<!-- Optional: If this PR affects performance, please provide a before/after comparison. -->

```
python benchmarks/bench_kda_fwd_bwd_e2e.py
```

Before
```

========================================================================================================================
 Fixed-Length E2E Benchmark: cuLA vs FLA  phase=e2e  disable_recompute=False
========================================================================================================================

========================================================================================================================
 Varlen E2E Benchmark: cuLA vs FLA  phase=e2e  disable_recompute=False
========================================================================================================================


==================================================================================================================================
                       BENCHMARK REPORT: chunk_kda forward+backward (E2E)
                       cuLA CuTe DSL vs FLA Triton
                       H=64  D=128  dtype=bf16  safe_gate=True  phase=e2e  disable_recompute=False
                       Warmup=25  Iters=100
==================================================================================================================================

  [Fixed-Length]
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    B      T  │    FLA(ms)     cuLA(ms)   Speedup  │                     o          ht          dq          dk          dv          dg       dbeta         dh0
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    1    512  │     1.6974       1.5595     1.09x  │    rel_max:  0.001351    0.001241    0.001497    0.002907    0.000368    0.001016    0.000042    0.000195
              │                                    │  err_ratio:  0.000209    0.000140    0.000431    0.000402    0.000067    0.000787    0.000030    0.000021
    1   1024  │     1.6818       1.5445     1.09x  │    rel_max:  0.001250    0.002949    0.003185    0.002717    0.000282    0.001337    0.000053    0.000203
              │                                    │  err_ratio:  0.000203    0.000129    0.000429    0.000310    0.000073    0.000770    0.000037    0.000017
    1   4096  │     2.9315       2.6690     1.10x  │    rel_max:  0.001147    0.001377    0.003472    0.002778    0.000343    0.002793    0.000078    0.000246
              │                                    │  err_ratio:  0.000343    0.000152    0.000616    0.000500    0.000101    0.001105    0.000068    0.000019
    1   8192  │     5.6286       5.1320     1.10x  │    rel_max:  0.001256    0.001118    0.003049    0.002762    0.000676    0.001412    0.000102    0.000116
              │                                    │  err_ratio:  0.000288    0.000175    0.000525    0.000447    0.000125    0.001019    0.000090    0.000017
    1  16384  │    11.0834      10.0999     1.10x  │    rel_max:  0.001374    0.001385    0.006494    0.001381    0.000744    0.001689    0.000158    0.000313
              │                                    │  err_ratio:  0.000322    0.000139    0.000575    0.000393    0.000127    0.001033    0.000093    0.000031
    2    512  │     1.6895       1.5800     1.07x  │    rel_max:  0.001250    0.001986    0.001250    0.002841    0.000317    0.003425    0.000059    0.000331
              │                                    │  err_ratio:  0.000188    0.000132    0.000385    0.000310    0.000052    0.000970    0.000034    0.000024
    2   1024  │     1.7118       1.6223     1.06x  │    rel_max:  0.002500    0.001625    0.002232    0.002688    0.000302    0.001656    0.000085    0.000462
              │                                    │  err_ratio:  0.000361    0.000138    0.000638    0.000389    0.000107    0.001280    0.000073    0.000029
    2   4096  │     5.5578       5.1452     1.08x  │    rel_max:  0.001116    0.000980    0.003049    0.002283    0.000563    0.003876    0.000153    0.000116
              │                                    │  err_ratio:  0.000288    0.000152    0.000523    0.000446    0.000102    0.001594    0.000072    0.000013
    2   8192  │    10.9437      10.1277     1.08x  │    rel_max:  0.001147    0.001434    0.003247    0.002347    0.000274    0.001250    0.000047    0.000313
              │                                    │  err_ratio:  0.000321    0.000160    0.000571    0.000436    0.000106    0.001046    0.000078    0.000030
    2  16384  │    21.7566      20.1755     1.08x  │    rel_max:  0.002874    0.000858    0.002907    0.004950    0.000573    0.005051    0.000056    0.000708
              │                                    │  err_ratio:  0.000305    0.000125    0.000527    0.000453    0.000116    0.001411    0.000088    0.000052
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  [Varlen]
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                         Config  │    FLA(ms)     cuLA(ms)   Speedup  │                     o          ht          dq          dk          dv          dg       dbeta         dh0
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       uniform 10seqs T=4096 [409..415] avg=409  │     3.0533       2.8237     1.08x  │    rel_max:  0.002008    0.001370    0.002577    0.004695    0.000571    0.003597    0.000238    0.000610
                                                 │                                    │  err_ratio:  0.000269    0.000111    0.000512    0.000355    0.000072    0.001395    0.000070    0.000062
        random 10seqs T=4096 [24..1201] avg=409  │     3.0290       2.8030     1.08x  │    rel_max:  0.001126    0.000953    0.004831    0.004032    0.000558    0.001276    0.000063    0.000166
                                                 │                                    │  err_ratio:  0.000280    0.000109    0.000524    0.000366    0.000081    0.000840    0.000060    0.000027
       skewed 10seqs T=4096 [227..2053] avg=409  │     3.0185       2.7985     1.08x  │    rel_max:  0.002128    0.001001    0.004348    0.001984    0.000661    0.002525    0.000174    0.000242
                                                 │                                    │  err_ratio:  0.000280    0.000139    0.000524    0.000415    0.000075    0.001284    0.000066    0.000046
       uniform 20seqs T=4096 [204..220] avg=204  │     3.3362       3.0856     1.08x  │    rel_max:  0.001866    0.001209    0.002415    0.003906    0.000523    0.002488    0.000132    0.000715
                                                 │                                    │  err_ratio:  0.000229    0.000113    0.000442    0.000358    0.000067    0.001210    0.000053    0.000083
          random 20seqs T=4096 [5..787] avg=204  │     3.2263       2.9930     1.08x  │    rel_max:  0.001825    0.000672    0.002577    0.004386    0.000514    0.001531    0.000111    0.000330
                                                 │                                    │  err_ratio:  0.000243    0.000101    0.000461    0.000358    0.000064    0.000708    0.000050    0.000017
       skewed 20seqs T=4096 [107..2063] avg=204  │     3.1407       2.8990     1.08x  │    rel_max:  0.001000    0.000824    0.002174    0.003953    0.000551    0.002252    0.000116    0.000673
                                                 │                                    │  err_ratio:  0.000235    0.000140    0.000442    0.000446    0.000072    0.001138    0.000046    0.000040
       uniform 10seqs T=8192 [819..821] avg=819  │     5.6042       5.1801     1.08x  │    rel_max:  0.001096    0.001395    0.002825    0.003846    0.000601    0.004658    0.000108    0.000429
                                                 │                                    │  err_ratio:  0.000261    0.000156    0.000493    0.000453    0.000080    0.001370    0.000053    0.000032
        random 10seqs T=8192 [48..2401] avg=819  │     5.6678       5.2571     1.08x  │    rel_max:  0.001078    0.000648    0.002717    0.003846    0.000473    0.002513    0.000112    0.000208
                                                 │                                    │  err_ratio:  0.000257    0.000115    0.000471    0.000343    0.000068    0.001360    0.000051    0.000027
       skewed 10seqs T=8192 [455..4097] avg=819  │     5.7032       5.2701     1.08x  │    rel_max:  0.000933    0.001622    0.002646    0.003846    0.000658    0.001337    0.000156    0.000773
                                                 │                                    │  err_ratio:  0.000260    0.000114    0.000487    0.000393    0.000078    0.001114    0.000069    0.000094
       uniform 20seqs T=8192 [409..421] avg=409  │     5.8884       5.4352     1.08x  │    rel_max:  0.001136    0.001047    0.002165    0.004425    0.000592    0.004548    0.000289    0.000962
                                                 │                                    │  err_ratio:  0.000235    0.000095    0.000449    0.000285    0.000054    0.001395    0.000053    0.000075
         random 20seqs T=8192 [9..1574] avg=409  │     5.8599       5.4192     1.08x  │    rel_max:  0.000954    0.000503    0.002632    0.003906    0.000584    0.001603    0.000149    0.000026
                                                 │                                    │  err_ratio:  0.000232    0.000093    0.000445    0.000317    0.000057    0.000939    0.000042    0.000006
       skewed 20seqs T=8192 [215..4107] avg=409  │     5.8880       5.4407     1.08x  │    rel_max:  0.001116    0.000848    0.002551    0.004762    0.001131    0.004032    0.000163    0.000539
                                                 │                                    │  err_ratio:  0.000240    0.000090    0.000454    0.000280    0.000055    0.001358    0.000044    0.000065
   uniform 10seqs T=16384 [1638..1642] avg=1638  │    10.8906      10.0593     1.08x  │    rel_max:  0.001106    0.001571    0.005464    0.004525    0.000530    0.003142    0.000115    0.000461
                                                 │                                    │  err_ratio:  0.000303    0.000121    0.000550    0.000411    0.000081    0.001349    0.000063    0.000033
      random 10seqs T=16384 [95..4802] avg=1638  │    10.9026      10.0969     1.08x  │    rel_max:  0.001042    0.001316    0.005464    0.003817    0.000566    0.003817    0.000115    0.000197
                                                 │                                    │  err_ratio:  0.000301    0.000131    0.000545    0.000383    0.000083    0.001405    0.000061    0.000034
     skewed 10seqs T=16384 [910..8194] avg=1638  │    10.8851      10.0914     1.08x  │    rel_max:  0.000919    0.001289    0.002415    0.004525    0.000556    0.002083    0.000086    0.000515
                                                 │                                    │  err_ratio:  0.000305    0.000124    0.000550    0.000374    0.000085    0.001195    0.000065    0.000028
      uniform 20seqs T=16384 [819..823] avg=819  │    10.9470      10.1343     1.08x  │    rel_max:  0.001214    0.001901    0.002427    0.004016    0.000530    0.004082    0.000098    0.001208
                                                 │                                    │  err_ratio:  0.000286    0.000178    0.000524    0.000488    0.000091    0.001632    0.000065    0.000048
       random 20seqs T=16384 [19..3147] avg=819  │    11.0081      10.2026     1.08x  │    rel_max:  0.002304    0.000738    0.005376    0.004348    0.000523    0.003759    0.000104    0.000272
                                                 │                                    │  err_ratio:  0.000289    0.000132    0.000528    0.000403    0.000078    0.001159    0.000059    0.000024
      skewed 20seqs T=16384 [431..8195] avg=819  │    10.9206      10.1174     1.08x  │    rel_max:  0.001046    0.001168    0.004695    0.004566    0.000498    0.002732    0.000119    0.000663
                                                 │                                    │  err_ratio:  0.000286    0.000133    0.000526    0.000394    0.000076    0.001177    0.000053    0.000048
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

==================================================================================================================================
```

After
```
========================================================================================================================
 Fixed-Length E2E Benchmark: cuLA vs FLA  phase=e2e  disable_recompute=False
========================================================================================================================

========================================================================================================================
 Varlen E2E Benchmark: cuLA vs FLA  phase=e2e  disable_recompute=False
========================================================================================================================


==================================================================================================================================
                       BENCHMARK REPORT: chunk_kda forward+backward (E2E)
                       cuLA CuTe DSL vs FLA Triton
                       H=64  D=128  dtype=bf16  safe_gate=True  phase=e2e  disable_recompute=False
                       Warmup=25  Iters=100
==================================================================================================================================

  [Fixed-Length]
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    B      T  │    FLA(ms)     cuLA(ms)   Speedup  │                     o          ht          dq          dk          dv          dg       dbeta         dh0
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    1    512  │     1.6702       1.5680     1.07x  │    rel_max:  0.001351    0.001241    0.001497    0.002907    0.000368    0.001016    0.000042    0.000195
              │                                    │  err_ratio:  0.000209    0.000140    0.000431    0.000402    0.000067    0.000787    0.000030    0.000021
    1   1024  │     1.7021       1.5874     1.07x  │    rel_max:  0.001250    0.002949    0.003185    0.002717    0.000282    0.001337    0.000053    0.000203
              │                                    │  err_ratio:  0.000203    0.000129    0.000429    0.000310    0.000073    0.000769    0.000037    0.000017
    1   4096  │     2.8746       2.5550     1.13x  │    rel_max:  0.001147    0.001377    0.003472    0.002778    0.000343    0.002793    0.000078    0.000246
              │                                    │  err_ratio:  0.000343    0.000152    0.000616    0.000500    0.000101    0.001105    0.000068    0.000019
    1   8192  │     5.5079       4.8948     1.13x  │    rel_max:  0.001256    0.001118    0.003049    0.002762    0.000676    0.001412    0.000102    0.000116
              │                                    │  err_ratio:  0.000288    0.000175    0.000526    0.000447    0.000125    0.001019    0.000090    0.000017
    1  16384  │    10.8521       9.6277     1.13x  │    rel_max:  0.001374    0.001385    0.006494    0.001381    0.000744    0.001689    0.000158    0.000313
              │                                    │  err_ratio:  0.000322    0.000139    0.000576    0.000393    0.000127    0.001033    0.000093    0.000031
    2    512  │     1.7115       1.6329     1.05x  │    rel_max:  0.001250    0.001986    0.001250    0.002841    0.000317    0.003425    0.000059    0.000331
              │                                    │  err_ratio:  0.000188    0.000132    0.000385    0.000310    0.000052    0.000970    0.000034    0.000024
    2   1024  │     1.7228       1.6016     1.08x  │    rel_max:  0.002500    0.001625    0.002232    0.002688    0.000302    0.001656    0.000085    0.000462
              │                                    │  err_ratio:  0.000361    0.000138    0.000637    0.000389    0.000107    0.001280    0.000073    0.000029
    2   4096  │     5.5017       4.9205     1.12x  │    rel_max:  0.001116    0.000980    0.003049    0.002283    0.000563    0.003876    0.000153    0.000116
              │                                    │  err_ratio:  0.000288    0.000152    0.000523    0.000446    0.000102    0.001595    0.000072    0.000013
    2   8192  │    10.8215       9.6492     1.12x  │    rel_max:  0.001147    0.001434    0.003247    0.002347    0.000274    0.001250    0.000047    0.000313
              │                                    │  err_ratio:  0.000321    0.000160    0.000571    0.000436    0.000106    0.001046    0.000078    0.000030
    2  16384  │    21.4718      19.1993     1.12x  │    rel_max:  0.002874    0.000858    0.002907    0.004950    0.000573    0.005051    0.000056    0.000708
              │                                    │  err_ratio:  0.000305    0.000125    0.000527    0.000453    0.000116    0.001411    0.000088    0.000052
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  [Varlen]
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                         Config  │    FLA(ms)     cuLA(ms)   Speedup  │                     o          ht          dq          dk          dv          dg       dbeta         dh0
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       uniform 10seqs T=4096 [409..415] avg=409  │     3.0597       2.7359     1.12x  │    rel_max:  0.002008    0.001370    0.002577    0.004695    0.000571    0.003597    0.000238    0.000610
                                                 │                                    │  err_ratio:  0.000269    0.000111    0.000512    0.000355    0.000072    0.001395    0.000070    0.000062
        random 10seqs T=4096 [24..1201] avg=409  │     3.0382       2.7130     1.12x  │    rel_max:  0.001126    0.000953    0.004831    0.004032    0.000558    0.001276    0.000063    0.000166
                                                 │                                    │  err_ratio:  0.000280    0.000109    0.000524    0.000366    0.000081    0.000844    0.000060    0.000027
       skewed 10seqs T=4096 [227..2053] avg=409  │     3.0356       2.7199     1.12x  │    rel_max:  0.002128    0.001001    0.004348    0.001984    0.000661    0.002525    0.000174    0.000242
                                                 │                                    │  err_ratio:  0.000280    0.000139    0.000524    0.000415    0.000075    0.001284    0.000066    0.000046
       uniform 20seqs T=4096 [204..220] avg=204  │     3.3675       2.9866     1.13x  │    rel_max:  0.001866    0.001209    0.002415    0.003906    0.000523    0.002488    0.000132    0.000715
                                                 │                                    │  err_ratio:  0.000229    0.000113    0.000442    0.000358    0.000067    0.001210    0.000053    0.000083
          random 20seqs T=4096 [5..787] avg=204  │     3.2700       2.8985     1.13x  │    rel_max:  0.001825    0.000672    0.002577    0.004386    0.000514    0.001531    0.000111    0.000330
                                                 │                                    │  err_ratio:  0.000243    0.000101    0.000461    0.000358    0.000064    0.000708    0.000050    0.000017
       skewed 20seqs T=4096 [107..2063] avg=204  │     3.1809       2.8049     1.13x  │    rel_max:  0.001000    0.000824    0.002174    0.003953    0.000551    0.002252    0.000116    0.000673
                                                 │                                    │  err_ratio:  0.000235    0.000140    0.000442    0.000447    0.000072    0.001137    0.000046    0.000040
       uniform 10seqs T=8192 [819..821] avg=819  │     5.5858       5.0027     1.12x  │    rel_max:  0.001096    0.001395    0.002825    0.003846    0.000601    0.004658    0.000108    0.000429
                                                 │                                    │  err_ratio:  0.000261    0.000156    0.000493    0.000453    0.000080    0.001370    0.000053    0.000032
        random 10seqs T=8192 [48..2401] avg=819  │     5.6658       5.0680     1.12x  │    rel_max:  0.001078    0.000648    0.002717    0.003846    0.000473    0.002513    0.000112    0.000208
                                                 │                                    │  err_ratio:  0.000257    0.000115    0.000470    0.000343    0.000068    0.001360    0.000051    0.000027
       skewed 10seqs T=8192 [455..4097] avg=819  │     5.7004       5.0861     1.12x  │    rel_max:  0.000933    0.001622    0.002646    0.003846    0.000658    0.001337    0.000156    0.000773
                                                 │                                    │  err_ratio:  0.000260    0.000114    0.000487    0.000393    0.000078    0.001113    0.000069    0.000094
       uniform 20seqs T=8192 [409..421] avg=409  │     5.9049       5.2410     1.13x  │    rel_max:  0.001136    0.001047    0.002165    0.004425    0.000592    0.004548    0.000289    0.000962
                                                 │                                    │  err_ratio:  0.000235    0.000095    0.000449    0.000285    0.000054    0.001396    0.000053    0.000075
         random 20seqs T=8192 [9..1574] avg=409  │     5.8889       5.2357     1.12x  │    rel_max:  0.000954    0.000503    0.002632    0.003906    0.000584    0.001603    0.000149    0.000026
                                                 │                                    │  err_ratio:  0.000232    0.000093    0.000444    0.000317    0.000057    0.000939    0.000042    0.000006
       skewed 20seqs T=8192 [215..4107] avg=409  │     5.9194       5.2630     1.12x  │    rel_max:  0.001116    0.000848    0.002551    0.004762    0.001131    0.004032    0.000163    0.000539
                                                 │                                    │  err_ratio:  0.000240    0.000090    0.000454    0.000280    0.000055    0.001358    0.000044    0.000065
   uniform 10seqs T=16384 [1638..1642] avg=1638  │    10.8497       9.7128     1.12x  │    rel_max:  0.001106    0.001571    0.005464    0.004525    0.000530    0.003142    0.000115    0.000461
                                                 │                                    │  err_ratio:  0.000303    0.000121    0.000550    0.000411    0.000081    0.001349    0.000063    0.000033
      random 10seqs T=16384 [95..4802] avg=1638  │    10.8669       9.7283     1.12x  │    rel_max:  0.001042    0.001316    0.005464    0.003817    0.000566    0.003817    0.000115    0.000197
                                                 │                                    │  err_ratio:  0.000301    0.000131    0.000545    0.000383    0.000083    0.001405    0.000061    0.000034
     skewed 10seqs T=16384 [910..8194] avg=1638  │    10.8886       9.7526     1.12x  │    rel_max:  0.000919    0.001289    0.002415    0.004525    0.000556    0.002083    0.000086    0.000515
                                                 │                                    │  err_ratio:  0.000305    0.000124    0.000550    0.000374    0.000085    0.001195    0.000065    0.000028
      uniform 20seqs T=16384 [819..823] avg=819  │    10.9403       9.7653     1.12x  │    rel_max:  0.001214    0.001901    0.002427    0.004016    0.000530    0.004082    0.000098    0.001208
                                                 │                                    │  err_ratio:  0.000286    0.000178    0.000524    0.000488    0.000091    0.001632    0.000065    0.000048
       random 20seqs T=16384 [19..3147] avg=819  │    11.0395       9.8669     1.12x  │    rel_max:  0.002304    0.000738    0.005376    0.004348    0.000523    0.003759    0.000104    0.000272
                                                 │                                    │  err_ratio:  0.000289    0.000132    0.000528    0.000403    0.000078    0.001159    0.000059    0.000024
      skewed 20seqs T=16384 [431..8195] avg=819  │    10.9311       9.7893     1.12x  │    rel_max:  0.001046    0.001168    0.004695    0.004566    0.000498    0.002732    0.000119    0.000663
                                                 │                                    │  err_ratio:  0.000286    0.000133    0.000526    0.000394    0.000076    0.001177    0.000053    0.000048
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

==================================================================================================================================
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->