### PR TITLE
[Fix] Wire cudac bindings

### DIFF
--- a/csrc/api/kda_sm100.cu
+++ b/csrc/api/kda_sm100.cu
@@ -189,9 +189,3 @@ ChunkKDAFwdRecompWU(
 
     kda::sm100::run_kda_fwd_recomp_w_u_sm100(params, at::cuda::getCurrentCUDAStream());
 }
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.doc() = "cuLA SM100/SM103 kernels";
-    m.def("chunk_kda_fwd_intra_cuda", &ChunkKDAFwdIntra);
-    m.def("recompute_w_u_cuda", &ChunkKDAFwdRecompWU);
-}

--- a/csrc/api/kda_sm90.cu
+++ b/csrc/api/kda_sm90.cu
@@ -224,8 +224,3 @@ kda_fwd_prefill(
 
     return {output, output_state};
 }
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.doc() = "cuLA SM90 kernels";
-    m.def("kda_fwd_prefill", &kda_fwd_prefill);
-}

--- a/csrc/api/pybind_sm100.cu
+++ b/csrc/api/pybind_sm100.cu
@@ -1,0 +1,1 @@
+#include "pybind.cu"

--- a/csrc/api/pybind_sm90.cu
+++ b/csrc/api/pybind_sm90.cu
@@ -1,0 +1,1 @@
+#include "pybind.cu"

--- a/setup.py
+++ b/setup.py
@@ -164,15 +164,16 @@ ext_modules = []
 if not DISABLE_SM100 or not DISABLE_SM103:
     sm100_arch_flags = []
     if not DISABLE_SM100:
-        sm100_arch_flags.extend(["-gencode", "arch=compute_100a,code=sm_100a"])
+        sm100_arch_flags.extend(["-gencode", "arch=compute_100a,code=sm_100a", "-DCULA_SM100_ENABLED"])
     if not DISABLE_SM103:
-        sm100_arch_flags.extend(["-gencode", "arch=compute_103a,code=sm_103a"])
+        sm100_arch_flags.extend(["-gencode", "arch=compute_103a,code=sm_103a", "-DCULA_SM103_ENABLED"])
 
     ext_modules.append(
         CUDAExtension(
             name="cula._cudac_sm100",
             sources=[
                 "csrc/api/kda_sm100.cu",
+                "csrc/api/pybind.cu",
                 "csrc/kda/sm100/kda_fwd_sm100.cu",
             ],
             extra_compile_args={
@@ -195,6 +196,7 @@ if not DISABLE_SM90:
             name="cula._cudac_sm90",
             sources=[
                 "csrc/api/kda_sm90.cu",
+                "csrc/api/pybind.cu",
                 "csrc/kda/sm90/kda_fwd_sm90.cu",
                 "csrc/kda/sm90/kda_fwd_sm90_safe_gate.cu",
             ],

--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ if not DISABLE_SM100 or not DISABLE_SM103:
             name="cula._cudac_sm100",
             sources=[
                 "csrc/api/kda_sm100.cu",
-                "csrc/api/pybind.cu",
+                "csrc/api/pybind_sm100.cu",
                 "csrc/kda/sm100/kda_fwd_sm100.cu",
             ],
             extra_compile_args={
@@ -196,7 +196,7 @@ if not DISABLE_SM90:
             name="cula._cudac_sm90",
             sources=[
                 "csrc/api/kda_sm90.cu",
-                "csrc/api/pybind.cu",
+                "csrc/api/pybind_sm90.cu",
                 "csrc/kda/sm90/kda_fwd_sm90.cu",
                 "csrc/kda/sm90/kda_fwd_sm90_safe_gate.cu",
             ],


### PR DESCRIPTION
## 📌 Description

This PR fixes the Python bindings used by `setup.py` builds for the SM90 and SM100/SM103 prefill extensions.

#86 added two optional prefill arguments and moved the binding definitions into `csrc/api/pybind.cu`, where their names and default values are defined. However, that new binding file was not wired into the CUDA extension sources, so source builds still used the legacy unnamed bindings. As a result:

- the basic wrapper failed when the optional arguments were omitted;
- the optimized and CP paths could not pass those arguments by keyword.

This PR wires the shared binding file into both architecture-specific extensions, enables the SM100/SM103 binding guards from `setup.py`, and removes the duplicate legacy `PYBIND11_MODULE` blocks.

**No kernel computation or routing logic is changed.**

## 🔍 Related Issues

Follow-up to #86.

## 🚀 Pull Request Checklist

Thank you for contributing to cuLA! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x]  I have installed `pre-commit` by running `pip install pre-commit` (or used my preferred method).
- [x]  I have installed the hooks with `pre-commit install`.
- [x]  I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

`pre-commit run --all-files` and `git diff --check` both pass.

## 🧪 Tests

- [x]  Tests have been added or updated as needed.
- [ ]  All tests are passing.

Validation performed on an H100:

- Rebuilt the SM90 extension from source.
- Verified both affected call styles reach the kernel:
    - basic wrapper: positional call with optional arguments omitted;
    - optimized/CP wrappers: keyword calls with the optional arguments.
- Ran the SM90 C++ test suites: 113 passed, 1 failed.

The remaining failure is pre-existing and hardware-dependent: `test_cp_bypass_matches_basic[128K + 5×1K, H=8]`. On a 132-SM H100, the CP heuristic engages, while the test table expects a bypass. The assertion fails in a pure-Python precondition before any kernel runs, so it is independent of this binding change.

## ⚡ Performance

Not applicable. This PR only fixes extension binding and build wiring; no kernel computation or routing logic is changed.

## Reviewer Notes

The SM90 and SM100/SM103 extensions now use the shared bindings in `csrc/api/pybind.cu` instead of separate legacy `PYBIND11_MODULE` blocks.