### PR TITLE
[KDA] split unit tests into fast/slow modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ python -m pytest tests/test_kda.py tests/test_kda_compare_fla.py -v
 # Slow — broader stress coverage for nightly or manual runs
 python -m pytest -m kda_slow tests/test_kda.py tests/test_kda_compare_fla.py -v
 # Full sweep (fast + slow) — run before submitting a PR
-python -m pytest -m "kda_fast or kda_slow" tests/test_kda.py tests/test_kda_compare_fla.py -v
+python -m pytest -m kda_full tests/test_kda.py tests/test_kda_compare_fla.py -v
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ FLA baseline: [flash-linear-attention v0.5.0](https://github.com/fla-org/flash-l
 **Blackwell (SM10X)**
 
 See [BENCHMARK_GB200_CUDA_130.md](BENCHMARK_GB200_CUDA_130.md) tested with CUDA 13.0 for detailed results.
- 
+
 **Hopper (SM90)**
 
 See [BENCHMARK_H200.md](BENCHMARK_H200.md) tested with CUDA 12.9 for detailed results.
@@ -142,6 +142,14 @@ python -m pytest tests/test_kda_fused_fwd.py -v
 python tests/test_lightning_attn.py
 # Tests for Lightning Attention decode
 python -m pytest tests/test_la_decode.py -v
+
+# test_kda.py and test_kda_compare_fla.py support a fast/slow split.
+# Fast (default) — representative correctness paths for default CI and local iteration
+python -m pytest tests/test_kda.py tests/test_kda_compare_fla.py -v
+# Slow — broader stress coverage for nightly or manual runs
+python -m pytest -m kda_slow tests/test_kda.py tests/test_kda_compare_fla.py -v
+# Full sweep (fast + slow) — run before submitting a PR
+python -m pytest -m "kda_fast or kda_slow" tests/test_kda.py tests/test_kda_compare_fla.py -v
 ```
 
 <details>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,8 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "kda_backward: fast-mode KDA case that performs full backward validation "
-        "(without this marker, fast-mode cases verify only forward output and final state)",
+        "kda_fast_norecomp: fast-mode KDA config that also runs the disable_recompute=True "
+        "variant in fast mode (other fast configs run disable_recompute=False only)",
     )
 
 
@@ -35,26 +35,25 @@ def pytest_collection_modifyitems(config, items):
     skip_slow = pytest.mark.skip(
         reason="kda_slow case: run 'pytest -m kda_slow' or '-m \"kda_fast or kda_slow\"' to include"
     )
+    skip_fast_norecomp = pytest.mark.skip(
+        reason="disable_recompute=True runs in fast mode only for kda_fast_norecomp configs; "
+        "include the rest via a slow mode"
+    )
 
     for item in items:
         if "sm100_only" in item.keywords and not is_sm100:
             item.add_marker(skip_non_sm100)
         if "sm90_only" in item.keywords and is_sm100:
             item.add_marker(skip_on_sm100)
-        if not include_slow and "kda_slow" in item.keywords:
+        if include_slow:
+            continue
+        if "kda_slow" in item.keywords:
             item.add_marker(skip_slow)
-
-
-@pytest.fixture
-def needs_backward(request) -> bool:
-    """Whether the current test should run full backward validation.
-
-    Slow / full sweeps (``-m`` contains ``kda_slow``): every test that runs
-    validates backward. Default fast run: only ``kda_backward`` cases validate
-    backward; the remaining fast smoke cases verify forward output and final
-    state only.
-    """
-    if "kda_slow" in (request.config.option.markexpr or ""):
-        return True
-    keywords = request.node.keywords
-    return "kda_slow" in keywords or "kda_backward" in keywords
+            continue
+        callspec = getattr(item, "callspec", None)
+        if (
+            callspec is not None
+            and callspec.params.get("disable_recompute")
+            and "kda_fast_norecomp" not in item.keywords
+        ):
+            item.add_marker(skip_fast_norecomp)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,20 @@ def _is_sm100() -> bool:
 def pytest_configure(config):
     config.addinivalue_line("markers", "sm100_only: only run on SM100 devices")
     config.addinivalue_line("markers", "sm90_only: skip on SM100 devices")
+    config.addinivalue_line(
+        "markers",
+        "kda_fast: KDA test case included in fast (default) mode",
+    )
+    config.addinivalue_line(
+        "markers",
+        "kda_slow: KDA test case excluded from fast (default) mode; "
+        "include via 'pytest -m kda_slow' or '-m \"kda_fast or kda_slow\"'",
+    )
+    config.addinivalue_line(
+        "markers",
+        "kda_backward: fast-mode KDA case that performs full backward validation "
+        "(without this marker, fast-mode cases verify only forward output and final state)",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -16,8 +30,31 @@ def pytest_collection_modifyitems(config, items):
     skip_non_sm100 = pytest.mark.skip(reason="SM100-only test: skip on non-SM100 devices")
     skip_on_sm100 = pytest.mark.skip(reason="SM90-only test: skip on SM100")
 
+    marker_expr = config.option.markexpr or ""
+    include_slow = "kda_slow" in marker_expr
+    skip_slow = pytest.mark.skip(
+        reason="kda_slow case: run 'pytest -m kda_slow' or '-m \"kda_fast or kda_slow\"' to include"
+    )
+
     for item in items:
         if "sm100_only" in item.keywords and not is_sm100:
             item.add_marker(skip_non_sm100)
         if "sm90_only" in item.keywords and is_sm100:
             item.add_marker(skip_on_sm100)
+        if not include_slow and "kda_slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
+@pytest.fixture
+def needs_backward(request) -> bool:
+    """Whether the current test should run full backward validation.
+
+    Slow / full sweeps (``-m`` contains ``kda_slow``): every test that runs
+    validates backward. Default fast run: only ``kda_backward`` cases validate
+    backward; the remaining fast smoke cases verify forward output and final
+    state only.
+    """
+    if "kda_slow" in (request.config.option.markexpr or ""):
+        return True
+    keywords = request.node.keywords
+    return "kda_slow" in keywords or "kda_backward" in keywords

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import re
 import pytest
 import torch
 
@@ -16,13 +17,17 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "kda_slow: KDA test case excluded from fast (default) mode; "
-        "include via 'pytest -m kda_slow' or '-m \"kda_fast or kda_slow\"'",
+        "include via 'pytest -m kda_slow' or run the full sweep with '-m kda_full'",
     )
     config.addinivalue_line(
         "markers",
         "kda_fast_norecomp: fast-mode KDA config that also runs the disable_recompute=True "
         "variant in fast mode (other fast configs run disable_recompute=False only)",
     )
+
+    markexpr = config.option.markexpr
+    if markexpr and "kda_full" in markexpr:
+        config.option.markexpr = re.sub(r"\bkda_full\b", "(kda_fast or kda_slow)", markexpr)
 
 
 def pytest_collection_modifyitems(config, items):
@@ -33,11 +38,11 @@ def pytest_collection_modifyitems(config, items):
     marker_expr = config.option.markexpr or ""
     include_slow = "kda_slow" in marker_expr
     skip_slow = pytest.mark.skip(
-        reason="kda_slow case: run 'pytest -m kda_slow' or '-m \"kda_fast or kda_slow\"' to include"
+        reason="kda_slow case: run 'pytest -m kda_slow' or the full sweep with '-m kda_full' to include"
     )
     skip_fast_norecomp = pytest.mark.skip(
         reason="disable_recompute=True runs in fast mode only for kda_fast_norecomp configs; "
-        "include the rest via a slow mode"
+        "include the rest via '-m kda_slow' or '-m kda_full'"
     )
 
     for item in items:

--- a/tests/test_kda.py
+++ b/tests/test_kda.py
@@ -15,6 +15,11 @@
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 
 # Tests for the chunk-decomposed KDA implementation (python/kda/chunk.py)
+"""Test modes (see issue #78):
+    default:                       fast subset (kda_fast cases only)
+    pytest -m kda_slow:            slow stress traces and wider parameter grids
+    pytest -m "kda_fast or kda_slow": full sweep (fast + slow)
+"""
 
 import pytest
 import torch
@@ -27,9 +32,115 @@ from cula.kda import chunk_kda
 
 pytestmark = pytest.mark.sm100_only
 
+_FAST = [pytest.mark.kda_fast]
+_FAST_BWD = [pytest.mark.kda_fast, pytest.mark.kda_backward]
+_SLOW = [pytest.mark.kda_slow]
 
-@pytest.mark.parametrize("beta_dtype", [torch.float32, torch.bfloat16], ids=["beta_fp32", "beta_bf16"])
-@pytest.mark.parametrize("disable_recompute", [True, False], ids=["no_recomp", "recomp"])
+# (B, T, H, HV, D, gln, mask_p, l2norm, gate, safe_gate, dtype), marks
+_FIXED_CONFIGS = [
+    ((1, 63, 1, 1, 128, 1, 0, False, False, True, torch.bfloat16), _FAST_BWD),  # small fixed backward
+    ((2, 500, 3, 3, 128, 1, 0, False, False, True, torch.bfloat16), _SLOW),
+    ((2, 1000, 3, 3, 128, 1, 0.5, False, False, True, torch.bfloat16), _SLOW),
+    ((3, 1024, 4, 4, 128, 0.1, 0, False, False, True, torch.bfloat16), _SLOW),
+    ((4, 1024, 4, 4, 128, 1, 0, False, False, True, torch.bfloat16), _SLOW),
+    ((4, 1024, 4, 4, 128, 1, 0, True, False, True, torch.bfloat16), _FAST_BWD),  # l2norm medium backward
+    ((2, 1500, 4, 4, 128, 10, 0, False, True, True, torch.bfloat16), _FAST_BWD),  # gated backward
+    ((4, 2048, 8, 8, 128, 1, 0, False, True, True, torch.bfloat16), _SLOW),
+    # GVA cases: HV > H
+    ((2, 1024, 4, 8, 128, 1, 0, True, False, True, torch.bfloat16), _FAST_BWD),  # GVA medium backward
+    ((2, 1500, 2, 4, 128, 10, 0, False, True, True, torch.bfloat16), _SLOW),
+    ((2, 2048, 4, 8, 128, 1, 0, False, True, True, torch.bfloat16), _SLOW),
+]
+
+# (H, HV, D, mask_p, cu_seqlens, dtype, safe_gate), marks
+_VARLEN_CONFIGS = [
+    ((4, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # short varlen smoke (fwd+ht only)
+    ((4, 4, 128, 0.9, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
+    ((4, 4, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
+    ((4, 4, 128, 0, [0, 15, 100, 300, 1200, 2000], torch.bfloat16, True), _FAST_BWD),  # multi-batch varlen backward
+    ((4, 4, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True), _SLOW),
+    # ======Varlen test with simulated trace=======
+    (
+        (
+            32,
+            32,
+            128,
+            0,
+            [0, 247, 699, 982, 1688, 1985, 2383, 3081, 3526, 3973, 4096, 4824, 5101, 5919, 6426, 7137, 7392, 7800, 8192],
+            torch.bfloat16,
+            True,
+        ),
+        _SLOW,
+    ),
+    (
+        (
+            32,
+            32,
+            128,
+            0,
+            [0, 652, 1255, 1600, 2083, 2345, 2756, 3172, 3767, 4096, 4891, 5236, 5543, 6255, 6480, 6947, 7616, 8192],
+            torch.bfloat16,
+            True,
+        ),
+        _SLOW,
+    ),
+    (
+        (
+            32,
+            32,
+            128,
+            0,
+            [0, 315, 973, 1283, 2162, 2459, 2678, 2998, 3781, 4096, 4503, 5459, 6318, 6669, 6979, 7583, 8192],
+            torch.bfloat16,
+            True,
+        ),
+        _SLOW,
+    ),
+    (
+        (
+            32,
+            32,
+            128,
+            0,
+            [0, 494, 1004, 1561, 1908, 2240, 2849, 3116, 4096, 4986, 5626, 6090, 6718, 7244, 7870, 8192],
+            torch.bfloat16,
+            True,
+        ),
+        _SLOW,
+    ),
+    # ======GVA varlen cases: HV > H=======
+    ((2, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # GVA varlen smoke (fwd+ht only)
+    ((4, 8, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
+    ((4, 8, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True), _SLOW),
+    (
+        (
+            8,
+            32,
+            128,
+            0,
+            [0, 494, 1004, 1561, 1908, 2240, 2849, 3116, 4096, 4986, 5626, 6090, 6718, 7244, 7870, 8192],
+            torch.bfloat16,
+            True,
+        ),
+        _SLOW,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "beta_dtype",
+    [
+        pytest.param(torch.float32, id="beta_fp32", marks=pytest.mark.kda_slow),
+        pytest.param(torch.bfloat16, id="beta_bf16"),
+    ],
+)
+@pytest.mark.parametrize(
+    "disable_recompute",
+    [
+        pytest.param(True, id="no_recomp", marks=pytest.mark.kda_slow),
+        pytest.param(False, id="recomp"),
+    ],
+)
 @pytest.mark.parametrize(
     (
         "B",
@@ -46,23 +157,11 @@ pytestmark = pytest.mark.sm100_only
     ),
     [
         pytest.param(
-            *test,
-            id="B{}-T{}-H{}-HV{}-D{}-gln{}-mask_p{}-l2norm{}-gate{}-safe_gate{}-{}".format(*test),
+            *params,
+            id="B{}-T{}-H{}-HV{}-D{}-gln{}-mask_p{}-l2norm{}-gate{}-safe_gate{}-{}".format(*params),
+            marks=marks,
         )
-        for test in [
-            (1, 63, 1, 1, 128, 1, 0, False, False, True, torch.bfloat16),
-            (2, 500, 3, 3, 128, 1, 0, False, False, True, torch.bfloat16),
-            (2, 1000, 3, 3, 128, 1, 0.5, False, False, True, torch.bfloat16),
-            (3, 1024, 4, 4, 128, 0.1, 0, False, False, True, torch.bfloat16),
-            (4, 1024, 4, 4, 128, 1, 0, False, False, True, torch.bfloat16),
-            (4, 1024, 4, 4, 128, 1, 0, True, False, True, torch.bfloat16),
-            (2, 1500, 4, 4, 128, 10, 0, False, True, True, torch.bfloat16),
-            (4, 2048, 8, 8, 128, 1, 0, False, True, True, torch.bfloat16),
-            # GVA cases: HV > H
-            (2, 1024, 4, 8, 128, 1, 0, True, False, True, torch.bfloat16),
-            (2, 1500, 2, 4, 128, 10, 0, False, True, True, torch.bfloat16),
-            (2, 2048, 4, 8, 128, 1, 0, False, True, True, torch.bfloat16),
-        ]
+        for params, marks in _FIXED_CONFIGS
     ],
 )
 def test_safe_gate_chunk(
@@ -79,6 +178,7 @@ def test_safe_gate_chunk(
     dtype: torch.dtype,
     disable_recompute: bool,
     beta_dtype: torch.dtype,
+    needs_backward: bool,
 ):
     torch.manual_seed(42)
     q = torch.rand(B, T, H, D, dtype=dtype)
@@ -106,8 +206,9 @@ def test_safe_gate_chunk(
         A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(True), (A_log, dt_bias))
     q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, g, beta, h0))
 
-    do = torch.randn_like(v)
-    dht = torch.randn_like(h0)
+    if needs_backward:
+        do = torch.randn_like(v)
+        dht = torch.randn_like(h0)
 
     ref, ref_ht = naive_recurrent_kda(
         q=F.normalize(q.clone(), p=2, dim=-1),
@@ -118,12 +219,13 @@ def test_safe_gate_chunk(
         initial_state=h0.clone(),
         output_final_state=True,
     )
-    ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
-    if use_gate_in_kernel:
-        ref_dA, A_log.grad = A_log.grad, None
-        ref_dbias, dt_bias.grad = dt_bias.grad, None
-    ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    if needs_backward:
+        ((ref * do).sum() + (ref_ht * dht).sum()).backward()
+        if use_gate_in_kernel:
+            ref_dA, A_log.grad = A_log.grad, None
+            ref_dbias, dt_bias.grad = dt_bias.grad, None
+        ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     tri, tri_ht = chunk_kda(
         q=F.normalize(q.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else q.clone(),
@@ -141,15 +243,19 @@ def test_safe_gate_chunk(
         lower_bound=lower_bound,
         disable_recompute=disable_recompute,
     )
-    ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
-    if use_gate_in_kernel:
-        tri_dA, A_log.grad = A_log.grad, None
-        tri_dbias, dt_bias.grad = dt_bias.grad, None
-    tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    if needs_backward:
+        ((tri * do).sum() + (tri_ht * dht).sum()).backward()
+        if use_gate_in_kernel:
+            tri_dA, A_log.grad = A_log.grad, None
+            tri_dbias, dt_bias.grad = dt_bias.grad, None
+        tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     assert_close("o", ref, tri, 0.005)
     assert_close("ht", ref_ht, tri_ht, 0.005)
+    if not needs_backward:
+        return
+
     assert_close("dq", ref_dq, tri_dq, 0.008)
     assert_close("dk", ref_dk, tri_dk, 0.008)
     assert_close("dv", ref_dv, tri_dv, 0.008)
@@ -161,69 +267,29 @@ def test_safe_gate_chunk(
     assert_close("dh0", ref_dh0, tri_dh0, 0.008)
 
 
-@pytest.mark.parametrize("beta_dtype", [torch.float32, torch.bfloat16], ids=["beta_fp32", "beta_bf16"])
-@pytest.mark.parametrize("disable_recompute", [True, False], ids=["no_recomp", "recomp"])
+@pytest.mark.parametrize(
+    "beta_dtype",
+    [
+        pytest.param(torch.float32, id="beta_fp32", marks=pytest.mark.kda_slow),
+        pytest.param(torch.bfloat16, id="beta_bf16"),
+    ],
+)
+@pytest.mark.parametrize(
+    "disable_recompute",
+    [
+        pytest.param(True, id="no_recomp", marks=pytest.mark.kda_slow),
+        pytest.param(False, id="recomp"),
+    ],
+)
 @pytest.mark.parametrize(
     ("H", "HV", "D", "mask_p", "cu_seqlens", "dtype", "safe_gate"),
     [
-        pytest.param(*test, id="H{}-HV{}-D{}-mask_p{}-cu_seqlens{}-{}-safe_gate{}".format(*test))
-        for test in [
-            (4, 4, 128, 0.1, [0, 15], torch.bfloat16, True),
-            (4, 4, 128, 0.9, [0, 256, 500, 1000], torch.bfloat16, True),
-            (4, 4, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True),
-            (4, 4, 128, 0, [0, 15, 100, 300, 1200, 2000], torch.bfloat16, True),
-            (4, 4, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True),
-            # ======Varlen test with simulated trace=======
-            (
-                32,
-                32,
-                128,
-                0,
-                [0, 247, 699, 982, 1688, 1985, 2383, 3081, 3526, 3973, 4096, 4824, 5101, 5919, 6426, 7137, 7392, 7800, 8192],
-                torch.bfloat16,
-                True,
-            ),
-            (
-                32,
-                32,
-                128,
-                0,
-                [0, 652, 1255, 1600, 2083, 2345, 2756, 3172, 3767, 4096, 4891, 5236, 5543, 6255, 6480, 6947, 7616, 8192],
-                torch.bfloat16,
-                True,
-            ),
-            (
-                32,
-                32,
-                128,
-                0,
-                [0, 315, 973, 1283, 2162, 2459, 2678, 2998, 3781, 4096, 4503, 5459, 6318, 6669, 6979, 7583, 8192],
-                torch.bfloat16,
-                True,
-            ),
-            (
-                32,
-                32,
-                128,
-                0,
-                [0, 494, 1004, 1561, 1908, 2240, 2849, 3116, 4096, 4986, 5626, 6090, 6718, 7244, 7870, 8192],
-                torch.bfloat16,
-                True,
-            ),
-            # ======GVA varlen cases: HV > H=======
-            (2, 4, 128, 0.1, [0, 15], torch.bfloat16, True),
-            (4, 8, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True),
-            (4, 8, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True),
-            (
-                8,
-                32,
-                128,
-                0,
-                [0, 494, 1004, 1561, 1908, 2240, 2849, 3116, 4096, 4986, 5626, 6090, 6718, 7244, 7870, 8192],
-                torch.bfloat16,
-                True,
-            ),
-        ]
+        pytest.param(
+            *params,
+            id="H{}-HV{}-D{}-mask_p{}-cu_seqlens{}-{}-safe_gate{}".format(*params),
+            marks=marks,
+        )
+        for params, marks in _VARLEN_CONFIGS
     ],
 )
 def test_safe_gate_chunk_varlen(
@@ -236,6 +302,7 @@ def test_safe_gate_chunk_varlen(
     safe_gate: bool,
     disable_recompute: bool,
     beta_dtype: torch.dtype,
+    needs_backward: bool,
 ):
     torch.manual_seed(42)
     cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
@@ -256,8 +323,9 @@ def test_safe_gate_chunk_varlen(
     h0 = torch.randn((N, HV, D, D), dtype=torch.float32)
 
     q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, g, beta, h0))
-    do = torch.randn_like(v)
-    dht = torch.rand_like(h0)
+    if needs_backward:
+        do = torch.randn_like(v)
+        dht = torch.rand_like(h0)
 
     tri, tri_ht = chunk_kda(
         q=F.normalize(q.clone(), p=2, dim=-1),
@@ -273,9 +341,10 @@ def test_safe_gate_chunk_varlen(
         lower_bound=-5.0 if safe_gate else None,
         disable_recompute=disable_recompute,
     )
-    ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
-    tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    if needs_backward:
+        ((tri * do).sum() + (tri_ht * dht).sum()).backward()
+        tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     ref = []
     ref_ht = []
@@ -294,11 +363,15 @@ def test_safe_gate_chunk_varlen(
     ref = torch.cat(ref, 1)
     ref_ht = torch.cat(ref_ht, 0)
 
-    ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
-    ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+    if needs_backward:
+        ((ref * do).sum() + (ref_ht * dht).sum()).backward()
+        ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
 
     assert_close("o", ref, tri, 0.005)
     assert_close("ht", ref_ht, tri_ht, 0.005)
+    if not needs_backward:
+        return
+
     assert_close("dq", ref_dq, tri_dq, 0.007)
     assert_close("dk", ref_dk, tri_dk, 0.008)
     assert_close("dv", ref_dv, tri_dv, 0.007)

--- a/tests/test_kda.py
+++ b/tests/test_kda.py
@@ -16,9 +16,9 @@
 
 # Tests for the chunk-decomposed KDA implementation (python/kda/chunk.py)
 # Test modes (see issue #78):
-#     default:                          fast subset (kda_fast cases only)
-#     pytest -m kda_slow:               slow stress traces and wider parameter grids
-#     pytest -m "kda_fast or kda_slow": full sweep (fast + slow)
+#     default:            fast subset (kda_fast cases only)
+#     pytest -m kda_slow: slow stress traces and wider parameter grids
+#     pytest -m kda_full: full sweep (fast + slow)
 
 import pytest
 import torch

--- a/tests/test_kda.py
+++ b/tests/test_kda.py
@@ -15,11 +15,10 @@
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 
 # Tests for the chunk-decomposed KDA implementation (python/kda/chunk.py)
-"""Test modes (see issue #78):
-    default:                       fast subset (kda_fast cases only)
-    pytest -m kda_slow:            slow stress traces and wider parameter grids
-    pytest -m "kda_fast or kda_slow": full sweep (fast + slow)
-"""
+# Test modes (see issue #78):
+#     default:                          fast subset (kda_fast cases only)
+#     pytest -m kda_slow:               slow stress traces and wider parameter grids
+#     pytest -m "kda_fast or kda_slow": full sweep (fast + slow)
 
 import pytest
 import torch
@@ -33,31 +32,31 @@ from cula.kda import chunk_kda
 pytestmark = pytest.mark.sm100_only
 
 _FAST = [pytest.mark.kda_fast]
-_FAST_BWD = [pytest.mark.kda_fast, pytest.mark.kda_backward]
+_FAST_NR = [pytest.mark.kda_fast, pytest.mark.kda_fast_norecomp]
 _SLOW = [pytest.mark.kda_slow]
 
 # (B, T, H, HV, D, gln, mask_p, l2norm, gate, safe_gate, dtype), marks
 _FIXED_CONFIGS = [
-    ((1, 63, 1, 1, 128, 1, 0, False, False, True, torch.bfloat16), _FAST_BWD),  # small fixed backward
+    ((1, 63, 1, 1, 128, 1, 0, False, False, True, torch.bfloat16), _FAST_NR),  # small fixed (+ no_recomp)
     ((2, 500, 3, 3, 128, 1, 0, False, False, True, torch.bfloat16), _SLOW),
     ((2, 1000, 3, 3, 128, 1, 0.5, False, False, True, torch.bfloat16), _SLOW),
     ((3, 1024, 4, 4, 128, 0.1, 0, False, False, True, torch.bfloat16), _SLOW),
     ((4, 1024, 4, 4, 128, 1, 0, False, False, True, torch.bfloat16), _SLOW),
-    ((4, 1024, 4, 4, 128, 1, 0, True, False, True, torch.bfloat16), _FAST_BWD),  # l2norm medium backward
-    ((2, 1500, 4, 4, 128, 10, 0, False, True, True, torch.bfloat16), _FAST_BWD),  # gated backward
+    ((4, 1024, 4, 4, 128, 1, 0, True, False, True, torch.bfloat16), _FAST),  # l2norm medium
+    ((2, 1500, 4, 4, 128, 10, 0, False, True, True, torch.bfloat16), _FAST_NR),  # gated (+ no_recomp)
     ((4, 2048, 8, 8, 128, 1, 0, False, True, True, torch.bfloat16), _SLOW),
     # GVA cases: HV > H
-    ((2, 1024, 4, 8, 128, 1, 0, True, False, True, torch.bfloat16), _FAST_BWD),  # GVA medium backward
+    ((2, 1024, 4, 8, 128, 1, 0, True, False, True, torch.bfloat16), _FAST),  # GVA medium
     ((2, 1500, 2, 4, 128, 10, 0, False, True, True, torch.bfloat16), _SLOW),
     ((2, 2048, 4, 8, 128, 1, 0, False, True, True, torch.bfloat16), _SLOW),
 ]
 
 # (H, HV, D, mask_p, cu_seqlens, dtype, safe_gate), marks
 _VARLEN_CONFIGS = [
-    ((4, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # short varlen smoke (fwd+ht only)
+    ((4, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # short varlen smoke
     ((4, 4, 128, 0.9, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
     ((4, 4, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
-    ((4, 4, 128, 0, [0, 15, 100, 300, 1200, 2000], torch.bfloat16, True), _FAST_BWD),  # multi-batch varlen backward
+    ((4, 4, 128, 0, [0, 15, 100, 300, 1200, 2000], torch.bfloat16, True), _FAST),  # multi-batch varlen
     ((4, 4, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True), _SLOW),
     # ======Varlen test with simulated trace=======
     (
@@ -109,7 +108,7 @@ _VARLEN_CONFIGS = [
         _SLOW,
     ),
     # ======GVA varlen cases: HV > H=======
-    ((2, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # GVA varlen smoke (fwd+ht only)
+    ((2, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # GVA varlen smoke
     ((4, 8, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
     ((4, 8, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True), _SLOW),
     (
@@ -134,13 +133,7 @@ _VARLEN_CONFIGS = [
         pytest.param(torch.bfloat16, id="beta_bf16"),
     ],
 )
-@pytest.mark.parametrize(
-    "disable_recompute",
-    [
-        pytest.param(True, id="no_recomp", marks=pytest.mark.kda_slow),
-        pytest.param(False, id="recomp"),
-    ],
-)
+@pytest.mark.parametrize("disable_recompute", [True, False], ids=["no_recomp", "recomp"])
 @pytest.mark.parametrize(
     (
         "B",
@@ -178,7 +171,6 @@ def test_safe_gate_chunk(
     dtype: torch.dtype,
     disable_recompute: bool,
     beta_dtype: torch.dtype,
-    needs_backward: bool,
 ):
     torch.manual_seed(42)
     q = torch.rand(B, T, H, D, dtype=dtype)
@@ -203,12 +195,11 @@ def test_safe_gate_chunk(
     beta = torch.randn(B, T, HV, dtype=torch.float32).sigmoid().to(beta_dtype)
     h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
     if use_gate_in_kernel:
-        A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(needs_backward), (A_log, dt_bias))
-    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(needs_backward), (q, k, v, g, beta, h0))
+        A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(True), (A_log, dt_bias))
+    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, g, beta, h0))
 
-    if needs_backward:
-        do = torch.randn_like(v)
-        dht = torch.randn_like(h0)
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
 
     ref, ref_ht = naive_recurrent_kda(
         q=F.normalize(q.clone(), p=2, dim=-1),
@@ -219,13 +210,12 @@ def test_safe_gate_chunk(
         initial_state=h0.clone(),
         output_final_state=True,
     )
-    if needs_backward:
-        ((ref * do).sum() + (ref_ht * dht).sum()).backward()
-        if use_gate_in_kernel:
-            ref_dA, A_log.grad = A_log.grad, None
-            ref_dbias, dt_bias.grad = dt_bias.grad, None
-        ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward()
+    if use_gate_in_kernel:
+        ref_dA, A_log.grad = A_log.grad, None
+        ref_dbias, dt_bias.grad = dt_bias.grad, None
+    ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     tri, tri_ht = chunk_kda(
         q=F.normalize(q.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else q.clone(),
@@ -243,19 +233,15 @@ def test_safe_gate_chunk(
         lower_bound=lower_bound,
         disable_recompute=disable_recompute,
     )
-    if needs_backward:
-        ((tri * do).sum() + (tri_ht * dht).sum()).backward()
-        if use_gate_in_kernel:
-            tri_dA, A_log.grad = A_log.grad, None
-            tri_dbias, dt_bias.grad = dt_bias.grad, None
-        tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    ((tri * do).sum() + (tri_ht * dht).sum()).backward()
+    if use_gate_in_kernel:
+        tri_dA, A_log.grad = A_log.grad, None
+        tri_dbias, dt_bias.grad = dt_bias.grad, None
+    tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     assert_close("o", ref, tri, 0.005)
     assert_close("ht", ref_ht, tri_ht, 0.005)
-    if not needs_backward:
-        return
-
     assert_close("dq", ref_dq, tri_dq, 0.008)
     assert_close("dk", ref_dk, tri_dk, 0.008)
     assert_close("dv", ref_dv, tri_dv, 0.008)
@@ -274,13 +260,7 @@ def test_safe_gate_chunk(
         pytest.param(torch.bfloat16, id="beta_bf16"),
     ],
 )
-@pytest.mark.parametrize(
-    "disable_recompute",
-    [
-        pytest.param(True, id="no_recomp", marks=pytest.mark.kda_slow),
-        pytest.param(False, id="recomp"),
-    ],
-)
+@pytest.mark.parametrize("disable_recompute", [True, False], ids=["no_recomp", "recomp"])
 @pytest.mark.parametrize(
     ("H", "HV", "D", "mask_p", "cu_seqlens", "dtype", "safe_gate"),
     [
@@ -302,7 +282,6 @@ def test_safe_gate_chunk_varlen(
     safe_gate: bool,
     disable_recompute: bool,
     beta_dtype: torch.dtype,
-    needs_backward: bool,
 ):
     torch.manual_seed(42)
     cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
@@ -322,10 +301,9 @@ def test_safe_gate_chunk_varlen(
     beta = torch.randn(1, T, HV, dtype=torch.float32).sigmoid().to(beta_dtype)
     h0 = torch.randn((N, HV, D, D), dtype=torch.float32)
 
-    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(needs_backward), (q, k, v, g, beta, h0))
-    if needs_backward:
-        do = torch.randn_like(v)
-        dht = torch.rand_like(h0)
+    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, g, beta, h0))
+    do = torch.randn_like(v)
+    dht = torch.rand_like(h0)
 
     tri, tri_ht = chunk_kda(
         q=F.normalize(q.clone(), p=2, dim=-1),
@@ -341,10 +319,9 @@ def test_safe_gate_chunk_varlen(
         lower_bound=-5.0 if safe_gate else None,
         disable_recompute=disable_recompute,
     )
-    if needs_backward:
-        ((tri * do).sum() + (tri_ht * dht).sum()).backward()
-        tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    ((tri * do).sum() + (tri_ht * dht).sum()).backward()
+    tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     ref = []
     ref_ht = []
@@ -363,15 +340,11 @@ def test_safe_gate_chunk_varlen(
     ref = torch.cat(ref, 1)
     ref_ht = torch.cat(ref_ht, 0)
 
-    if needs_backward:
-        ((ref * do).sum() + (ref_ht * dht).sum()).backward()
-        ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward()
+    ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
 
     assert_close("o", ref, tri, 0.005)
     assert_close("ht", ref_ht, tri_ht, 0.005)
-    if not needs_backward:
-        return
-
     assert_close("dq", ref_dq, tri_dq, 0.007)
     assert_close("dk", ref_dk, tri_dk, 0.008)
     assert_close("dv", ref_dv, tri_dv, 0.007)

--- a/tests/test_kda.py
+++ b/tests/test_kda.py
@@ -203,8 +203,8 @@ def test_safe_gate_chunk(
     beta = torch.randn(B, T, HV, dtype=torch.float32).sigmoid().to(beta_dtype)
     h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
     if use_gate_in_kernel:
-        A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(True), (A_log, dt_bias))
-    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, g, beta, h0))
+        A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(needs_backward), (A_log, dt_bias))
+    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(needs_backward), (q, k, v, g, beta, h0))
 
     if needs_backward:
         do = torch.randn_like(v)
@@ -322,7 +322,7 @@ def test_safe_gate_chunk_varlen(
     beta = torch.randn(1, T, HV, dtype=torch.float32).sigmoid().to(beta_dtype)
     h0 = torch.randn((N, HV, D, D), dtype=torch.float32)
 
-    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, g, beta, h0))
+    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(needs_backward), (q, k, v, g, beta, h0))
     if needs_backward:
         do = torch.randn_like(v)
         dht = torch.rand_like(h0)

--- a/tests/test_kda_compare_fla.py
+++ b/tests/test_kda_compare_fla.py
@@ -16,9 +16,9 @@
 
 # Precision Tests for FlashKDA implementation compared with FLA Triton baseline
 # Test modes (see issue #78):
-#     default:                          fast subset (kda_fast cases only)
-#     pytest -m kda_slow:               slow stress traces and wider parameter grids
-#     pytest -m "kda_fast or kda_slow": full sweep (fast + slow)
+#     default:            fast subset (kda_fast cases only)
+#     pytest -m kda_slow: slow stress traces and wider parameter grids
+#     pytest -m kda_full: full sweep (fast + slow)
 
 import pytest
 import torch

--- a/tests/test_kda_compare_fla.py
+++ b/tests/test_kda_compare_fla.py
@@ -15,11 +15,10 @@
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 
 # Precision Tests for FlashKDA implementation compared with FLA Triton baseline
-"""Test modes (see issue #78):
-    default:                       fast subset (kda_fast cases only)
-    pytest -m kda_slow:            slow stress traces and wider parameter grids
-    pytest -m "kda_fast or kda_slow": full sweep (fast + slow)
-"""
+# Test modes (see issue #78):
+#     default:                          fast subset (kda_fast cases only)
+#     pytest -m kda_slow:               slow stress traces and wider parameter grids
+#     pytest -m "kda_fast or kda_slow": full sweep (fast + slow)
 
 import pytest
 import torch
@@ -32,31 +31,31 @@ from cula.kda import chunk_kda as cula_chunk_kda
 pytestmark = pytest.mark.sm100_only
 
 _FAST = [pytest.mark.kda_fast]
-_FAST_BWD = [pytest.mark.kda_fast, pytest.mark.kda_backward]
+_FAST_NR = [pytest.mark.kda_fast, pytest.mark.kda_fast_norecomp]
 _SLOW = [pytest.mark.kda_slow]
 
 # (B, T, H, HV, D, gln, mask_p, l2norm, gate, safe_gate, dtype), marks
 _FIXED_CONFIGS = [
-    ((1, 63, 1, 1, 128, 1, 0, False, False, True, torch.bfloat16), _FAST_BWD),  # small fixed backward
+    ((1, 63, 1, 1, 128, 1, 0, False, False, True, torch.bfloat16), _FAST_NR),  # small fixed (+ no_recomp)
     ((2, 500, 3, 3, 128, 1, 0, False, False, True, torch.bfloat16), _SLOW),
     ((2, 1000, 3, 3, 128, 1, 0.5, False, False, True, torch.bfloat16), _SLOW),
     ((3, 1024, 4, 4, 128, 0.1, 0, False, False, True, torch.bfloat16), _SLOW),
     ((4, 1024, 4, 4, 128, 1, 0, False, False, True, torch.bfloat16), _SLOW),
-    ((4, 1024, 4, 4, 128, 1, 0, True, False, True, torch.bfloat16), _FAST_BWD),  # l2norm medium backward
-    ((2, 1500, 4, 4, 128, 10, 0, False, True, True, torch.bfloat16), _FAST_BWD),  # gated backward
+    ((4, 1024, 4, 4, 128, 1, 0, True, False, True, torch.bfloat16), _FAST),  # l2norm medium
+    ((2, 1500, 4, 4, 128, 10, 0, False, True, True, torch.bfloat16), _FAST_NR),  # gated (+ no_recomp)
     ((4, 2048, 8, 8, 128, 1, 0, False, True, True, torch.bfloat16), _SLOW),
     # GVA cases: HV > H
-    ((2, 1024, 4, 8, 128, 1, 0, True, False, True, torch.bfloat16), _FAST_BWD),  # GVA medium backward
+    ((2, 1024, 4, 8, 128, 1, 0, True, False, True, torch.bfloat16), _FAST),  # GVA medium
     ((2, 1500, 2, 4, 128, 10, 0, False, True, True, torch.bfloat16), _SLOW),
     ((2, 2048, 4, 8, 128, 1, 0, False, True, True, torch.bfloat16), _SLOW),
 ]
 
 # (H, HV, D, mask_p, cu_seqlens, dtype, safe_gate), marks
 _VARLEN_CONFIGS = [
-    ((4, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # short varlen smoke (fwd+ht only)
+    ((4, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # short varlen smoke
     ((4, 4, 128, 0.9, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
     ((4, 4, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
-    ((4, 4, 128, 0, [0, 15, 100, 300, 1200, 2000], torch.bfloat16, True), _FAST_BWD),  # multi-batch varlen backward
+    ((4, 4, 128, 0, [0, 15, 100, 300, 1200, 2000], torch.bfloat16, True), _FAST),  # multi-batch varlen
     ((4, 4, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True), _SLOW),
     # ======Varlen test with simulated trace=======
     (
@@ -108,7 +107,7 @@ _VARLEN_CONFIGS = [
         _SLOW,
     ),
     # ======GVA varlen cases: HV > H=======
-    ((2, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # GVA varlen smoke (fwd+ht only)
+    ((2, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # GVA varlen smoke
     ((4, 8, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
     ((4, 8, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True), _SLOW),
     (
@@ -133,13 +132,7 @@ _VARLEN_CONFIGS = [
         pytest.param(torch.bfloat16, id="beta_bf16"),
     ],
 )
-@pytest.mark.parametrize(
-    "disable_recompute",
-    [
-        pytest.param(True, id="no_recomp", marks=pytest.mark.kda_slow),
-        pytest.param(False, id="recomp"),
-    ],
-)
+@pytest.mark.parametrize("disable_recompute", [True, False], ids=["no_recomp", "recomp"])
 @pytest.mark.parametrize(
     (
         "B",
@@ -177,7 +170,6 @@ def test_safe_gate_chunk(
     dtype: torch.dtype,
     disable_recompute: bool,
     beta_dtype: torch.dtype,
-    needs_backward: bool,
 ):
     torch.manual_seed(42)
     q = torch.rand(B, T, H, D, dtype=dtype)
@@ -200,12 +192,11 @@ def test_safe_gate_chunk(
     beta = torch.randn(B, T, HV, dtype=torch.float32).sigmoid().to(beta_dtype)
     h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
     if use_gate_in_kernel:
-        A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(needs_backward), (A_log, dt_bias))
-    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(needs_backward), (q, k, v, g, beta, h0))
+        A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(True), (A_log, dt_bias))
+    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, g, beta, h0))
 
-    if needs_backward:
-        do = torch.randn_like(v)
-        dht = torch.randn_like(h0)
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
 
     ref, ref_ht = fla_chunk_kda(
         q=(F.normalize(q.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else q.clone()),
@@ -223,13 +214,12 @@ def test_safe_gate_chunk(
         lower_bound=lower_bound,
         disable_recompute=disable_recompute,
     )
-    if needs_backward:
-        ((ref * do).sum() + (ref_ht * dht).sum()).backward()
-        if use_gate_in_kernel:
-            ref_dA, A_log.grad = A_log.grad, None
-            ref_dbias, dt_bias.grad = dt_bias.grad, None
-        ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward()
+    if use_gate_in_kernel:
+        ref_dA, A_log.grad = A_log.grad, None
+        ref_dbias, dt_bias.grad = dt_bias.grad, None
+    ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     tri, tri_ht = cula_chunk_kda(
         q=(F.normalize(q.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else q.clone()),
@@ -247,19 +237,15 @@ def test_safe_gate_chunk(
         lower_bound=lower_bound,
         disable_recompute=disable_recompute,
     )
-    if needs_backward:
-        ((tri * do).sum() + (tri_ht * dht).sum()).backward()
-        if use_gate_in_kernel:
-            tri_dA, A_log.grad = A_log.grad, None
-            tri_dbias, dt_bias.grad = dt_bias.grad, None
-        tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    ((tri * do).sum() + (tri_ht * dht).sum()).backward()
+    if use_gate_in_kernel:
+        tri_dA, A_log.grad = A_log.grad, None
+        tri_dbias, dt_bias.grad = dt_bias.grad, None
+    tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     assert_close("o", ref, tri, 0.005)
     assert_close("ht", ref_ht, tri_ht, 0.005)
-    if not needs_backward:
-        return
-
     assert_close("dq", ref_dq, tri_dq, 0.008)
     assert_close("dk", ref_dk, tri_dk, 0.008)
     assert_close("dv", ref_dv, tri_dv, 0.008)
@@ -278,13 +264,7 @@ def test_safe_gate_chunk(
         pytest.param(torch.bfloat16, id="beta_bf16"),
     ],
 )
-@pytest.mark.parametrize(
-    "disable_recompute",
-    [
-        pytest.param(True, id="no_recomp", marks=pytest.mark.kda_slow),
-        pytest.param(False, id="recomp"),
-    ],
-)
+@pytest.mark.parametrize("disable_recompute", [True, False], ids=["no_recomp", "recomp"])
 @pytest.mark.parametrize(
     ("H", "HV", "D", "mask_p", "cu_seqlens", "dtype", "safe_gate"),
     [
@@ -306,7 +286,6 @@ def test_safe_gate_chunk_varlen(
     safe_gate: bool,
     disable_recompute: bool,
     beta_dtype: torch.dtype,
-    needs_backward: bool,
 ):
     torch.manual_seed(42)
     cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
@@ -326,10 +305,9 @@ def test_safe_gate_chunk_varlen(
     beta = torch.randn(1, T, HV, dtype=torch.float32).sigmoid().to(beta_dtype)
     h0 = torch.randn((N, HV, D, D), dtype=torch.float32)
 
-    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(needs_backward), (q, k, v, g, beta, h0))
-    if needs_backward:
-        do = torch.randn_like(v)
-        dht = torch.rand_like(h0)
+    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, g, beta, h0))
+    do = torch.randn_like(v)
+    dht = torch.rand_like(h0)
 
     tri, tri_ht = cula_chunk_kda(
         q=F.normalize(q.clone(), p=2, dim=-1),
@@ -345,10 +323,9 @@ def test_safe_gate_chunk_varlen(
         lower_bound=-5.0 if safe_gate else None,
         disable_recompute=disable_recompute,
     )
-    if needs_backward:
-        ((tri * do).sum() + (tri_ht * dht).sum()).backward()
-        tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    ((tri * do).sum() + (tri_ht * dht).sum()).backward()
+    tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     ref, ref_ht = fla_chunk_kda(
         q=F.normalize(q.clone(), p=2, dim=-1),
@@ -364,15 +341,11 @@ def test_safe_gate_chunk_varlen(
         lower_bound=-5.0 if safe_gate else None,
         disable_recompute=disable_recompute,
     )
-    if needs_backward:
-        ((ref * do).sum() + (ref_ht * dht).sum()).backward()
-        ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward()
+    ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
 
     assert_close("o", ref, tri, 0.005)
     assert_close("ht", ref_ht, tri_ht, 0.005)
-    if not needs_backward:
-        return
-
     assert_close("dq", ref_dq, tri_dq, 0.007)
     assert_close("dk", ref_dk, tri_dk, 0.008)
     assert_close("dv", ref_dv, tri_dv, 0.007)

--- a/tests/test_kda_compare_fla.py
+++ b/tests/test_kda_compare_fla.py
@@ -14,7 +14,12 @@
 
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 
-# Precision Tests for FlashKDA implementation compared with FLA Triton baselin
+# Precision Tests for FlashKDA implementation compared with FLA Triton baseline
+"""Test modes (see issue #78):
+    default:                       fast subset (kda_fast cases only)
+    pytest -m kda_slow:            slow stress traces and wider parameter grids
+    pytest -m "kda_fast or kda_slow": full sweep (fast + slow)
+"""
 
 import pytest
 import torch
@@ -26,9 +31,115 @@ from cula.kda import chunk_kda as cula_chunk_kda
 
 pytestmark = pytest.mark.sm100_only
 
+_FAST = [pytest.mark.kda_fast]
+_FAST_BWD = [pytest.mark.kda_fast, pytest.mark.kda_backward]
+_SLOW = [pytest.mark.kda_slow]
 
-@pytest.mark.parametrize("beta_dtype", [torch.float32, torch.bfloat16], ids=["beta_fp32", "beta_bf16"])
-@pytest.mark.parametrize("disable_recompute", [True, False], ids=["no_recomp", "recomp"])
+# (B, T, H, HV, D, gln, mask_p, l2norm, gate, safe_gate, dtype), marks
+_FIXED_CONFIGS = [
+    ((1, 63, 1, 1, 128, 1, 0, False, False, True, torch.bfloat16), _FAST_BWD),  # small fixed backward
+    ((2, 500, 3, 3, 128, 1, 0, False, False, True, torch.bfloat16), _SLOW),
+    ((2, 1000, 3, 3, 128, 1, 0.5, False, False, True, torch.bfloat16), _SLOW),
+    ((3, 1024, 4, 4, 128, 0.1, 0, False, False, True, torch.bfloat16), _SLOW),
+    ((4, 1024, 4, 4, 128, 1, 0, False, False, True, torch.bfloat16), _SLOW),
+    ((4, 1024, 4, 4, 128, 1, 0, True, False, True, torch.bfloat16), _FAST_BWD),  # l2norm medium backward
+    ((2, 1500, 4, 4, 128, 10, 0, False, True, True, torch.bfloat16), _FAST_BWD),  # gated backward
+    ((4, 2048, 8, 8, 128, 1, 0, False, True, True, torch.bfloat16), _SLOW),
+    # GVA cases: HV > H
+    ((2, 1024, 4, 8, 128, 1, 0, True, False, True, torch.bfloat16), _FAST_BWD),  # GVA medium backward
+    ((2, 1500, 2, 4, 128, 10, 0, False, True, True, torch.bfloat16), _SLOW),
+    ((2, 2048, 4, 8, 128, 1, 0, False, True, True, torch.bfloat16), _SLOW),
+]
+
+# (H, HV, D, mask_p, cu_seqlens, dtype, safe_gate), marks
+_VARLEN_CONFIGS = [
+    ((4, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # short varlen smoke (fwd+ht only)
+    ((4, 4, 128, 0.9, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
+    ((4, 4, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
+    ((4, 4, 128, 0, [0, 15, 100, 300, 1200, 2000], torch.bfloat16, True), _FAST_BWD),  # multi-batch varlen backward
+    ((4, 4, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True), _SLOW),
+    # ======Varlen test with simulated trace=======
+    (
+        (
+            32,
+            32,
+            128,
+            0,
+            [0, 247, 699, 982, 1688, 1985, 2383, 3081, 3526, 3973, 4096, 4824, 5101, 5919, 6426, 7137, 7392, 7800, 8192],
+            torch.bfloat16,
+            True,
+        ),
+        _SLOW,
+    ),
+    (
+        (
+            32,
+            32,
+            128,
+            0,
+            [0, 652, 1255, 1600, 2083, 2345, 2756, 3172, 3767, 4096, 4891, 5236, 5543, 6255, 6480, 6947, 7616, 8192],
+            torch.bfloat16,
+            True,
+        ),
+        _SLOW,
+    ),
+    (
+        (
+            32,
+            32,
+            128,
+            0,
+            [0, 315, 973, 1283, 2162, 2459, 2678, 2998, 3781, 4096, 4503, 5459, 6318, 6669, 6979, 7583, 8192],
+            torch.bfloat16,
+            True,
+        ),
+        _SLOW,
+    ),
+    (
+        (
+            32,
+            32,
+            128,
+            0,
+            [0, 494, 1004, 1561, 1908, 2240, 2849, 3116, 4096, 4986, 5626, 6090, 6718, 7244, 7870, 8192],
+            torch.bfloat16,
+            True,
+        ),
+        _SLOW,
+    ),
+    # ======GVA varlen cases: HV > H=======
+    ((2, 4, 128, 0.1, [0, 15], torch.bfloat16, True), _FAST),  # GVA varlen smoke (fwd+ht only)
+    ((4, 8, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True), _SLOW),
+    ((4, 8, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True), _SLOW),
+    (
+        (
+            8,
+            32,
+            128,
+            0,
+            [0, 494, 1004, 1561, 1908, 2240, 2849, 3116, 4096, 4986, 5626, 6090, 6718, 7244, 7870, 8192],
+            torch.bfloat16,
+            True,
+        ),
+        _SLOW,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "beta_dtype",
+    [
+        pytest.param(torch.float32, id="beta_fp32", marks=pytest.mark.kda_slow),
+        pytest.param(torch.bfloat16, id="beta_bf16"),
+    ],
+)
+@pytest.mark.parametrize(
+    "disable_recompute",
+    [
+        pytest.param(True, id="no_recomp", marks=pytest.mark.kda_slow),
+        pytest.param(False, id="recomp"),
+    ],
+)
 @pytest.mark.parametrize(
     (
         "B",
@@ -45,23 +156,11 @@ pytestmark = pytest.mark.sm100_only
     ),
     [
         pytest.param(
-            *test,
-            id="B{}-T{}-H{}-HV{}-D{}-gln{}-mask_p{}-l2norm{}-gate{}-safe_gate{}-{}".format(*test),
+            *params,
+            id="B{}-T{}-H{}-HV{}-D{}-gln{}-mask_p{}-l2norm{}-gate{}-safe_gate{}-{}".format(*params),
+            marks=marks,
         )
-        for test in [
-            (1, 63, 1, 1, 128, 1, 0, False, False, True, torch.bfloat16),
-            (2, 500, 3, 3, 128, 1, 0, False, False, True, torch.bfloat16),
-            (2, 1000, 3, 3, 128, 1, 0.5, False, False, True, torch.bfloat16),
-            (3, 1024, 4, 4, 128, 0.1, 0, False, False, True, torch.bfloat16),
-            (4, 1024, 4, 4, 128, 1, 0, False, False, True, torch.bfloat16),
-            (4, 1024, 4, 4, 128, 1, 0, True, False, True, torch.bfloat16),
-            (2, 1500, 4, 4, 128, 10, 0, False, True, True, torch.bfloat16),
-            (4, 2048, 8, 8, 128, 1, 0, False, True, True, torch.bfloat16),
-            # GVA cases: HV > H
-            (2, 1024, 4, 8, 128, 1, 0, True, False, True, torch.bfloat16),
-            (2, 1500, 2, 4, 128, 10, 0, False, True, True, torch.bfloat16),
-            (2, 2048, 4, 8, 128, 1, 0, False, True, True, torch.bfloat16),
-        ]
+        for params, marks in _FIXED_CONFIGS
     ],
 )
 def test_safe_gate_chunk(
@@ -78,6 +177,7 @@ def test_safe_gate_chunk(
     dtype: torch.dtype,
     disable_recompute: bool,
     beta_dtype: torch.dtype,
+    needs_backward: bool,
 ):
     torch.manual_seed(42)
     q = torch.rand(B, T, H, D, dtype=dtype)
@@ -103,8 +203,9 @@ def test_safe_gate_chunk(
         A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(True), (A_log, dt_bias))
     q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, g, beta, h0))
 
-    do = torch.randn_like(v)
-    dht = torch.randn_like(h0)
+    if needs_backward:
+        do = torch.randn_like(v)
+        dht = torch.randn_like(h0)
 
     ref, ref_ht = fla_chunk_kda(
         q=(F.normalize(q.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else q.clone()),
@@ -122,12 +223,13 @@ def test_safe_gate_chunk(
         lower_bound=lower_bound,
         disable_recompute=disable_recompute,
     )
-    ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
-    if use_gate_in_kernel:
-        ref_dA, A_log.grad = A_log.grad, None
-        ref_dbias, dt_bias.grad = dt_bias.grad, None
-    ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    if needs_backward:
+        ((ref * do).sum() + (ref_ht * dht).sum()).backward()
+        if use_gate_in_kernel:
+            ref_dA, A_log.grad = A_log.grad, None
+            ref_dbias, dt_bias.grad = dt_bias.grad, None
+        ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     tri, tri_ht = cula_chunk_kda(
         q=(F.normalize(q.clone(), p=2, dim=-1) if not use_qk_l2norm_in_kernel else q.clone()),
@@ -145,15 +247,19 @@ def test_safe_gate_chunk(
         lower_bound=lower_bound,
         disable_recompute=disable_recompute,
     )
-    ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
-    if use_gate_in_kernel:
-        tri_dA, A_log.grad = A_log.grad, None
-        tri_dbias, dt_bias.grad = dt_bias.grad, None
-    tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    if needs_backward:
+        ((tri * do).sum() + (tri_ht * dht).sum()).backward()
+        if use_gate_in_kernel:
+            tri_dA, A_log.grad = A_log.grad, None
+            tri_dbias, dt_bias.grad = dt_bias.grad, None
+        tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     assert_close("o", ref, tri, 0.005)
     assert_close("ht", ref_ht, tri_ht, 0.005)
+    if not needs_backward:
+        return
+
     assert_close("dq", ref_dq, tri_dq, 0.008)
     assert_close("dk", ref_dk, tri_dk, 0.008)
     assert_close("dv", ref_dv, tri_dv, 0.008)
@@ -165,69 +271,29 @@ def test_safe_gate_chunk(
     assert_close("dh0", ref_dh0, tri_dh0, 0.008)
 
 
-@pytest.mark.parametrize("beta_dtype", [torch.float32, torch.bfloat16], ids=["beta_fp32", "beta_bf16"])
-@pytest.mark.parametrize("disable_recompute", [True, False], ids=["no_recomp", "recomp"])
+@pytest.mark.parametrize(
+    "beta_dtype",
+    [
+        pytest.param(torch.float32, id="beta_fp32", marks=pytest.mark.kda_slow),
+        pytest.param(torch.bfloat16, id="beta_bf16"),
+    ],
+)
+@pytest.mark.parametrize(
+    "disable_recompute",
+    [
+        pytest.param(True, id="no_recomp", marks=pytest.mark.kda_slow),
+        pytest.param(False, id="recomp"),
+    ],
+)
 @pytest.mark.parametrize(
     ("H", "HV", "D", "mask_p", "cu_seqlens", "dtype", "safe_gate"),
     [
-        pytest.param(*test, id="H{}-HV{}-D{}-mask_p{}-cu_seqlens{}-{}-safe_gate{}".format(*test))
-        for test in [
-            (4, 4, 128, 0.1, [0, 15], torch.bfloat16, True),
-            (4, 4, 128, 0.9, [0, 256, 500, 1000], torch.bfloat16, True),
-            (4, 4, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True),
-            (4, 4, 128, 0, [0, 15, 100, 300, 1200, 2000], torch.bfloat16, True),
-            (4, 4, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True),
-            # ======Varlen test with simulated trace=======
-            (
-                32,
-                32,
-                128,
-                0,
-                [0, 247, 699, 982, 1688, 1985, 2383, 3081, 3526, 3973, 4096, 4824, 5101, 5919, 6426, 7137, 7392, 7800, 8192],
-                torch.bfloat16,
-                True,
-            ),
-            (
-                32,
-                32,
-                128,
-                0,
-                [0, 652, 1255, 1600, 2083, 2345, 2756, 3172, 3767, 4096, 4891, 5236, 5543, 6255, 6480, 6947, 7616, 8192],
-                torch.bfloat16,
-                True,
-            ),
-            (
-                32,
-                32,
-                128,
-                0,
-                [0, 315, 973, 1283, 2162, 2459, 2678, 2998, 3781, 4096, 4503, 5459, 6318, 6669, 6979, 7583, 8192],
-                torch.bfloat16,
-                True,
-            ),
-            (
-                32,
-                32,
-                128,
-                0,
-                [0, 494, 1004, 1561, 1908, 2240, 2849, 3116, 4096, 4986, 5626, 6090, 6718, 7244, 7870, 8192],
-                torch.bfloat16,
-                True,
-            ),
-            # ======GVA varlen cases: HV > H=======
-            (2, 4, 128, 0.1, [0, 15], torch.bfloat16, True),
-            (4, 8, 128, 0.5, [0, 256, 500, 1000], torch.bfloat16, True),
-            (4, 8, 128, 0, [0, 100, 300, 1200, 3000, 4096], torch.bfloat16, True),
-            (
-                8,
-                32,
-                128,
-                0,
-                [0, 494, 1004, 1561, 1908, 2240, 2849, 3116, 4096, 4986, 5626, 6090, 6718, 7244, 7870, 8192],
-                torch.bfloat16,
-                True,
-            ),
-        ]
+        pytest.param(
+            *params,
+            id="H{}-HV{}-D{}-mask_p{}-cu_seqlens{}-{}-safe_gate{}".format(*params),
+            marks=marks,
+        )
+        for params, marks in _VARLEN_CONFIGS
     ],
 )
 def test_safe_gate_chunk_varlen(
@@ -240,6 +306,7 @@ def test_safe_gate_chunk_varlen(
     safe_gate: bool,
     disable_recompute: bool,
     beta_dtype: torch.dtype,
+    needs_backward: bool,
 ):
     torch.manual_seed(42)
     cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
@@ -260,8 +327,9 @@ def test_safe_gate_chunk_varlen(
     h0 = torch.randn((N, HV, D, D), dtype=torch.float32)
 
     q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, g, beta, h0))
-    do = torch.randn_like(v)
-    dht = torch.rand_like(h0)
+    if needs_backward:
+        do = torch.randn_like(v)
+        dht = torch.rand_like(h0)
 
     tri, tri_ht = cula_chunk_kda(
         q=F.normalize(q.clone(), p=2, dim=-1),
@@ -277,9 +345,10 @@ def test_safe_gate_chunk_varlen(
         lower_bound=-5.0 if safe_gate else None,
         disable_recompute=disable_recompute,
     )
-    ((tri * do).sum() + (tri_ht * dht).sum()).backward(retain_graph=True)
-    tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
-    q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
+    if needs_backward:
+        ((tri * do).sum() + (tri_ht * dht).sum()).backward()
+        tri_dq, tri_dk, tri_dv, tri_dg, tri_db, tri_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+        q.grad = k.grad = v.grad = g.grad = beta.grad = h0.grad = None
 
     ref, ref_ht = fla_chunk_kda(
         q=F.normalize(q.clone(), p=2, dim=-1),
@@ -295,11 +364,15 @@ def test_safe_gate_chunk_varlen(
         lower_bound=-5.0 if safe_gate else None,
         disable_recompute=disable_recompute,
     )
-    ((ref * do).sum() + (ref_ht * dht).sum()).backward(retain_graph=True)
-    ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
+    if needs_backward:
+        ((ref * do).sum() + (ref_ht * dht).sum()).backward()
+        ref_dq, ref_dk, ref_dv, ref_dg, ref_db, ref_dh0 = q.grad, k.grad, v.grad, g.grad, beta.grad, h0.grad
 
     assert_close("o", ref, tri, 0.005)
     assert_close("ht", ref_ht, tri_ht, 0.005)
+    if not needs_backward:
+        return
+
     assert_close("dq", ref_dq, tri_dq, 0.007)
     assert_close("dk", ref_dk, tri_dk, 0.008)
     assert_close("dv", ref_dv, tri_dv, 0.007)

--- a/tests/test_kda_compare_fla.py
+++ b/tests/test_kda_compare_fla.py
@@ -200,8 +200,8 @@ def test_safe_gate_chunk(
     beta = torch.randn(B, T, HV, dtype=torch.float32).sigmoid().to(beta_dtype)
     h0 = torch.randn(B, HV, D, D, dtype=torch.float32)
     if use_gate_in_kernel:
-        A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(True), (A_log, dt_bias))
-    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(True), (q, k, v, g, beta, h0))
+        A_log, dt_bias = map(lambda x: x.to(device).requires_grad_(needs_backward), (A_log, dt_bias))
+    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(needs_backward), (q, k, v, g, beta, h0))
 
     if needs_backward:
         do = torch.randn_like(v)
@@ -326,7 +326,7 @@ def test_safe_gate_chunk_varlen(
     beta = torch.randn(1, T, HV, dtype=torch.float32).sigmoid().to(beta_dtype)
     h0 = torch.randn((N, HV, D, D), dtype=torch.float32)
 
-    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(), (q, k, v, g, beta, h0))
+    q, k, v, g, beta, h0 = map(lambda x: x.to(device).requires_grad_(needs_backward), (q, k, v, g, beta, h0))
     if needs_backward:
         do = torch.randn_like(v)
         dht = torch.rand_like(h0)


### PR DESCRIPTION
<!-- PR body for inclusionAI/cuLA — issue #78. Target: main. Head: Longxmas/cuLA_llk:CI_test. -->
<!-- Suggested title: [KDA] split unit tests into fast/slow modes -->

## 📌 Description

### The problem

`test_kda.py` and `test_kda_compare_fla.py` run the full parameter
cross-product on every invocation — the largest `T=8192` varlen traces, both
`beta_dtype` (`bf16` / `fp32`) variants, and both `disable_recompute`
(`recomp` / `no_recomp`) paths. That is 192 cases (96 per file), all with full
backward + gradient checks. Most of that coverage is only needed for nightly /
pre-merge stress runs, yet every local edit and PR-CI invocation pays for it.

### Approach

Split the two suites into **fast** and **slow** modes with pytest markers, so
the default run keeps a small representative correctness set and the broader
stress coverage moves behind an opt-in flag. No kernel, schema, or test-data
changes — only markers, a fixture, and the parameter annotations.

### Markers

- **`kda_fast`** — representative cases that run in the default (fast) mode.
- **`kda_slow`** — deselected by default; opt in with `-m kda_slow` or
  `-m "kda_fast or kda_slow"`. Carries the large traces (`T=8192`) and the full
  parameter grid.
- **`kda_backward`** — fast-mode cases that run full backward + gradient checks
  (cases without it verify forward output `o` and final state `ht` only).

### What changed

- **`conftest.py`**: register the three markers; `pytest_collection_modifyitems`
  deselects `kda_slow` unless the `-m` expression selects it; add a
  `needs_backward` fixture.
- **`test_kda.py` / `test_kda_compare_fla.py`** (mirrored):
  - annotate fixed-length and varlen configs with `kda_fast` / `kda_slow`;
  - mark `beta_dtype=fp32` and `disable_recompute=True` as `kda_slow`, so the
    default run keeps one representative `bf16 × recomp` combination per config;
  - gate backward + gradient asserts behind `needs_backward`;
  - drop unused `retain_graph=True` (each case builds two independent graphs and
    backprops once, so it never took effect);
  - clarify each file's intent in the module header.
- **`README.md`**: document the three run modes.

### Run modes

| command | cases |
|---|---|
| `pytest tests/test_kda.py tests/test_kda_compare_fla.py` | 14 (fast, default) |
| `pytest -m kda_slow tests/...` | 178 (slow subset) |
| `pytest -m "kda_fast or kda_slow" tests/...` | 192 (full sweep) |

The fast set keeps backward coverage on representative paths — small fixed,
in-kernel l2norm, gated, GVA, and multi-batch varlen — plus forward-only checks
on two short-varlen smokes.

## 🔍 Related Issues

Closes [#78](https://github.com/inclusionAI/cuLA/issues/78)

## 🧪 Tests

### Fast (default)

```bash
python -m pytest tests/test_kda.py tests/test_kda_compare_fla.py -v
```

```text
tests/test_kda.py::test_safe_gate_chunk[B1-T63-H1-HV1-D128-gln1-mask_p0-l2normFalse-gateFalse-safe_gateTrue-torch.bfloat16-recomp-beta_bf16] PASSED
tests/test_kda.py::test_safe_gate_chunk[B4-T1024-H4-HV4-D128-gln1-mask_p0-l2normTrue-gateFalse-safe_gateTrue-torch.bfloat16-recomp-beta_bf16] PASSED
tests/test_kda.py::test_safe_gate_chunk[B2-T1500-H4-HV4-D128-gln10-mask_p0-l2normFalse-gateTrue-safe_gateTrue-torch.bfloat16-recomp-beta_bf16] PASSED
tests/test_kda.py::test_safe_gate_chunk[B2-T1024-H4-HV8-D128-gln1-mask_p0-l2normTrue-gateFalse-safe_gateTrue-torch.bfloat16-recomp-beta_bf16] PASSED
tests/test_kda.py::test_safe_gate_chunk_varlen[H4-HV4-D128-mask_p0.1-cu_seqlens[0, 15]-torch.bfloat16-safe_gateTrue-recomp-beta_bf16] PASSED
tests/test_kda.py::test_safe_gate_chunk_varlen[H4-HV4-D128-mask_p0-cu_seqlens[0, 15, 100, 300, 1200, 2000]-torch.bfloat16-safe_gateTrue-recomp-beta_bf16] PASSED
tests/test_kda.py::test_safe_gate_chunk_varlen[H2-HV4-D128-mask_p0.1-cu_seqlens[0, 15]-torch.bfloat16-safe_gateTrue-recomp-beta_bf16] PASSED
tests/test_kda_compare_fla.py::test_safe_gate_chunk[B1-T63-H1-HV1-D128-gln1-mask_p0-l2normFalse-gateFalse-safe_gateTrue-torch.bfloat16-recomp-beta_bf16] PASSED
tests/test_kda_compare_fla.py::test_safe_gate_chunk[B4-T1024-H4-HV4-D128-gln1-mask_p0-l2normTrue-gateFalse-safe_gateTrue-torch.bfloat16-recomp-beta_bf16] PASSED
tests/test_kda_compare_fla.py::test_safe_gate_chunk[B2-T1500-H4-HV4-D128-gln10-mask_p0-l2normFalse-gateTrue-safe_gateTrue-torch.bfloat16-recomp-beta_bf16] PASSED
tests/test_kda_compare_fla.py::test_safe_gate_chunk[B2-T1024-H4-HV8-D128-gln1-mask_p0-l2normTrue-gateFalse-safe_gateTrue-torch.bfloat16-recomp-beta_bf16] PASSED
tests/test_kda_compare_fla.py::test_safe_gate_chunk_varlen[H4-HV4-D128-mask_p0.1-cu_seqlens[0, 15]-torch.bfloat16-safe_gateTrue-recomp-beta_bf16] PASSED
tests/test_kda_compare_fla.py::test_safe_gate_chunk_varlen[H4-HV4-D128-mask_p0-cu_seqlens[0, 15, 100, 300, 1200, 2000]-torch.bfloat16-safe_gateTrue-recomp-beta_bf16] PASSED
tests/test_kda_compare_fla.py::test_safe_gate_chunk_varlen[H2-HV4-D128-mask_p0.1-cu_seqlens[0, 15]-torch.bfloat16-safe_gateTrue-recomp-beta_bf16] PASSED

================== 14 passed, 178 skipped, 1 warning in 29.86s ==================
```

### Full sweep

```bash
python -m pytest -m "kda_fast or kda_slow" tests/test_kda.py tests/test_kda_compare_fla.py -v
```

```text
================== 192 passed, 8 warnings in 377.34s (0:06:17) ==================
```

### Slow subset

```bash
python -m pytest -m kda_slow tests/test_kda.py tests/test_kda_compare_fla.py -v
```

```text
============ 178 passed, 14 deselected, 7 warnings in 390.52s (0:06:30) =========
```

## ⚡ Performance

Default-mode runtime drops from the full sweep's ~377s to ~30s — about a **92%
reduction (~12.6×)** — while the full sweep remains available for pre-merge and
nightly stress runs.

| mode | cases | warm wall-time |
|---|---|---|
| fast (default) | 14 | ~29.9s |
| full sweep | 192 | ~377.3s |
