### PR TITLE
fix output_final_state wrapper issue

### DIFF
--- a/cula/kda/hopper_fused_fwd.py
+++ b/cula/kda/hopper_fused_fwd.py
@@ -121,7 +121,7 @@ class HopperChunkKDAFunction(torch.autograd.Function):
         # reshape back
         o = rearrange(o, "(b t) h d -> b t h d", b=batch_size)
 
-        return o.to(q.dtype), final_state
+        return o.to(q.dtype), final_state if output_final_state else None
 
     @staticmethod
     @input_guard


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
This PR fixes the Hopper KDA fused forward Python wrapper to respect `output_final_state=False`.

Previously, the underlying C++ kernel always returned a `final_state` tensor, and the Python wrapper returned it unconditionally. This made the wrapper behavior inconsistent with the documented API:

```python
final_state is None if output_final_state=False
```

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to cuLA! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing. 

## ⚡ Performance

<!-- Optional: If this PR affects performance, please provide a before/after comparison. -->

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
Note: this PR only fixes the Python wrapper return behavior. In [FLA](https://github.com/fla-org/flash-linear-attention/blob/794f183cac656df47014df3e3e75531fc8fdb383/fla/ops/common/chunk_delta_h.py#L41), `output_final_state=False` also avoids allocating `final_state` and disables the final `ht` store in the kernel. cuLA still allocates/writes `output_state` internally today; skipping that work can be considered as a separate follow-up optimization.
