### PR TITLE
[KDA] fix internal output_final_state wrapper issue in SM90

### DIFF
--- a/csrc/api/kda_sm90.cu
+++ b/csrc/api/kda_sm90.cu
@@ -21,7 +21,7 @@
 
 using OptionalTensor = std::optional<torch::Tensor>;
 
-std::tuple<torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, OptionalTensor>
 kda_fwd_prefill(
     OptionalTensor output_,
     OptionalTensor output_state_,
@@ -34,6 +34,7 @@ kda_fwd_prefill(
     torch::Tensor const& cu_seqlens,
     torch::Tensor workspace_buffer,
     float scale,
+    bool output_final_state,
     bool safe_gate) {
     // Q, K, V: [packed_seq, H, D] (already packed by Python layer)
     auto packed_seq = q.size(0);
@@ -52,12 +53,12 @@ kda_fwd_prefill(
                                                      {packed_seq, num_heads, head_size},
                                                      torch::TensorOptions().dtype(q.dtype()).device(q.device()));
 
-    // Allocate output state if not provided
-    torch::Tensor output_state = output_state_.has_value()
-                                     ? output_state_.value()
-                                     : torch::zeros(
-                                           {num_seqs, num_heads, head_size, head_size},
-                                           torch::TensorOptions().dtype(torch::kFloat32).device(q.device()));
+    OptionalTensor output_state = output_state_;
+    if (!output_state.has_value() && output_final_state) {
+        output_state = torch::zeros(
+            {num_seqs, num_heads, head_size, head_size},
+            torch::TensorOptions().dtype(torch::kFloat32).device(q.device()));
+    }
 
     // Validate dtypes
     TORCH_CHECK(q.dtype() == torch::kBFloat16, "q must be bfloat16");
@@ -70,7 +71,10 @@ kda_fwd_prefill(
     TORCH_CHECK(k.is_contiguous(), "k must be contiguous");
     TORCH_CHECK(v.is_contiguous(), "v must be contiguous");
     TORCH_CHECK(output.is_contiguous(), "output must be contiguous");
-    TORCH_CHECK(output_state.is_contiguous(), "output_state must be contiguous");
+    if (output_state.has_value()) {
+        TORCH_CHECK(output_state->dtype() == torch::kFloat32, "output_state must be float32");
+        TORCH_CHECK(output_state->is_contiguous(), "output_state must be contiguous");
+    }
     TORCH_CHECK(cu_seqlens.is_contiguous(), "cu_seqlens must be contiguous");
     TORCH_CHECK(workspace_buffer.is_contiguous(), "workspace_buffer must be contiguous");
 
@@ -87,6 +91,8 @@ kda_fwd_prefill(
             "alpha shape must be [packed_seq, num_heads, head_size]");
         alpha_ptr = alpha.data_ptr<float>();
     }
+
+    float* output_state_ptr = output_state.has_value() ? output_state->data_ptr<float>() : nullptr;
     if (beta_.has_value()) {
         auto& beta = beta_.value();
         TORCH_CHECK(
@@ -121,7 +127,7 @@ kda_fwd_prefill(
         kda::sm90::launch_kda_fwd_prefill_kernel<Sm90, bf16, bf16, float, bf16>(
             stream,
             reinterpret_cast<bf16*>(output.data_ptr()),
-            output_state.data_ptr<float>(),
+            output_state_ptr,
             reinterpret_cast<bf16 const*>(q.data_ptr()),
             reinterpret_cast<bf16 const*>(k.data_ptr()),
             reinterpret_cast<bf16 const*>(v.data_ptr()),
@@ -142,7 +148,7 @@ kda_fwd_prefill(
         kda::sm90::launch_kda_fwd_prefill_kernel<Sm90, bf16, bf16, float, float>(
             stream,
             reinterpret_cast<bf16*>(output.data_ptr()),
-            output_state.data_ptr<float>(),
+            output_state_ptr,
             reinterpret_cast<bf16 const*>(q.data_ptr()),
             reinterpret_cast<bf16 const*>(k.data_ptr()),
             reinterpret_cast<bf16 const*>(v.data_ptr()),

--- a/csrc/api/kda_sm90.cu
+++ b/csrc/api/kda_sm90.cu
@@ -53,11 +53,16 @@ kda_fwd_prefill(
                                                      {packed_seq, num_heads, head_size},
                                                      torch::TensorOptions().dtype(q.dtype()).device(q.device()));
 
-    OptionalTensor output_state = output_state_;
-    if (!output_state.has_value() && output_final_state) {
-        output_state = torch::zeros(
-            {num_seqs, num_heads, head_size, head_size},
-            torch::TensorOptions().dtype(torch::kFloat32).device(q.device()));
+    // output_final_state controls the API side effect. If it is false, ignore
+    // even an explicitly provided output_state_ buffer so the kernel skips the
+    // final-state store.
+    OptionalTensor output_state = std::nullopt;
+    if (output_final_state) {
+        output_state = output_state_.has_value()
+                           ? output_state_.value()
+                           : torch::zeros(
+                                 {num_seqs, num_heads, head_size, head_size},
+                                 torch::TensorOptions().dtype(torch::kFloat32).device(q.device()));
     }
 
     // Validate dtypes

--- a/csrc/api/pybind.cu
+++ b/csrc/api/pybind.cu
@@ -51,7 +51,7 @@ ChunkKDAFwdRecompWU(
 #endif
 
 #if defined(CULA_SM90A_ENABLED)
-std::tuple<torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, std::optional<torch::Tensor>>
 kda_fwd_prefill(
     std::optional<torch::Tensor> output_,
     std::optional<torch::Tensor> output_state_,
@@ -64,6 +64,7 @@ kda_fwd_prefill(
     torch::Tensor const& cu_seqlens,
     torch::Tensor workspace_buffer,
     float scale,
+    bool output_final_state,
     bool safe_gate);
 #endif
 

--- a/csrc/kda/sm90/collective/mainloop_kda_fwd.hpp
+++ b/csrc/kda/sm90/collective/mainloop_kda_fwd.hpp
@@ -1369,7 +1369,9 @@ struct FlatMainloopTmaWarpSpecializedKdaFwd {
                 /*is_first_block_=*/cute::false_type{},
                 /*is_final_block_=*/cute::true_type{});
         }
-        kv_store();
+        if (params.ptr_output_state != nullptr) {
+            kv_store();
+        }
     }
 
     template <class ProblemShape, class WorkDesc>

--- a/cula/kda/hopper_fused_fwd.py
+++ b/cula/kda/hopper_fused_fwd.py
@@ -121,7 +121,7 @@ class HopperChunkKDAFunction(torch.autograd.Function):
         # reshape back
         o = rearrange(o, "(b t) h d -> b t h d", b=batch_size)
 
-        return o.to(q.dtype), final_state
+        return o.to(q.dtype), final_state if output_final_state else None
 
     @staticmethod
     @input_guard

--- a/cula/kda/hopper_fused_fwd.py
+++ b/cula/kda/hopper_fused_fwd.py
@@ -102,7 +102,8 @@ class HopperChunkKDAFunction(torch.autograd.Function):
         workspace_buffer = _get_cache_buf("hopper_kda_fwd_workspace", workspace_size, q.device)
 
         # call the C++ kernel
-        # Signature: kda_fwd_prefill(output_, output_state_, q, k, v, input_state_, alpha_, beta_, cu_seqlens, workspace, scale, safe_gate)
+        # Signature: kda_fwd_prefill(output_, output_state_, q, k, v, input_state_, alpha_, beta_, cu_seqlens,
+        #                            workspace, scale, output_final_state, safe_gate)
         o, final_state = cula_cuda.kda_fwd_prefill(
             None,  # output_ (auto-allocate)
             None,  # output_state_ (auto-allocate)
@@ -115,13 +116,14 @@ class HopperChunkKDAFunction(torch.autograd.Function):
             cu_seqlens,
             workspace_buffer,
             scale,
+            output_final_state,
             safe_gate,
         )
 
         # reshape back
         o = rearrange(o, "(b t) h d -> b t h d", b=batch_size)
 
-        return o.to(q.dtype), final_state if output_final_state else None
+        return o.to(q.dtype), final_state
 
     @staticmethod
     @input_guard

--- a/tests/test_kda_fused_fwd.py
+++ b/tests/test_kda_fused_fwd.py
@@ -173,6 +173,53 @@ def test_safe_gate_chunk(
     assert_close("ht", ref_ht_fla_trans, tri_ht, 0.005)
 
 
+def test_safe_gate_chunk_no_final_state():
+    cula_kda_fused_fwd = get_kda_fused_fwd(device)
+
+    B, T, H, D = 1, 63, 1, 128
+    dtype = torch.bfloat16
+
+    torch.manual_seed(42)
+    q = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(B, T, H, D, dtype=torch.float32, device=device)).clamp(-5, 0)
+    beta = torch.randn(B, T, H, dtype=torch.float32, device=device).sigmoid()
+    h0 = torch.randn(B, H, D, D, dtype=torch.float32, device=device)
+    h0_vk = h0.transpose(-1, -2).contiguous()
+
+    q = F.normalize(q, p=2, dim=-1)
+    k = F.normalize(k, p=2, dim=-1)
+
+    tri_no_state, tri_ht_no_state = cula_kda_fused_fwd(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        initial_state=h0_vk.clone(),
+        output_final_state=False,
+        safe_gate=True,
+        lower_bound=-5.0,
+    )
+
+    tri_with_state, tri_ht_with_state = cula_kda_fused_fwd(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        initial_state=h0_vk.clone(),
+        output_final_state=True,
+        safe_gate=True,
+        lower_bound=-5.0,
+    )
+
+    assert tri_ht_no_state is None
+    assert tri_ht_with_state is not None
+    assert_close("o", tri_with_state, tri_no_state, 0.005)
+
+
 @pytest.mark.parametrize("beta_dtype", [torch.float32, torch.bfloat16], ids=["beta_fp32", "beta_bf16"])
 @pytest.mark.parametrize(
     ("H", "D", "mask_p", "cu_seqlens", "dtype", "safe_gate"),


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR is a follow-up to [#63](https://github.com/inclusionAI/cuLA/pull/63).

#63 fixed the Python wrapper behavior of Hopper KDA fused prefill so that `final_state` is returned as `None` when `output_final_state=False`. However, that PR only changed the Python-side return value. The underlying C++/CUDA path still allocated an `output_state` buffer and passed a non-null `ptr_output_state` to the kernel, so the final state was still written internally even when the caller did not request it.

This PR passes `output_final_state` from the Python wrapper to the C++ API, and avoids allocating or storing the final state when it is not requested.

Specifically, this PR:

- updates the C++ API to accept `output_final_state`;
- allocates `output_state` only when `output_final_state=True`;
- passes `nullptr` as `ptr_output_state` when final state output is not requested;
- skips the final `kv_store()` in the SM90 KDA mainloop when `ptr_output_state == nullptr`;
- adds a regression test to verify that `output_final_state=False` returns `None` and produces the same output tensor as `output_final_state=True`.

This avoids unnecessary final-state allocation and the final global-memory store while preserving the output tensor.

## 🔍 Related Issues

mentioned [here](https://github.com/inclusionAI/cuLA/issues/55).

## 🚀 Pull Request Checklist

Thank you for contributing to cuLA! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing. 

tested with 
`pytest tests/test_kda_fused_fwd.py 
`
## ⚡ Performance

<!-- Optional: If this PR affects performance, please provide a before/after comparison. -->

`python benchmarks/bench_kda_fused_fwd.py 
`

before:
1:output_final_state = True
```text
[Device] NVIDIA H800 PCIe  compute capability sm90  →  using cula.kda.hopper_fused_fwd.cula_kda_prefill

====================================================================================================
 Fixed-Length Benchmark: cuLA fully-fused (sm90) vs FLA Triton
====================================================================================================

====================================================================================================
 Varlen Benchmark: cuLA fully-fused (sm90) vs FLA Triton
====================================================================================================


==============================================================================================================
                  BENCHMARK REPORT: cula_kda_fused_fwd (fully-fused)
                  cuLA sm90 fully-fused vs FLA Triton
                  H=64  D=128  dtype=bf16  safe_gate=True  has_init_state=False
                  Warmup=25  Iters=100
==============================================================================================================

  [Fixed-Length]
  ──────────────────────────────────────────────────────────────────────────────────────────
    B       T  │        RMSE     rel_max   mean_diff  │    FLA(ms)    cuLA(ms)   Speedup
  ──────────────────────────────────────────────────────────────────────────────────────────
    1     512  │    0.000019    0.007692    0.000008  │     0.7245      0.2834     2.56x
    1    1024  │    0.000022    0.008021    0.000010  │     0.7165      0.3142     2.28x
    1    4096  │    0.000019    0.008523    0.000008  │     1.6661      1.1345     1.47x
    1    8192  │    0.000021    0.010204    0.000009  │     3.2977      2.2818     1.45x
    1   16384  │    0.000019    0.008368    0.000008  │     6.5983      4.4572     1.48x
    2     512  │    0.000022    0.008021    0.000010  │     0.7180      0.3628     1.98x
    2    1024  │    0.000020    0.007353    0.000009  │     0.8813      0.6292     1.40x
    2    4096  │    0.000021    0.010204    0.000009  │     3.3218      2.2665     1.47x
    2    8192  │    0.000019    0.008368    0.000008  │     6.7096      4.4716     1.50x
    2   16384  │    0.000019    0.007353    0.000008  │    13.4159      8.7355     1.54x
  ──────────────────────────────────────────────────────────────────────────────────────────

  [Varlen]
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
                                         Config  │        RMSE     rel_max   mean_diff  │    FLA(ms)    cuLA(ms)   Speedup
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
       uniform 10seqs T=4096 [409..415] avg=409  │    0.000019    0.011364    0.000008  │     1.7035      1.1006     1.55x
        random 10seqs T=4096 [24..1201] avg=409  │    0.000019    0.008523    0.000008  │     1.6985      1.0122     1.68x
       skewed 10seqs T=4096 [227..2053] avg=409  │    0.000019    0.008523    0.000008  │     1.6890      0.9857     1.71x
       uniform 20seqs T=4096 [204..220] avg=204  │    0.000019    0.008523    0.000008  │     1.8191      1.4444     1.26x
          random 20seqs T=4096 [5..787] avg=204  │    0.000019    0.011364    0.000008  │     1.7835      1.0948     1.63x
       skewed 20seqs T=4096 [107..2063] avg=204  │    0.000019    0.011364    0.000008  │     1.7408      1.1191     1.56x
       uniform 10seqs T=8192 [819..821] avg=819  │    0.000021    0.010204    0.000009  │     3.2902      1.8610     1.77x
        random 10seqs T=8192 [48..2401] avg=819  │    0.000021    0.010204    0.000009  │     3.3108      1.8550     1.78x
       skewed 10seqs T=8192 [455..4097] avg=819  │    0.000021    0.010204    0.000009  │     3.3159      1.8308     1.81x
       uniform 20seqs T=8192 [409..421] avg=409  │    0.000020    0.010204    0.000009  │     3.3826      2.2154     1.53x
         random 20seqs T=8192 [9..1574] avg=409  │    0.000020    0.010204    0.000009  │     3.3713      1.9197     1.76x
       skewed 20seqs T=8192 [215..4107] avg=409  │    0.000020    0.010256    0.000009  │     3.3757      1.9554     1.73x
   uniform 10seqs T=16384 [1638..1642] avg=1638  │    0.000019    0.008368    0.000008  │     6.5568      3.4048     1.93x
      random 10seqs T=16384 [95..4802] avg=1638  │    0.000019    0.008368    0.000008  │     6.5580      3.4761     1.89x
     skewed 10seqs T=16384 [910..8194] avg=1638  │    0.000019    0.008368    0.000008  │     6.5515      3.3333     1.97x
      uniform 20seqs T=16384 [819..823] avg=819  │    0.000019    0.008368    0.000008  │     6.6029      3.7340     1.77x
       random 20seqs T=16384 [19..3147] avg=819  │    0.000019    0.008368    0.000008  │     6.5960      3.4868     1.89x
      skewed 20seqs T=16384 [431..8195] avg=819  │    0.000019    0.008403    0.000008  │     6.5702      3.4492     1.90x
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────

==============================================================================================================
```
2: output_final_state = False
```text
[Device] NVIDIA H800 PCIe  compute capability sm90  →  using cula.kda.hopper_fused_fwd.cula_kda_prefill

====================================================================================================
 Fixed-Length Benchmark: cuLA fully-fused (sm90) vs FLA Triton
====================================================================================================

====================================================================================================
 Varlen Benchmark: cuLA fully-fused (sm90) vs FLA Triton
====================================================================================================


==============================================================================================================
                  BENCHMARK REPORT: cula_kda_fused_fwd (fully-fused)
                  cuLA sm90 fully-fused vs FLA Triton
                  H=64  D=128  dtype=bf16  safe_gate=True  has_init_state=False
                  Warmup=25  Iters=100
==============================================================================================================

  [Fixed-Length]
  ──────────────────────────────────────────────────────────────────────────────────────────
    B       T  │        RMSE     rel_max   mean_diff  │    FLA(ms)    cuLA(ms)   Speedup
  ──────────────────────────────────────────────────────────────────────────────────────────
    1     512  │    0.000019    0.007692    0.000008  │     0.7226      0.2873     2.51x
    1    1024  │    0.000022    0.008021    0.000010  │     0.7123      0.3140     2.27x
    1    4096  │    0.000019    0.008523    0.000008  │     1.6578      1.1286     1.47x
    1    8192  │    0.000021    0.010204    0.000009  │     3.2904      2.2521     1.46x
    1   16384  │    0.000019    0.008368    0.000008  │     6.5959      4.4610     1.48x
    2     512  │    0.000022    0.008021    0.000010  │     0.6983      0.3517     1.99x
    2    1024  │    0.000020    0.007353    0.000009  │     0.8698      0.6290     1.38x
    2    4096  │    0.000021    0.010204    0.000009  │     3.3259      2.2705     1.46x
    2    8192  │    0.000019    0.008368    0.000008  │     6.7053      4.4761     1.50x
    2   16384  │    0.000019    0.007353    0.000008  │    13.4593      8.7126     1.54x
  ──────────────────────────────────────────────────────────────────────────────────────────

  [Varlen]
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
                                         Config  │        RMSE     rel_max   mean_diff  │    FLA(ms)    cuLA(ms)   Speedup
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
       uniform 10seqs T=4096 [409..415] avg=409  │    0.000019    0.011364    0.000008  │     1.6610      1.1007     1.51x
        random 10seqs T=4096 [24..1201] avg=409  │    0.000019    0.008523    0.000008  │     1.6489      1.0130     1.63x
       skewed 10seqs T=4096 [227..2053] avg=409  │    0.000019    0.008523    0.000008  │     1.6413      0.9868     1.66x
       uniform 20seqs T=4096 [204..220] avg=204  │    0.000019    0.008523    0.000008  │     1.7251      1.4417     1.20x
          random 20seqs T=4096 [5..787] avg=204  │    0.000019    0.011364    0.000008  │     1.6955      1.0956     1.55x
       skewed 20seqs T=4096 [107..2063] avg=204  │    0.000019    0.011364    0.000008  │     1.6552      1.1234     1.47x
       uniform 10seqs T=8192 [819..821] avg=819  │    0.000021    0.010204    0.000009  │     3.2432      1.8628     1.74x
        random 10seqs T=8192 [48..2401] avg=819  │    0.000021    0.010204    0.000009  │     3.2664      1.8515     1.76x
       skewed 10seqs T=8192 [455..4097] avg=819  │    0.000021    0.010204    0.000009  │     3.2711      1.8314     1.79x
       uniform 20seqs T=8192 [409..421] avg=409  │    0.000020    0.010204    0.000009  │     3.2875      2.2031     1.49x
         random 20seqs T=8192 [9..1574] avg=409  │    0.000020    0.010204    0.000009  │     3.2906      1.9254     1.71x
       skewed 20seqs T=8192 [215..4107] avg=409  │    0.000020    0.010256    0.000009  │     3.2773      1.9557     1.68x
   uniform 10seqs T=16384 [1638..1642] avg=1638  │    0.000019    0.008368    0.000008  │     6.5063      3.4007     1.91x
      random 10seqs T=16384 [95..4802] avg=1638  │    0.000019    0.008368    0.000008  │     6.4758      3.4772     1.86x
     skewed 10seqs T=16384 [910..8194] avg=1638  │    0.000019    0.008368    0.000008  │     6.5240      3.3306     1.96x
      uniform 20seqs T=16384 [819..823] avg=819  │    0.000019    0.008368    0.000008  │     6.4837      3.7402     1.73x
       random 20seqs T=16384 [19..3147] avg=819  │    0.000019    0.008368    0.000008  │     6.5310      3.5019     1.86x
      skewed 20seqs T=16384 [431..8195] avg=819  │    0.000019    0.008403    0.000008  │     6.4862      3.4524     1.88x
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
==============================================================================================================
```

after:

1: output_final_state = True
```text
[Device] NVIDIA H800 PCIe  compute capability sm90  →  using cula.kda.hopper_fused_fwd.cula_kda_prefill

====================================================================================================
 Fixed-Length Benchmark: cuLA fully-fused (sm90) vs FLA Triton
====================================================================================================

====================================================================================================
 Varlen Benchmark: cuLA fully-fused (sm90) vs FLA Triton
====================================================================================================


==============================================================================================================
                  BENCHMARK REPORT: cula_kda_fused_fwd (fully-fused)
                  cuLA sm90 fully-fused vs FLA Triton
                  H=64  D=128  dtype=bf16  safe_gate=True  has_init_state=False
                  Warmup=25  Iters=100
==============================================================================================================

  [Fixed-Length]
  ──────────────────────────────────────────────────────────────────────────────────────────
    B       T  │        RMSE     rel_max   mean_diff  │    FLA(ms)    cuLA(ms)   Speedup
  ──────────────────────────────────────────────────────────────────────────────────────────
    1     512  │    0.000019    0.007692    0.000008  │     0.7338      0.2845     2.58x
    1    1024  │    0.000022    0.008021    0.000010  │     0.7264      0.3161     2.30x
    1    4096  │    0.000019    0.008523    0.000008  │     1.6662      1.1320     1.47x
    1    8192  │    0.000021    0.010204    0.000009  │     3.2996      2.2640     1.46x
    1   16384  │    0.000019    0.008368    0.000008  │     6.6189      4.4580     1.48x
    2     512  │    0.000022    0.008021    0.000010  │     0.7168      0.3510     2.04x
    2    1024  │    0.000020    0.007353    0.000009  │     0.8810      0.6302     1.40x
    2    4096  │    0.000021    0.010204    0.000009  │     3.3290      2.2683     1.47x
    2    8192  │    0.000019    0.008368    0.000008  │     6.7120      4.4719     1.50x
    2   16384  │    0.000019    0.007353    0.000008  │    13.4336      8.7589     1.53x
  ──────────────────────────────────────────────────────────────────────────────────────────

  [Varlen]
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
                                         Config  │        RMSE     rel_max   mean_diff  │    FLA(ms)    cuLA(ms)   Speedup
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
       uniform 10seqs T=4096 [409..415] avg=409  │    0.000019    0.011364    0.000008  │     1.7064      1.1039     1.55x
        random 10seqs T=4096 [24..1201] avg=409  │    0.000019    0.008523    0.000008  │     1.7010      1.0118     1.68x
       skewed 10seqs T=4096 [227..2053] avg=409  │    0.000019    0.008523    0.000008  │     1.6935      0.9855     1.72x
       uniform 20seqs T=4096 [204..220] avg=204  │    0.000019    0.008523    0.000008  │     1.8211      1.4417     1.26x
          random 20seqs T=4096 [5..787] avg=204  │    0.000019    0.011364    0.000008  │     1.7834      1.0969     1.63x
       skewed 20seqs T=4096 [107..2063] avg=204  │    0.000019    0.011364    0.000008  │     1.7422      1.1298     1.54x
       uniform 10seqs T=8192 [819..821] avg=819  │    0.000021    0.010204    0.000009  │     3.2886      1.8640     1.76x
        random 10seqs T=8192 [48..2401] avg=819  │    0.000021    0.010204    0.000009  │     3.3087      1.8534     1.79x
       skewed 10seqs T=8192 [455..4097] avg=819  │    0.000021    0.010204    0.000009  │     3.3164      1.8312     1.81x
       uniform 20seqs T=8192 [409..421] avg=409  │    0.000020    0.010204    0.000009  │     3.3816      2.2141     1.53x
         random 20seqs T=8192 [9..1574] avg=409  │    0.000020    0.010204    0.000009  │     3.3760      1.9246     1.75x
       skewed 20seqs T=8192 [215..4107] avg=409  │    0.000020    0.010256    0.000009  │     3.3764      1.9501     1.73x
   uniform 10seqs T=16384 [1638..1642] avg=1638  │    0.000019    0.008368    0.000008  │     6.5511      3.4041     1.92x
      random 10seqs T=16384 [95..4802] avg=1638  │    0.000019    0.008368    0.000008  │     6.5635      3.4809     1.89x
     skewed 10seqs T=16384 [910..8194] avg=1638  │    0.000019    0.008368    0.000008  │     6.5311      3.3224     1.97x
      uniform 20seqs T=16384 [819..823] avg=819  │    0.000019    0.008368    0.000008  │     6.5863      3.7379     1.76x
       random 20seqs T=16384 [19..3147] avg=819  │    0.000019    0.008368    0.000008  │     6.6000      3.4784     1.90x
      skewed 20seqs T=16384 [431..8195] avg=819  │    0.000019    0.008403    0.000008  │     6.5688      3.4395     1.91x
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────

===================================================================================
```
2: output_final_state = False
```text
[Device] NVIDIA H800 PCIe  compute capability sm90  →  using cula.kda.hopper_fused_fwd.cula_kda_prefill

====================================================================================================
 Fixed-Length Benchmark: cuLA fully-fused (sm90) vs FLA Triton
====================================================================================================

====================================================================================================
 Varlen Benchmark: cuLA fully-fused (sm90) vs FLA Triton
====================================================================================================


==============================================================================================================
                  BENCHMARK REPORT: cula_kda_fused_fwd (fully-fused)
                  cuLA sm90 fully-fused vs FLA Triton
                  H=64  D=128  dtype=bf16  safe_gate=True  has_init_state=False
                  Warmup=25  Iters=100
==============================================================================================================

  [Fixed-Length]
  ──────────────────────────────────────────────────────────────────────────────────────────
    B       T  │        RMSE     rel_max   mean_diff  │    FLA(ms)    cuLA(ms)   Speedup
  ──────────────────────────────────────────────────────────────────────────────────────────
    1     512  │    0.000019    0.007692    0.000008  │     0.7232      0.3457     2.09x
    1    1024  │    0.000022    0.008021    0.000010  │     0.7560      0.3233     2.34x
    1    4096  │    0.000019    0.008523    0.000008  │     1.6876      1.1215     1.50x
    1    8192  │    0.000021    0.010204    0.000009  │     3.2877      2.2564     1.46x
    1   16384  │    0.000019    0.008368    0.000008  │     6.6044      4.4438     1.49x
    2     512  │    0.000022    0.008021    0.000010  │     0.7270      0.3366     2.16x
    2    1024  │    0.000020    0.007353    0.000009  │     0.8686      0.6167     1.41x
    2    4096  │    0.000021    0.010204    0.000009  │     3.3357      2.2605     1.48x
    2    8192  │    0.000019    0.008368    0.000008  │     6.6871      4.4606     1.50x
    2   16384  │    0.000019    0.007353    0.000008  │    13.4401      8.7195     1.54x
  ──────────────────────────────────────────────────────────────────────────────────────────

  [Varlen]
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
                                         Config  │        RMSE     rel_max   mean_diff  │    FLA(ms)    cuLA(ms)   Speedup
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
       uniform 10seqs T=4096 [409..415] avg=409  │    0.000019    0.011364    0.000008  │     1.6597      1.0504     1.58x
        random 10seqs T=4096 [24..1201] avg=409  │    0.000019    0.008523    0.000008  │     1.6547      0.9786     1.69x
       skewed 10seqs T=4096 [227..2053] avg=409  │    0.000019    0.008523    0.000008  │     1.6441      0.9521     1.73x
       uniform 20seqs T=4096 [204..220] avg=204  │    0.000019    0.008523    0.000008  │     1.7286      1.3447     1.29x
          random 20seqs T=4096 [5..787] avg=204  │    0.000019    0.011364    0.000008  │     1.6961      1.0298     1.65x
       skewed 20seqs T=4096 [107..2063] avg=204  │    0.000019    0.011364    0.000008  │     1.6574      1.0063     1.65x
       uniform 10seqs T=8192 [819..821] avg=819  │    0.000021    0.010204    0.000009  │     3.2471      1.8187     1.79x
        random 10seqs T=8192 [48..2401] avg=819  │    0.000021    0.010204    0.000009  │     3.2708      1.8295     1.79x
       skewed 10seqs T=8192 [455..4097] avg=819  │    0.000021    0.010204    0.000009  │     3.2701      1.8005     1.82x
       uniform 20seqs T=8192 [409..421] avg=409  │    0.000020    0.010204    0.000009  │     3.2918      2.1226     1.55x
         random 20seqs T=8192 [9..1574] avg=409  │    0.000020    0.010204    0.000009  │     3.2901      1.8700     1.76x
       skewed 20seqs T=8192 [215..4107] avg=409  │    0.000020    0.010256    0.000009  │     3.2880      1.8955     1.73x
   uniform 10seqs T=16384 [1638..1642] avg=1638  │    0.000019    0.008368    0.000008  │     6.4912      3.3560     1.93x
      random 10seqs T=16384 [95..4802] avg=1638  │    0.000019    0.008368    0.000008  │     6.5376      3.4580     1.89x
     skewed 10seqs T=16384 [910..8194] avg=1638  │    0.000019    0.008368    0.000008  │     6.5152      3.2913     1.98x
      uniform 20seqs T=16384 [819..823] avg=819  │    0.000019    0.008368    0.000008  │     6.4979      3.6403     1.78x
       random 20seqs T=16384 [19..3147] avg=819  │    0.000019    0.008368    0.000008  │     6.5160      3.4194     1.91x
      skewed 20seqs T=16384 [431..8195] avg=819  │    0.000019    0.008403    0.000008  │     6.4658      3.3754     1.92x
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────

==============================================================================================================
```
## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->