### PR TITLE
[GDN] Add Hopper SM90 CuTe DSL prefill

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,39 @@ print(f'Final state shape: {final_state.shape}')  # [2, 32, 128, 128]
 - `beta` supports both `float32` and `bfloat16`; `initial_state` must be `float32`.
 - `cu_seqlens` (for variable-length sequences) must be `int32`.
 
+### GDN Prefill — Hopper (SM90)
+
+```python
+import torch
+
+from cula.gdn import chunk_gated_delta_rule
+
+q = torch.randn(8, 2, 128, device="cuda", dtype=torch.bfloat16)
+k = torch.randn_like(q)
+v = torch.randn_like(q)
+g = torch.rand(8, 2, device="cuda", dtype=torch.float32) * 0.1 + 0.85
+beta = torch.rand(8, 2, device="cuda", dtype=torch.float32)
+cu_seqlens = torch.tensor([0, 5, 8], device="cuda", dtype=torch.int64)
+
+output, final_state = chunk_gated_delta_rule(
+    q,
+    k,
+    v,
+    g=g,
+    beta=beta,
+    cu_seqlens=cu_seqlens,
+    output_final_state=True,
+)
+```
+
+This path requires compute capability 9.0 and
+`nvidia-cutlass-dsl==4.5.1`. It supports packed MHA, GQA, and GVA with BF16
+Q/K/V, head size 128, and optional FP32 initial/final state. See the
+[GDN SM90 API guide](docs/gdn_sm90_api.md) for the complete contract,
+unsupported behavior, and canonical 28-row benchmark. The
+[GDN SM90 pipeline](docs/gdn_sm90_pipeline.md) documents the kernel's thread
+roles, pipelines, and recurrent-state dataflow.
+
 ## Usage
 
 See [USAGE.md](USAGE.md) for detailed usage examples and notes.
@@ -143,6 +176,9 @@ python benchmarks/generate_benchmark_md.py
 
 # Hopper (SM90)
 python benchmarks/generate_benchmark_hopper_md.py
+
+# GDN prefill — canonical 28-row SM90 matrix
+python benchmarks/bench_gdn_prefill.py --output gdn-sm90-benchmark.json
 ```
 
 ## Tests

--- a/REPO_LAYOUT.md
+++ b/REPO_LAYOUT.md
@@ -18,6 +18,10 @@ cuLA/
 │   │   ├── chunk_bwd.py          # chunk_kda_bwd — Triton + FLA + CuTeDSL + C++ mix
 │   │   └── hopper_fused_fwd.py   # cula_kda_prefill (=kda_prefill_hopper) — SM90 prefill via the C++ kernel (cula.cudac)
 │   │
+│   ├── gdn/                      # GDN packed-varlen PUBLIC API (NO kernels)
+│   │   ├── __init__.py           # chunk_gated_delta_rule public export
+│   │   ├── prefill.py            # validation, output allocation, and dispatch
+│   │
 │   ├── lightning/                # [non-KDA] Lightning Attention operator (LinearAttentionChunkwiseDecay, lightning_attn_fwd, linear_attention_decode)
 │   │   └── __init__.py
 │   │
@@ -43,6 +47,9 @@ cuLA/
 │       │       ├── kda_fully_fused_wip.py   #   KDAChunkwise (~6k lines)
 │       │       └── wrapper.py                #   flash_kda_prefill (dead path; raises on SM100 dispatch)
 │       │
+│       ├── gdn/                  # GDN Python backends — by arch
+│       │   └── sm90/             #   512-thread Hopper WGMMA/TMA implementation
+│       │
 │       ├── lightning/            # [non-KDA] Lightning/linear attention kernels
 │       │   ├── prefill_sm100.py  #   Lightning Attn prefill (LinearAttentionChunkwiseDecay, lightning_attn_fwd[_varlen])
 │       │   └── decode.py         #   linear_attention_decode
@@ -67,6 +74,8 @@ cuLA/
 | Directory | Language | Description |
 |-----------|----------|-------------|
 | `cula/kda/` | Python | KDA **public API only** — autograd + dispatch, no kernels. Two prefill entries: modular chunk `chunk_kda` (SM100) and `kda_prefill_hopper` (SM90, driving the C++ kernel). |
+| `cula/gdn/` | Python | Packed-variable-length GDN prefill **public API only** — validation, output allocation, and dispatch. |
+| `cula/ops/gdn/` | Python (CuTe DSL) | **GDN Python backends**, by architecture: `sm90/` contains the 512-thread Hopper WGMMA/TMA implementation. |
 | `cula/ops/kda/` | Python (CuTe DSL) | **KDA Python backends**, by arch: `sm100/` (+cp), `decode/`, `experimental/`, plus `policy.py` (CP dispatch). |
 | `cula/ops/lightning/` · `cula/ops/experimental/` | Python (CuTe DSL) | `[non-KDA]` Lightning/linear attention kernels. |
 | `cula/ops/{inv,ptx}.py`, `cula/ops/sm100/ptx.py` | Python | Shared low-level helpers (kept in place; not KDA-specific). |

--- a/benchmarks/bench_gdn_prefill.py
+++ b/benchmarks/bench_gdn_prefill.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark the canonical GDN prefill matrix on Hopper SM90.
+
+The default invocation always runs the 10 fixed-length and 18 variable-length
+rows. Compilation/setup latency is recorded separately and is excluded from
+the steady-state CUDA-event measurement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import importlib.metadata
+import json
+import math
+import pathlib
+import platform
+import random
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import torch
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from cula.gdn import (  # noqa: E402
+    chunk_gated_delta_rule,
+    get_sm90_gdn_prefill_backend,
+    get_sm90_gdn_prefill_backend_identity,
+)
+
+HEAD_SIZE = 128
+NUM_HEADS = 64
+DTYPE = torch.bfloat16
+FIXED_BATCHES = (1, 2)
+FIXED_LENGTHS = (512, 1024, 4096, 8192, 16384)
+VARLEN_NUM_SEQS = (10, 20)
+VARLEN_TOTAL_LENGTHS = (4096, 8192, 16384)
+VARLEN_DISTRIBUTIONS = ("uniform", "random", "skewed")
+
+
+@dataclass(frozen=True)
+class BenchmarkRow:
+    row_id: str
+    row_index: int
+    mode: str
+    seq_lens: tuple[int, ...]
+    distribution: str
+    batch_size: int | None
+    seq_len: int | None
+    num_seqs: int
+    total_tokens: int
+
+
+def _exclusive_cumsum(values: tuple[int, ...]) -> list[int]:
+    result = [0]
+    for value in values:
+        result.append(result[-1] + value)
+    return result
+
+
+def _uniform_seq_lens(num_seqs: int, total_len: int) -> tuple[int, ...]:
+    base, remainder = divmod(total_len, num_seqs)
+    return tuple(base + (index < remainder) for index in range(num_seqs))
+
+
+def _random_seq_lens(num_seqs: int, total_len: int, seed: int) -> tuple[int, ...]:
+    rng = random.Random(seed)
+    cuts = sorted(rng.sample(range(1, total_len), num_seqs - 1))
+    return tuple(end - start for start, end in zip([0, *cuts], [*cuts, total_len]))
+
+
+def _skewed_seq_lens(num_seqs: int, total_len: int) -> tuple[int, ...]:
+    remaining = total_len - num_seqs
+    weights = tuple((num_seqs - index) ** 2 for index in range(num_seqs))
+    weight_sum = sum(weights)
+    lengths = [1 + remaining * weight // weight_sum for weight in weights]
+    lengths[0] += total_len - sum(lengths)
+    return tuple(lengths)
+
+
+def _varlen_seq_lens(distribution: str, num_seqs: int, total_len: int, seed: int) -> tuple[int, ...]:
+    if distribution == "uniform":
+        return _uniform_seq_lens(num_seqs, total_len)
+    if distribution == "random":
+        return _random_seq_lens(num_seqs, total_len, seed)
+    if distribution == "skewed":
+        return _skewed_seq_lens(num_seqs, total_len)
+    raise ValueError(f"unknown distribution: {distribution}")
+
+
+def build_gdn_prefill_matrix(base_seed: int) -> tuple[BenchmarkRow, ...]:
+    """Return the immutable canonical 28-row workload."""
+
+    rows: list[BenchmarkRow] = []
+    for batch_size in FIXED_BATCHES:
+        for seq_len in FIXED_LENGTHS:
+            index = len(rows)
+            rows.append(
+                BenchmarkRow(
+                    row_id=f"fixed-b{batch_size}-t{seq_len}",
+                    row_index=index,
+                    mode="fixed",
+                    seq_lens=(seq_len,) * batch_size,
+                    distribution="-",
+                    batch_size=batch_size,
+                    seq_len=seq_len,
+                    num_seqs=batch_size,
+                    total_tokens=batch_size * seq_len,
+                ),
+            )
+    for num_seqs in VARLEN_NUM_SEQS:
+        for total_len in VARLEN_TOTAL_LENGTHS:
+            for distribution in VARLEN_DISTRIBUTIONS:
+                index = len(rows)
+                rows.append(
+                    BenchmarkRow(
+                        row_id=f"varlen-n{num_seqs}-t{total_len}-{distribution}",
+                        row_index=index,
+                        mode="varlen",
+                        seq_lens=_varlen_seq_lens(distribution, num_seqs, total_len, base_seed + index),
+                        distribution=distribution,
+                        batch_size=None,
+                        seq_len=None,
+                        num_seqs=num_seqs,
+                        total_tokens=total_len,
+                    ),
+                )
+    if len(rows) != 28 or len({row.row_id for row in rows}) != 28:
+        raise AssertionError("GDN prefill benchmark must contain exactly 28 unique rows")
+    return tuple(rows)
+
+
+def _tensor_sha256(tensor: torch.Tensor) -> str:
+    byte_tensor = tensor.detach().contiguous().view(torch.uint8)
+    if byte_tensor.is_cuda:
+        byte_tensor = byte_tensor.cpu()
+    return hashlib.sha256(memoryview(byte_tensor.numpy())).hexdigest()
+
+
+def _make_inputs(row: BenchmarkRow, base_seed: int, device: torch.device) -> dict[str, torch.Tensor]:
+    row_seed = base_seed + row.row_index
+    generator = torch.Generator(device="cpu").manual_seed(row_seed)
+    shape = (row.total_tokens, NUM_HEADS, HEAD_SIZE)
+    gate_shape = (row.total_tokens, NUM_HEADS)
+    cpu_inputs = {
+        "q": (torch.randn(shape, generator=generator) * 0.03).to(DTYPE),
+        "k": (torch.randn(shape, generator=generator) * 0.01).to(DTYPE),
+        "v": (torch.randn(shape, generator=generator) * 0.1).to(DTYPE),
+        "g": torch.rand(gate_shape, generator=generator, dtype=torch.float32) * 0.1 + 0.85,
+        "beta": torch.rand(gate_shape, generator=generator, dtype=torch.float32) * 0.5,
+        "cu_seqlens": torch.tensor(_exclusive_cumsum(row.seq_lens), dtype=torch.int64),
+    }
+    cpu_hashes = {name: _tensor_sha256(tensor) for name, tensor in cpu_inputs.items()}
+    inputs = {name: tensor.to(device=device) for name, tensor in cpu_inputs.items()}
+    torch.cuda.synchronize(device)
+    cuda_hashes = {name: _tensor_sha256(tensor) for name, tensor in inputs.items()}
+    if cpu_hashes != cuda_hashes:
+        raise AssertionError(f"CPU/CUDA input bytes differ for {row.row_id}")
+    return inputs
+
+
+def _call_kernel(inputs: dict[str, torch.Tensor], output: torch.Tensor) -> torch.Tensor:
+    result = chunk_gated_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        g=inputs["g"],
+        beta=inputs["beta"],
+        scale=1.0 / math.sqrt(HEAD_SIZE),
+        cu_seqlens=inputs["cu_seqlens"],
+        output=output,
+    )
+    if isinstance(result, tuple) or result.data_ptr() != output.data_ptr():
+        raise RuntimeError("GDN benchmark requires the preallocated output path without final state")
+    return result
+
+
+def _measure_row(
+    row: BenchmarkRow,
+    *,
+    seed: int,
+    warmup: int,
+    iterations: int,
+    device: torch.device,
+) -> dict[str, Any]:
+    inputs = _make_inputs(row, seed, device)
+    output = torch.empty((row.total_tokens, NUM_HEADS, HEAD_SIZE), dtype=DTYPE, device=device)
+
+    setup_start = time.perf_counter()
+    _call_kernel(inputs, output)
+    torch.cuda.synchronize(device)
+    setup_ms = (time.perf_counter() - setup_start) * 1000.0
+
+    for _ in range(warmup):
+        _call_kernel(inputs, output)
+    torch.cuda.synchronize(device)
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        _call_kernel(inputs, output)
+    end.record()
+    end.synchronize()
+    latency_ms = start.elapsed_time(end) / iterations
+
+    if not bool(torch.isfinite(output).all()) or float(output.float().abs().sum().item()) == 0.0:
+        raise AssertionError(f"invalid output for {row.row_id}")
+    return {
+        **asdict(row),
+        "seq_lens": list(row.seq_lens),
+        "setup_ms_excluded": setup_ms,
+        "warmup": warmup,
+        "iterations": iterations,
+        "latency_ms": latency_ms,
+        "output_sha256": _tensor_sha256(output),
+        "status": "PASS",
+    }
+
+
+def _git_source() -> dict[str, Any]:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        dirty = (
+            subprocess.run(
+                ["git", "diff", "--quiet"],
+                cwd=REPO_ROOT,
+                check=False,
+            ).returncode
+            != 0
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        commit, dirty = None, None
+    return {
+        "repo_root": str(REPO_ROOT),
+        "commit": commit,
+        "tracked_worktree_dirty": dirty,
+        "backend": get_sm90_gdn_prefill_backend(),
+        "backend_identity": get_sm90_gdn_prefill_backend_identity(),
+    }
+
+
+def _environment(device: torch.device) -> dict[str, Any]:
+    props = torch.cuda.get_device_properties(device)
+    return {
+        "captured_at_utc": dt.datetime.now(dt.UTC).isoformat(),
+        "hostname": platform.node(),
+        "python": sys.version,
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda,
+        "cutlass_dsl": importlib.metadata.version("nvidia-cutlass-dsl"),
+        "device": device.index,
+        "gpu_name": props.name,
+        "compute_capability": [props.major, props.minor],
+    }
+
+
+def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--output", type=pathlib.Path, default=pathlib.Path("gdn-sm90-benchmark.json"))
+    parser.add_argument("--list-matrix", action="store_true")
+    args = parser.parse_args()
+    if args.warmup < 0 or args.iterations <= 0:
+        parser.error("--warmup must be non-negative and --iterations must be positive")
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    matrix = build_gdn_prefill_matrix(args.seed)
+    if args.list_matrix:
+        print(json.dumps([asdict(row) for row in matrix], indent=2))
+        return
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required")
+    device = torch.device("cuda", args.device)
+    if torch.cuda.get_device_capability(device) != (9, 0):
+        raise SystemExit(f"GDN prefill requires SM90, got {torch.cuda.get_device_capability(device)}")
+
+    record: dict[str, Any] = {
+        "schema": "cula.gdn.sm90.benchmark.v1",
+        "status": "RUNNING",
+        "protocol": {
+            "matrix_rows": 28,
+            "fixed_rows": 10,
+            "varlen_rows": 18,
+            "heads": [NUM_HEADS, NUM_HEADS, NUM_HEADS],
+            "head_size": HEAD_SIZE,
+            "dtype": str(DTYPE),
+            "seed": args.seed,
+            "warmup": args.warmup,
+            "iterations": args.iterations,
+            "statistic": "CUDA-event mean",
+            "compile_and_setup_excluded": True,
+        },
+        "source": _git_source(),
+        "environment": _environment(device),
+        "rows": [],
+    }
+    for position, row in enumerate(matrix, 1):
+        print(f"[{position:02d}/28] {row.row_id}", flush=True)
+        result = _measure_row(
+            row,
+            seed=args.seed,
+            warmup=args.warmup,
+            iterations=args.iterations,
+            device=device,
+        )
+        record["rows"].append(result)
+        print(f"  {result['latency_ms']:.6f} ms", flush=True)
+
+    record["status"] = "PASS"
+    record["coverage"] = "28/28"
+    _write_json(args.output, record)
+    print(f"GDN_SM90_BENCHMARK_PASS output={args.output}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/cula/gdn/__init__.py
+++ b/cula/gdn/__init__.py
@@ -1,0 +1,15 @@
+"""Public GDN operators."""
+
+from .prefill import (
+    chunk_gated_delta_rule,
+    get_sm90_gdn_prefill_backend,
+    get_sm90_gdn_prefill_backend_identity,
+    is_sm90_gdn_prefill_available,
+)
+
+__all__ = [
+    "chunk_gated_delta_rule",
+    "get_sm90_gdn_prefill_backend",
+    "get_sm90_gdn_prefill_backend_identity",
+    "is_sm90_gdn_prefill_available",
+]

--- a/cula/gdn/prefill.py
+++ b/cula/gdn/prefill.py
@@ -1,0 +1,413 @@
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public packed-varlen GDN prefill API for NVIDIA Hopper SM90."""
+
+from __future__ import annotations
+
+import functools
+import importlib.metadata
+import math
+from dataclasses import dataclass
+
+import torch
+
+from cula.ops.gdn.sm90.config import (
+    CHUNK_SIZE,
+    EXPECTED_CUTLASS_DSL_VERSION,
+    HEAD_SIZE,
+    SM90_BACKEND_ID,
+    classify_head_mode,
+)
+
+__all__ = [
+    "chunk_gated_delta_rule",
+    "get_sm90_gdn_prefill_backend",
+    "get_sm90_gdn_prefill_backend_identity",
+    "is_sm90_gdn_prefill_available",
+]
+
+_INT32_MAX = 2**31 - 1
+_TMA_ALIGNMENT = 16
+
+
+@dataclass(frozen=True)
+class _GDNPrefillInputs:
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    alpha: torch.Tensor
+    beta: torch.Tensor
+    output: torch.Tensor
+    initial_state: torch.Tensor | None
+    output_state: torch.Tensor | None
+    cu_seqlens: torch.Tensor
+    num_seqs: int
+    scale: float
+
+
+@functools.cache
+def _installed_cutlass_dsl_version() -> str | None:
+    try:
+        return importlib.metadata.version("nvidia-cutlass-dsl")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def get_sm90_gdn_prefill_backend() -> str:
+    """Return the production backend selected for SM90 GDN prefill.
+
+    Returns:
+        The backend name ``"dsl"``.
+    """
+
+    return "dsl"
+
+
+def get_sm90_gdn_prefill_backend_identity() -> str:
+    """Return the implementation identity used by the SM90 dispatch.
+
+    Returns:
+        A stable identifier for the SM90 CuTe DSL implementation.
+    """
+
+    return SM90_BACKEND_ID
+
+
+def is_sm90_gdn_prefill_available(
+    device: torch.device | int | str | None = None,
+) -> bool:
+    """Check whether SM90 GDN prefill is available on a device.
+
+    Args:
+        device: CUDA device to query. ``None`` selects the current CUDA device.
+
+    Returns:
+        ``True`` when the device has compute capability 9.0 and the required
+        CuTe DSL version is installed; otherwise ``False``.
+    """
+
+    if device is not None and not isinstance(device, int):
+        device = torch.device(device)
+        if device.type != "cuda":
+            return False
+    if not torch.cuda.is_available():
+        return False
+    if device is None:
+        device = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(device)
+    if (props.major, props.minor) != (9, 0):
+        return False
+    return _installed_cutlass_dsl_version() == EXPECTED_CUTLASS_DSL_VERSION
+
+
+def _check_tensor(
+    name: str,
+    tensor: torch.Tensor,
+    *,
+    device: torch.device,
+    ndim: int,
+    dtype: torch.dtype | tuple[torch.dtype, ...],
+) -> None:
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor")
+    if not tensor.is_cuda:
+        raise ValueError(f"{name} must be a CUDA tensor")
+    if tensor.device != device:
+        raise ValueError(f"{name} must be on {device}, got {tensor.device}")
+    if tensor.ndim != ndim:
+        raise ValueError(f"{name} must be rank {ndim}, got shape {tuple(tensor.shape)}")
+    valid_dtypes = dtype if isinstance(dtype, tuple) else (dtype,)
+    if tensor.dtype not in valid_dtypes:
+        expected = ", ".join(str(item) for item in valid_dtypes)
+        raise TypeError(f"{name} must use {expected}, got {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    if tensor.data_ptr() % _TMA_ALIGNMENT != 0:
+        raise ValueError(f"{name} data pointer must be {_TMA_ALIGNMENT}-byte aligned")
+
+
+def _check_cu_seqlens_metadata(
+    cu_seqlens: torch.Tensor | None,
+    *,
+    device: torch.device,
+) -> int:
+    if cu_seqlens is None:
+        raise ValueError("cu_seqlens is required for packed-varlen GDN prefill")
+    _check_tensor(
+        "cu_seqlens",
+        cu_seqlens,
+        device=device,
+        ndim=1,
+        dtype=(torch.int32, torch.int64),
+    )
+    if cu_seqlens.numel() < 2:
+        raise ValueError("cu_seqlens must contain at least [0, total_tokens]")
+    return cu_seqlens.numel() - 1
+
+
+def _validate_device_contents(
+    cu_seqlens: torch.Tensor,
+    alpha: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    total_tokens: int,
+) -> None:
+    """Synchronously validate CUDA-resident values for explicit diagnostics."""
+
+    offsets = tuple(int(value) for value in cu_seqlens.detach().cpu().tolist())
+    if offsets[0] != 0:
+        raise ValueError(f"cu_seqlens[0] must be 0, got {offsets[0]}")
+    if offsets[-1] != total_tokens:
+        raise ValueError(
+            f"cu_seqlens[-1] must equal total_tokens={total_tokens}, got {offsets[-1]}",
+        )
+    if offsets[-1] > _INT32_MAX:
+        raise ValueError(f"packed token count must not exceed {_INT32_MAX}")
+
+    seq_lens = tuple(end - start for start, end in zip(offsets, offsets[1:]))
+    if any(length <= 0 for length in seq_lens):
+        raise ValueError("zero-length or decreasing sequences are outside the SM90 GDN contract")
+    if not bool(torch.isfinite(alpha).all()) or not bool((alpha > 0).all()):
+        raise ValueError("g must contain finite, strictly positive forget factors")
+    if not bool(torch.isfinite(beta).all()):
+        raise ValueError("beta must contain finite update factors")
+
+
+def _prepare_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    alpha: torch.Tensor | None,
+    beta: torch.Tensor | None,
+    scale: float | None,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None,
+    output: torch.Tensor | None,
+    output_state: torch.Tensor | None,
+    state_checkpoints: torch.Tensor | None,
+    checkpoint_cu_starts: torch.Tensor | None,
+    checkpoint_every_n_tokens: int,
+    use_qk_l2norm_in_kernel: bool,
+    validate_inputs: bool,
+) -> _GDNPrefillInputs:
+    device = q.device if isinstance(q, torch.Tensor) else torch.device("cuda")
+    _check_tensor("q", q, device=device, ndim=3, dtype=torch.bfloat16)
+    _check_tensor("k", k, device=device, ndim=3, dtype=torch.bfloat16)
+    _check_tensor("v", v, device=device, ndim=3, dtype=torch.bfloat16)
+
+    if use_qk_l2norm_in_kernel:
+        raise NotImplementedError("SM90 GDN does not normalize Q/K inside the kernel")
+    if checkpoint_every_n_tokens < 0:
+        raise ValueError("checkpoint_every_n_tokens must be non-negative")
+    if checkpoint_every_n_tokens % CHUNK_SIZE != 0:
+        raise ValueError(f"checkpoint_every_n_tokens must be a multiple of {CHUNK_SIZE}")
+    if checkpoint_every_n_tokens or state_checkpoints is not None or checkpoint_cu_starts is not None:
+        raise NotImplementedError("SM90 GDN state checkpoints are not implemented")
+
+    total_tokens, num_q_heads, head_size = q.shape
+    if not 0 < total_tokens <= _INT32_MAX:
+        raise ValueError(f"packed token count must be in [1, {_INT32_MAX}]")
+    if k.shape[0] != total_tokens or v.shape[0] != total_tokens:
+        raise ValueError("q, k, and v must share the packed token dimension")
+    if q.shape[2] != HEAD_SIZE or k.shape[2] != HEAD_SIZE or v.shape[2] != HEAD_SIZE:
+        raise ValueError(f"q, k, and v head size must be {HEAD_SIZE}")
+    num_k_heads = k.shape[1]
+    num_v_heads = v.shape[1]
+    classify_head_mode(num_q_heads, num_k_heads, num_v_heads)
+    num_o_heads = max(num_q_heads, num_v_heads)
+    num_seqs = _check_cu_seqlens_metadata(
+        cu_seqlens,
+        device=device,
+    )
+
+    gate_shape = (total_tokens, num_o_heads)
+    if alpha is None:
+        alpha = torch.ones(gate_shape, dtype=torch.float32, device=device)
+    else:
+        _check_tensor("g", alpha, device=device, ndim=2, dtype=torch.float32)
+        if tuple(alpha.shape) != gate_shape:
+            raise ValueError(f"g must have shape {gate_shape}, got {tuple(alpha.shape)}")
+
+    if beta is None:
+        beta = torch.ones(gate_shape, dtype=torch.float32, device=device)
+    else:
+        _check_tensor("beta", beta, device=device, ndim=2, dtype=torch.float32)
+        if tuple(beta.shape) != gate_shape:
+            raise ValueError(f"beta must have shape {gate_shape}, got {tuple(beta.shape)}")
+
+    if not isinstance(validate_inputs, bool):
+        raise TypeError(f"validate_inputs must be a bool, got {type(validate_inputs).__name__}")
+    if validate_inputs:
+        _validate_device_contents(
+            cu_seqlens,
+            alpha,
+            beta,
+            total_tokens=total_tokens,
+        )
+
+    output_shape = (total_tokens, num_o_heads, head_size)
+    if output is None:
+        output = torch.empty(output_shape, dtype=torch.bfloat16, device=device)
+    else:
+        _check_tensor("output", output, device=device, ndim=3, dtype=torch.bfloat16)
+        if tuple(output.shape) != output_shape:
+            raise ValueError(f"output must have shape {output_shape}, got {tuple(output.shape)}")
+
+    state_shape = (num_seqs, num_o_heads, head_size, head_size)
+    if initial_state is not None:
+        _check_tensor(
+            "initial_state",
+            initial_state,
+            device=device,
+            ndim=4,
+            dtype=torch.float32,
+        )
+        if tuple(initial_state.shape) != state_shape:
+            raise ValueError(
+                f"initial_state must have [sequence, output_head, V, K] shape {state_shape}, got {tuple(initial_state.shape)}",
+            )
+
+    if output_state is not None and not output_final_state:
+        raise ValueError("output_state requires output_final_state=True")
+    if output_final_state and output_state is None:
+        output_state = torch.empty(state_shape, dtype=torch.float32, device=device)
+    elif output_state is not None:
+        _check_tensor(
+            "output_state",
+            output_state,
+            device=device,
+            ndim=4,
+            dtype=torch.float32,
+        )
+        if tuple(output_state.shape) != state_shape:
+            raise ValueError(
+                f"output_state must have [sequence, output_head, V, K] shape {state_shape}, got {tuple(output_state.shape)}",
+            )
+
+    scale_value = 1.0 / math.sqrt(head_size) if scale is None or scale == 0.0 else float(scale)
+    if not math.isfinite(scale_value):
+        raise ValueError(f"scale must be finite, got {scale_value}")
+    return _GDNPrefillInputs(
+        q=q,
+        k=k,
+        v=v,
+        alpha=alpha,
+        beta=beta,
+        output=output,
+        initial_state=initial_state,
+        output_state=output_state,
+        cu_seqlens=cu_seqlens,
+        num_seqs=num_seqs,
+        scale=scale_value,
+    )
+
+
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor | None = None,
+    beta: torch.Tensor | None = None,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: torch.Tensor | None = None,
+    output_state: torch.Tensor | None = None,
+    state_checkpoints: torch.Tensor | None = None,
+    checkpoint_cu_starts: torch.Tensor | None = None,
+    checkpoint_every_n_tokens: int = 0,
+    validate_inputs: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Run packed variable-length GDN prefill on Hopper SM90.
+
+    Args:
+        q: Contiguous BF16 queries with shape
+            ``[total_tokens, num_q_heads, 128]``.
+        k: Contiguous BF16 keys with shape
+            ``[total_tokens, num_k_heads, 128]``.
+        v: Contiguous BF16 values with shape
+            ``[total_tokens, num_v_heads, 128]``.
+        g: Optional FP32 forget factors with shape
+            ``[total_tokens, num_output_heads]``. Values must be finite and
+            strictly positive. ``None`` uses ones.
+        beta: Optional FP32 update factors with shape
+            ``[total_tokens, num_output_heads]``. Values must be finite.
+            ``None`` uses ones.
+        scale: Attention scale. ``None`` or ``0`` uses ``1 / sqrt(128)``.
+        initial_state: Optional FP32 state with shape
+            ``[num_sequences, num_output_heads, 128, 128]`` in public
+            ``[V, K]`` orientation.
+        output_final_state: Whether to return the final recurrent state.
+        cu_seqlens: CUDA INT32 or INT64 cumulative sequence lengths with shape
+            ``[num_sequences + 1]``. Every sequence must contain at least one
+            token.
+        use_qk_l2norm_in_kernel: Must be ``False``; in-kernel Q/K L2
+            normalization is unsupported.
+        output: Optional preallocated contiguous BF16 output with shape
+            ``[total_tokens, num_output_heads, 128]``.
+        output_state: Optional preallocated contiguous FP32 final-state buffer
+            with shape ``[num_sequences, num_output_heads, 128, 128]``.
+        state_checkpoints: Must be ``None``; intermediate state checkpoints are
+            unsupported.
+        checkpoint_cu_starts: Must be ``None``; intermediate state checkpoints
+            are unsupported.
+        checkpoint_every_n_tokens: Must be ``0``; intermediate state
+            checkpoints are unsupported.
+        validate_inputs: Whether to synchronously copy and validate
+            CUDA-resident sequence offsets and gate values. Leave disabled on
+            latency-sensitive paths.
+
+    Returns:
+        The BF16 output tensor, or ``(output, final_state)`` when
+        ``output_final_state=True``.
+
+    Raises:
+        TypeError: If an input has an unsupported type or dtype.
+        ValueError: If an input shape, layout, device, or value contract is
+            invalid.
+        NotImplementedError: If an unsupported normalization or checkpoint
+            option is requested.
+        RuntimeError: If the GPU or CuTe DSL runtime does not satisfy the SM90
+            backend requirements.
+    """
+
+    inputs = _prepare_inputs(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale,
+        initial_state,
+        output_final_state,
+        cu_seqlens,
+        output,
+        output_state,
+        state_checkpoints,
+        checkpoint_cu_starts,
+        checkpoint_every_n_tokens,
+        use_qk_l2norm_in_kernel,
+        validate_inputs,
+    )
+    props = torch.cuda.get_device_properties(inputs.q.device)
+    if (props.major, props.minor) != (9, 0):
+        raise RuntimeError(
+            f"SM90 GDN requires compute capability 9.0, got {props.major}.{props.minor}",
+        )
+    installed = _installed_cutlass_dsl_version()
+    if installed != EXPECTED_CUTLASS_DSL_VERSION:
+        raise RuntimeError(
+            f"SM90 GDN requires nvidia-cutlass-dsl=={EXPECTED_CUTLASS_DSL_VERSION}, found {installed}",
+        )
+
+    from cula.ops.gdn.sm90.launch import launch_sm90_gdn_prefill
+
+    launch_sm90_gdn_prefill(inputs)
+    if output_final_state:
+        assert inputs.output_state is not None
+        return inputs.output, inputs.output_state
+    return inputs.output

--- a/cula/ops/gdn/__init__.py
+++ b/cula/ops/gdn/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private GDN backend kernels."""

--- a/cula/ops/gdn/sm90/__init__.py
+++ b/cula/ops/gdn/sm90/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private Hopper implementation for the public GDN prefill API."""

--- a/cula/ops/gdn/sm90/alpha.py
+++ b/cula/ops/gdn/sm90/alpha.py
@@ -1,0 +1,60 @@
+# Copyright 2025-2026 FlashInfer team.
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import cutlass
+import cutlass.cute as cute
+
+# ─── AlphaProcessor ──────────────────────────────────────────────────────────
+# Computes alpha prefix products and scale channels for one chunk.
+
+
+class AlphaProcessor:
+    CUMSUM_LOG = 0
+    CUMPROD = 1
+    CUMPROD_SCALE = 2
+    CUMPROD_NEG_END_RCP = 2
+    NUM_CHANNELS = 3
+
+    @cute.jit
+    def run(
+        self,
+        vecs: cute.Tensor,
+        scale: cutlass.Float32,
+        channel2_neg_end_rcp: cutlass.Constexpr = False,
+    ):
+        WARP_SIZE = 32
+        blk_q = cute.size(vecs.shape[0])
+        num_iters = blk_q // WARP_SIZE
+
+        lane_id = cute.arch.lane_idx()
+
+        # vecs shape (blk_q, NUM_CHANNELS) col-major.
+        vecs_32 = cute.flat_divide(vecs, (WARP_SIZE,))
+
+        frag = cute.make_rmem_tensor(num_iters, cutlass.Float32)
+        for i in cutlass.range_constexpr(num_iters):
+            raw = cutlass.Float32(vecs_32[lane_id, i, AlphaProcessor.CUMSUM_LOG])
+            frag[i] = cute.math.log2(raw + cutlass.Float32(1e-10), fastmath=True)
+
+        for log_off in cutlass.range_constexpr(5):  # offsets 1, 2, 4, 8, 16
+            off = 1 << log_off
+            for i in cutlass.range_constexpr(num_iters):
+                v = cute.arch.shuffle_sync_up(frag[i], off, mask_and_clamp=0)
+                if lane_id >= off:
+                    frag[i] = frag[i] + v
+
+        for i in cutlass.range_constexpr(1, num_iters):
+            carry = cute.arch.shuffle_sync(frag[i - 1], 31)
+            frag[i] = frag[i] + carry
+
+        if cutlass.const_expr(channel2_neg_end_rcp):
+            end_log = cute.arch.shuffle_sync(frag[num_iters - 1], 31)
+        for i in cutlass.range_constexpr(num_iters):
+            vecs_32[lane_id, i, AlphaProcessor.CUMSUM_LOG] = frag[i]
+            cumprod = cute.math.exp2(frag[i], fastmath=True)
+            vecs_32[lane_id, i, AlphaProcessor.CUMPROD] = cumprod
+            if cutlass.const_expr(channel2_neg_end_rcp):
+                vecs_32[lane_id, i, AlphaProcessor.CUMPROD_NEG_END_RCP] = -cute.math.exp2(end_log - frag[i], fastmath=True)
+            else:
+                vecs_32[lane_id, i, AlphaProcessor.CUMPROD_SCALE] = cumprod * scale

--- a/cula/ops/gdn/sm90/collective_inverse_hmma.py
+++ b/cula/ops/gdn/sm90/collective_inverse_hmma.py
@@ -1,0 +1,370 @@
+# Copyright 2025-2026 FlashInfer team.
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import warp
+
+from .helpers import SM80, select_tensor_10
+
+# ─── CollectiveInverse ───────────────────────────────────────────────────────
+# Inverts a 64×64 lower-triangular smem matrix in-place (I + lower_tril(K)).
+# Warp group: 128 threads (4 warps). Layout of sT: (64,64) col-major.
+
+
+class CollectiveInverse:
+    def __init__(
+        self,
+        garbage_filled_diagonal: bool = True,
+        garbage_filled_upper_triangular: bool = False,
+    ):
+        self.garbage_filled_diagonal = garbage_filled_diagonal
+        self.garbage_filled_upper_triangular = garbage_filled_upper_triangular
+
+    # ── Level 1: NxN Gauss elimination on diagonal blocks ───────────────────────
+
+    @cute.jit
+    def compute_diagonal_block_inverse(
+        self,
+        mat: cute.Tensor,
+        tid_in_group: cutlass.Int32,
+        block_size: cutlass.Constexpr,
+    ):
+        """Invert one square lower-triangular block in place.
+
+        One row is assigned to each participating thread.
+        """
+        shuffle_mask = (block_size - 1) | ((32 - block_size) << 8)
+
+        # Vectorize the row load/store. Scalar U16 indexing creates excessive
+        # shared-memory wavefronts on the KK buffer.
+        row = cute.make_rmem_tensor(block_size, cutlass.Float16)
+        cute.autovec_copy(mat[tid_in_group, None], row)
+
+        # Apply I + lower_tril masking in fp32.
+        frag = cute.make_rmem_tensor(block_size, cutlass.Float32)
+        for j in cutlass.range_constexpr(block_size):
+            raw = cutlass.Float32(row[j])
+            if cutlass.const_expr(self.garbage_filled_diagonal or self.garbage_filled_upper_triangular):
+                if tid_in_group == cutlass.Int32(j):
+                    frag[j] = cutlass.Float32(1.0)
+                elif tid_in_group < cutlass.Int32(j):
+                    frag[j] = cutlass.Float32(0.0)
+                else:
+                    frag[j] = raw
+            else:
+                frag[j] = raw
+
+        # Gaussian elimination: row-reduce to produce inv(I + lower_tril(K))
+        for src_row in cutlass.range_constexpr(block_size - 1):
+            row_scale = -frag[src_row]
+            for i in cutlass.range_constexpr(src_row):
+                src_val = cute.arch.shuffle_sync(frag[i], cutlass.Int32(src_row), mask_and_clamp=shuffle_mask)
+                if tid_in_group > cutlass.Int32(src_row):
+                    frag[i] = frag[i] + row_scale * src_val
+            if tid_in_group > cutlass.Int32(src_row):
+                frag[src_row] = row_scale
+
+        row_out = cute.make_rmem_tensor(block_size, cutlass.Float16)
+        for j in cutlass.range_constexpr(block_size):
+            row_out[j] = cutlass.Float16(frag[j])
+        cute.autovec_copy(row_out, mat[tid_in_group, None])
+
+    # ── Level 2: 8×8 blocks → 16×16 blockwise inverse ───────────────────────────
+    # 8×8-to-16×16 blockwise merge (column-major path).
+    # Called by all 32 threads of one warp.
+    # mat: (16, 16) smem slice (one 16×16 diagonal block).
+
+    @cute.jit
+    def blockwise_8x8_to_16x16(self, mat: cute.Tensor):
+        lane_id = cute.arch.lane_idx()
+
+        tiled_mma = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(cutlass.Float16, cutlass.Float32, (16, 8, 8)),
+            (1, 1, 1),
+            permutation_mnk=(16, 8, 8),
+        )
+
+        mat_2x2 = cute.flat_divide(mat, (8, 8))
+        sDinv = mat_2x2[None, None, 1, 1]
+        sC = select_tensor_10(mat_2x2[None, None, 1, 0])
+        sAinv = select_tensor_10(mat_2x2[None, None, 0, 0])
+        sO = mat_2x2[None, None, 1, 0]
+
+        # Broadcast sDinv (8,8) → (16,8) by stride-0 on the extra M dimension
+        sDinv_bcast = cute.make_tensor(
+            sDinv.iterator,
+            cute.make_layout(
+                ((cute.size(sDinv, mode=[0]), 2), cute.size(sDinv, mode=[1])),
+                stride=((sDinv.layout.stride[0], 0), sDinv.layout.stride[1]),
+            ),
+        )
+        sO_bcast = cute.make_tensor(
+            sO.iterator,
+            cute.make_layout(
+                ((cute.size(sO, mode=[0]), 2), cute.size(sO, mode=[1])),
+                stride=((sO.layout.stride[0], 0), sO.layout.stride[1]),
+            ),
+        )
+
+        thr_mma = tiled_mma.get_slice(lane_id)
+        tOrDinv = thr_mma.make_fragment_A(thr_mma.partition_A(sDinv_bcast))
+        tOrC = thr_mma.make_fragment_B(thr_mma.partition_B(sC))
+        tOrAinv = thr_mma.make_fragment_B(thr_mma.partition_B(sAinv))
+        tDCrDC = cute.make_rmem_tensor(thr_mma.partition_shape_C((16, 8)), cutlass.Float32)
+        tOrO = cute.make_rmem_tensor(thr_mma.partition_shape_C((16, 8)), cutlass.Float32)
+
+        # Row-major copy atoms: A→LdMatrix_N, B→LdMatrix_T, C→StMatrix_N
+        dinv_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=1), cutlass.Float16)
+        b_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=1), cutlass.Float16)
+        o_atom = cute.make_copy_atom(warp.StMatrix8x8x16bOp(transpose=False, num_matrices=1), cutlass.Float16)
+
+        D_tiled_copy = cute.make_tiled_copy_A(dinv_atom, tiled_mma)
+        C_tiled_copy = cute.make_tiled_copy_B(b_atom, tiled_mma)
+        A_tiled_copy = cute.make_tiled_copy_B(b_atom, tiled_mma)
+        O_tiled_copy = cute.make_tiled_copy_C(o_atom, tiled_mma)
+
+        D_thr_copy = D_tiled_copy.get_slice(lane_id)
+        C_thr_copy = C_tiled_copy.get_slice(lane_id)
+        A_thr_copy = A_tiled_copy.get_slice(lane_id)
+        O_thr_copy = O_tiled_copy.get_slice(lane_id)
+
+        tOsDinv = D_thr_copy.partition_S(sDinv_bcast)
+        tOrDinv_cv = D_thr_copy.retile(tOrDinv)
+        tOsC = C_thr_copy.partition_S(sC)
+        tOrC_cv = C_thr_copy.retile(tOrC)
+        tOsAinv = A_thr_copy.partition_S(sAinv)
+        tOrAinv_cv = A_thr_copy.retile(tOrAinv)
+        tOsO = O_thr_copy.partition_D(sO_bcast)
+        tOrO_f16 = cute.make_fragment_like(tOrO, cutlass.Float16)
+        tOrO_cv = O_thr_copy.retile(tOrO_f16)
+
+        # ── Step 1: tDCrDC = -inv(D) @ C ─────────────────────────────────────────
+        # Load only the first MMA_M slice of D_inv (rows 0-7 of the 16-row broadcast)
+        cute.copy(D_tiled_copy, tOsDinv[None, None, 0], tOrDinv_cv[None, None, 0])
+        cute.copy(C_tiled_copy, tOsC, tOrC_cv)
+        tDCrDC.fill(0.0)
+        cute.gemm(tiled_mma, tDCrDC, tOrDinv, tOrC, tDCrDC)
+        for i in cutlass.range_constexpr(cute.size(tDCrDC)):
+            tDCrDC[i] = -tDCrDC[i]
+
+        # ── Step 2: tOrO = tDCrDC @ inv(A) ───────────────────────────────────────
+        tOrDC = SM80.make_acc_into_op(tDCrDC, tiled_mma, cutlass.Float16)
+
+        cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
+        tOrO.fill(0.0)
+        cute.gemm(tiled_mma, tOrO, tOrDC, tOrAinv, tOrO)
+
+        # ── Write output (first MMA_M slice → sO rows 0-7) ───────────────────────
+        tOrO_f16.store(tOrO.load().to(cutlass.Float16))
+        cute.copy(O_tiled_copy, tOrO_cv[None, None, 0], tOsO[None, None, 0])
+
+    # ── Level 3: 16×16 blocks → 32×32 blockwise inverse ─────────────────────────
+    # Called by one warp (thread_idx 0-31 or 32-63, i.e. thread_idx<64 in the WG).
+    # mat: (32, 32) smem slice.
+
+    @cute.jit
+    def blockwise_16x16_to_32x32(self, mat: cute.Tensor):
+        lane_id = cute.arch.lane_idx()
+
+        tiled_mma = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(cutlass.Float16, cutlass.Float32, (16, 8, 16)),
+            (1, 1, 1),
+            permutation_mnk=(16, 16, 16),
+        )
+
+        mat_2x2 = cute.flat_divide(mat, (16, 16))
+        sDinv = mat_2x2[None, None, 1, 1]
+        sC = select_tensor_10(mat_2x2[None, None, 1, 0])
+        sAinv = select_tensor_10(mat_2x2[None, None, 0, 0])
+        sO = mat_2x2[None, None, 1, 0]
+
+        thr_mma = tiled_mma.get_slice(lane_id)
+        tOrDinv = thr_mma.make_fragment_A(thr_mma.partition_A(sDinv))
+        tOrC = thr_mma.make_fragment_B(thr_mma.partition_B(sC))
+        tOrAinv = thr_mma.make_fragment_B(thr_mma.partition_B(sAinv))
+        tDCrDC = cute.make_rmem_tensor(thr_mma.partition_shape_C((16, 16)), cutlass.Float32)
+        tOrO = cute.make_rmem_tensor(thr_mma.partition_shape_C((16, 16)), cutlass.Float32)
+
+        dinv_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=2), cutlass.Float16)
+        b_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=2), cutlass.Float16)
+        o_atom = cute.make_copy_atom(warp.StMatrix8x8x16bOp(transpose=False, num_matrices=2), cutlass.Float16)
+
+        D_tiled_copy = cute.make_tiled_copy_A(dinv_atom, tiled_mma)
+        C_tiled_copy = cute.make_tiled_copy_B(b_atom, tiled_mma)
+        A_tiled_copy = cute.make_tiled_copy_B(b_atom, tiled_mma)
+        O_tiled_copy = cute.make_tiled_copy_C(o_atom, tiled_mma)
+
+        D_thr_copy = D_tiled_copy.get_slice(lane_id)
+        C_thr_copy = C_tiled_copy.get_slice(lane_id)
+        A_thr_copy = A_tiled_copy.get_slice(lane_id)
+        O_thr_copy = O_tiled_copy.get_slice(lane_id)
+
+        tOsDinv = D_thr_copy.partition_S(sDinv)
+        tOrDinv_cv = D_thr_copy.retile(tOrDinv)
+        tOsC = C_thr_copy.partition_S(sC)
+        tOrC_cv = C_thr_copy.retile(tOrC)
+        tOsAinv = A_thr_copy.partition_S(sAinv)
+        tOrAinv_cv = A_thr_copy.retile(tOrAinv)
+        tOsO = O_thr_copy.partition_D(sO)
+        tOrO_f16 = cute.make_fragment_like(tOrO, cutlass.Float16)
+        tOrO_cv = O_thr_copy.retile(tOrO_f16)
+
+        # ── Step 1: tDCrDC = -inv(D) @ C ─────────────────────────────────────────
+        cute.copy(D_tiled_copy, tOsDinv, tOrDinv_cv)
+        cute.copy(C_tiled_copy, tOsC, tOrC_cv)
+        tDCrDC.fill(0.0)
+        cute.gemm(tiled_mma, tDCrDC, tOrDinv, tOrC, tDCrDC)
+        for i in cutlass.range_constexpr(cute.size(tDCrDC)):
+            tDCrDC[i] = -tDCrDC[i]
+
+        # ── Step 2: tOrO = tDCrDC @ inv(A) ───────────────────────────────────────
+        tOrDC = SM80.make_acc_into_op(tDCrDC, tiled_mma, cutlass.Float16)
+
+        cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
+        tOrO.fill(0.0)
+        cute.gemm(tiled_mma, tOrO, tOrDC, tOrAinv, tOrO)
+
+        tOrO_f16.store(tOrO.load().to(cutlass.Float16))
+        cute.copy(O_tiled_copy, tOrO_cv, tOsO)
+
+    # ── Level 4: 32×32 blocks → 64×64 blockwise inverse ─────────────────────────
+    # Called by all 4 warps (128 threads).
+    # sT: (64, 64) smem tensor (the full matrix).
+
+    @cute.jit
+    def blockwise_32x32_to_64x64(self, sT: cute.Tensor, barrier_id: cutlass.Int32):
+        lane_id = cute.arch.lane_idx()
+        warp_id = cute.arch.warp_idx() % 4  # WG-local warp ID 0..3
+        x = warp_id // 2  # 0 or 1
+        y = warp_id % 2  # 0 or 1
+
+        # TiledMMA1: 16×16×32  (for -inv(D)@C, 1 K-pass of K=32)
+        tiled_mma1 = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(cutlass.Float16, cutlass.Float32, (16, 8, 16)),
+            (1, 1, 1),
+            permutation_mnk=(16, 16, 32),
+        )
+        # TiledMMA2: 16×32×16  (for (-inv(D)@C)@inv(A), N=32 output)
+        tiled_mma2 = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(cutlass.Float16, cutlass.Float32, (16, 8, 16)),
+            (1, 1, 1),
+            permutation_mnk=(16, 32, 16),
+        )
+
+        mat_2x2 = cute.flat_divide(sT, (32, 32))
+        mat_16x2_2x2 = cute.logical_divide(mat_2x2, (16, 16))
+
+        # Per-warp tile slices (each warp handles one 16×32 or 32×16 sub-tile)
+        sDinv = mat_16x2_2x2[(None, y), None, 1, 1]
+        sC = select_tensor_10(mat_16x2_2x2[None, (None, x), 1, 0])
+        sAinv = select_tensor_10(mat_16x2_2x2[(None, x), None, 0, 0])
+        sO = mat_16x2_2x2[(None, y), None, 1, 0]
+
+        thr_mma1 = tiled_mma1.get_slice(lane_id)
+        thr_mma2 = tiled_mma2.get_slice(lane_id)
+
+        tOrDinv = thr_mma1.make_fragment_A(thr_mma1.partition_A(sDinv))
+        tOrC = thr_mma1.make_fragment_B(thr_mma1.partition_B(sC))
+        tOrAinv = thr_mma2.make_fragment_B(thr_mma2.partition_B(sAinv))
+
+        tDCrDC = cute.make_rmem_tensor(thr_mma1.partition_shape_C((16, 16)), cutlass.Float32)
+        tOrO = cute.make_rmem_tensor(thr_mma2.partition_shape_C((16, 32)), cutlass.Float32)
+
+        dinv_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), cutlass.Float16)
+        c_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4), cutlass.Float16)
+        ainv_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=2), cutlass.Float16)
+        O_atom_s2r = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), cutlass.Float16)
+        O_atom_r2s = cute.make_copy_atom(warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), cutlass.Float16)
+
+        D_tiled_copy = cute.make_tiled_copy_A(dinv_atom, tiled_mma1)
+        C_tiled_copy = cute.make_tiled_copy_B(c_atom, tiled_mma1)
+        A_tiled_copy = cute.make_tiled_copy_B(ainv_atom, tiled_mma2)
+        O_tiled_s2r = cute.make_tiled_copy_C(O_atom_s2r, tiled_mma2)
+        O_tiled_r2s = cute.make_tiled_copy_C(O_atom_r2s, tiled_mma2)
+
+        D_thr_copy = D_tiled_copy.get_slice(lane_id)
+        C_thr_copy = C_tiled_copy.get_slice(lane_id)
+        A_thr_copy = A_tiled_copy.get_slice(lane_id)
+        O_thr_s2r = O_tiled_s2r.get_slice(lane_id)
+        O_thr_r2s = O_tiled_r2s.get_slice(lane_id)
+
+        tOsDinv = D_thr_copy.partition_S(sDinv)
+        tOrDinv_cv = D_thr_copy.retile(tOrDinv)
+        tOsC = C_thr_copy.partition_S(sC)
+        tOrC_cv = C_thr_copy.retile(tOrC)
+        tOsAinv = A_thr_copy.partition_S(sAinv)
+        tOrAinv_cv = A_thr_copy.retile(tOrAinv)
+
+        # ── Step 1: tDCrDC = -inv(D) @ C ─────────────────────────────────────────
+        cute.copy(D_tiled_copy, tOsDinv, tOrDinv_cv)
+        cute.copy(C_tiled_copy, tOsC, tOrC_cv)
+        tDCrDC.fill(0.0)
+        cute.gemm(tiled_mma1, tDCrDC, tOrDinv, tOrC, tDCrDC)
+        for i in cutlass.range_constexpr(cute.size(tDCrDC)):
+            tDCrDC[i] = -tDCrDC[i]
+
+        # ── Step 2: tOrO = tDCrDC @ inv(A) ───────────────────────────────────────
+        tOrDC = SM80.make_acc_into_op(tDCrDC, tiled_mma2, cutlass.Float16)
+
+        cute.copy(A_tiled_copy, tOsAinv, tOrAinv_cv)
+        tOrO.fill(0.0)
+        cute.gemm(tiled_mma2, tOrO, tOrDC, tOrAinv, tOrO)
+
+        tOrO_f16 = cute.make_fragment_like(tOrO, cutlass.Float16)
+        tOrO_f16.store(tOrO.load().to(cutlass.Float16))
+
+        # ── Cross-warp reduction: warps with x=0 write first, x=1 reads+adds+writes
+        cute.arch.barrier(barrier_id=barrier_id, number_of_threads=128)
+
+        tOsO = O_thr_r2s.partition_D(sO)
+        tOrO_cv = O_thr_r2s.retile(tOrO_f16)
+        if x == 0:
+            cute.copy(O_tiled_r2s, tOrO_cv, tOsO)
+
+        cute.arch.barrier(barrier_id=barrier_id, number_of_threads=128)
+
+        if x == 1:
+            tOrO_red = cute.make_fragment_like(tOrO_f16)
+            tOsO_s = O_thr_s2r.partition_S(sO)
+            tOrO_red_cv = O_thr_s2r.retile(tOrO_red)
+            cute.copy(O_tiled_s2r, tOsO_s, tOrO_red_cv)
+            for i in cutlass.range_constexpr(cute.size(tOrO_f16)):
+                tOrO_f16[i] = tOrO_f16[i] + tOrO_red[i]
+            cute.copy(O_tiled_r2s, tOrO_cv, tOsO)
+
+    @cute.jit
+    def run(self, sT: cute.Tensor, barrier_id: cutlass.Int32):
+        """Invert a 64×64 column-major shared-memory tensor in place.
+
+        The call requires one 128-thread warp group and an available barrier ID.
+        """
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % 128
+
+        # ── Level 1: 8×8 Gauss on diagonal 8×8 blocks (threads 0-63) ────────────
+        t8x8 = cute.flat_divide(sT, (8, 8))
+        if thread_idx < 64:
+            blk = thread_idx // 8
+            self.compute_diagonal_block_inverse(t8x8[None, None, blk, blk], thread_idx % 8, 8)
+
+        cute.arch.barrier(barrier_id=barrier_id, number_of_threads=128)
+
+        # ── Level 2: 16×16 blockwise inverse (all 4 warps → 4 diagonal blocks) ──
+        t16x16 = cute.flat_divide(sT, (16, 16))
+        blk2 = thread_idx // 32
+        self.blockwise_8x8_to_16x16(t16x16[None, None, blk2, blk2])
+
+        cute.arch.barrier(barrier_id=barrier_id, number_of_threads=128)
+
+        # ── Level 3: 32×32 blockwise inverse (threads 0-63 → 2 diagonal blocks) ─
+        t32x32 = cute.flat_divide(sT, (32, 32))
+        if thread_idx < 64:
+            blk3 = thread_idx // 32
+            self.blockwise_16x16_to_32x32(t32x32[None, None, blk3, blk3])
+
+        cute.arch.barrier(barrier_id=barrier_id, number_of_threads=128)
+
+        # ── Level 4: 64×64 blockwise inverse (all 4 warps) ───────────────────────
+        self.blockwise_32x32_to_64x64(sT, barrier_id)

--- a/cula/ops/gdn/sm90/collective_store_tma.py
+++ b/cula/ops/gdn/sm90/collective_store_tma.py
@@ -1,0 +1,229 @@
+# Copyright 2025-2026 FlashInfer team.
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import cutlass
+import cutlass._mlir.dialects.cute as _cute_ir
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+from cutlass.cute.nvgpu import cpasync
+from cutlass.utils.tensormap_manager import TensorMapManager, TensorMapUpdateMode
+
+from .helpers import smid, tensormap_replace_global_dim_1
+
+
+class CollectiveStoreTma:
+    def __init__(self, blk_q: int, d: int):
+        self.BLK_Q = blk_q
+        self.D = d
+
+    @cute.jit
+    def tail_tensormap_gmem_ptr(self, g_tensormaps: cute.Tensor):
+        manager = TensorMapManager(TensorMapUpdateMode.GMEM, 128)
+        return manager.get_tensormap_ptr(g_tensormaps.iterator + smid() * cutlass.Int32(128))
+
+    @cute.jit
+    def tail_tensormap_generic_ptr(self, g_tensormaps: cute.Tensor):
+        manager = TensorMapManager(TensorMapUpdateMode.GMEM, 128)
+        return manager.get_tensormap_ptr(
+            g_tensormaps.iterator + smid() * cutlass.Int32(128),
+            address_space=_cute_ir.AddressSpace.generic,
+        )
+
+    @cute.jit
+    def can_process(
+        self,
+        sO: cute.Tensor,
+        work_desc,
+        blk: cutlass.Int32,
+        num_blocks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+    ):
+        # 1. Intermediate full tiles always use the base descriptor.
+        # 2. A full last tile also uses the base descriptor.
+        # 3. The final sequence can rely on TMA OOB handling at allocation end.
+        # Otherwise, the last tile of a packed non-final sequence needs a
+        # temporary descriptor with the seqlen dimension shrunk to this sequence.
+        can_process = work_desc.seq_idx == num_seqs - cutlass.Int32(1)
+        if blk < num_blocks - cutlass.Int32(1):
+            can_process = True
+        if work_desc.seq_len % cutlass.Int32(self.BLK_Q) == cutlass.Int32(0):
+            can_process = True
+        return can_process
+
+    @cute.jit
+    def create_tensormap_for_tail(
+        self,
+        tma_atom_o: cute.CopyAtom,
+        g_tensormaps: cute.Tensor,
+        work_desc,
+    ):
+        tail_ptr = self.tail_tensormap_gmem_ptr(g_tensormaps)
+        with cute.arch.elect_one():
+            cpasync.copy_tensormap(tma_atom_o, tail_ptr)
+        cute.arch.sync_warp()
+        with cute.arch.elect_one():
+            tensormap_replace_global_dim_1(
+                tail_ptr,
+                # The descriptor extent is the absolute packed seq_end. A
+                # sequence-relative length would still expose its neighbour.
+                work_desc.tok_offset + work_desc.seq_len,
+            )
+        cute.arch.sync_warp()
+        # Publish descriptor writes to the TMA proxy; CTA synchronization alone
+        # does not order TensorMap updates against a later bulk copy.
+        cpasync.fence_tma_desc_release()
+
+    @cute.jit
+    def partition_sd(
+        self,
+        sO: cute.Tensor,
+        tma_atom_o: cute.CopyAtom,
+        tma_tensor_o: cute.Tensor,
+        work_desc,
+        o_head_idx: cutlass.Int32,
+        blk: cutlass.Int32,
+        stage_idx: cutlass.Int32,
+    ):
+        mO = cute.domain_offset(
+            (cutlass.Int32(0), work_desc.tok_offset + blk * cutlass.Int32(self.BLK_Q)),
+            tma_tensor_o[None, None, o_head_idx],
+        )
+        gO = cute.zipped_divide(mO, (self.D, self.BLK_Q))[
+            (
+                (None, None),
+                (cutlass.Int32(0), cutlass.Int32(0)),
+            )
+        ]
+        sO_pipe = sO[None, None, stage_idx]
+        return cpasync.tma_partition(
+            tma_atom_o,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sO_pipe, 0, 2),
+            cute.group_modes(gO, 0, 2),
+        )
+
+    @cute.jit
+    def issue_store(
+        self,
+        sO: cute.Tensor,
+        tma_atom_o: cute.CopyAtom,
+        tma_tensor_o: cute.Tensor,
+        work_desc,
+        o_head_idx: cutlass.Int32,
+        blk: cutlass.Int32,
+        stage_idx: cutlass.Int32,
+    ):
+        cute.arch.fence_view_async_shared()
+        tOsO, tOgO = self.partition_sd(sO, tma_atom_o, tma_tensor_o, work_desc, o_head_idx, blk, stage_idx)
+        cute.copy(tma_atom_o, tOsO, tOgO)
+        cute.arch.cp_async_bulk_commit_group()
+
+    @cute.jit
+    def issue_tail_store(
+        self,
+        sO: cute.Tensor,
+        tma_atom_o: cute.CopyAtom,
+        tma_tensor_o: cute.Tensor,
+        g_tensormaps: cute.Tensor,
+        work_desc,
+        o_head_idx: cutlass.Int32,
+        blk: cutlass.Int32,
+        stage_idx: cutlass.Int32,
+    ):
+        cute.arch.fence_view_async_shared()
+        tOsO, tOgO = self.partition_sd(sO, tma_atom_o, tma_tensor_o, work_desc, o_head_idx, blk, stage_idx)
+        tail_gmem_ptr = self.tail_tensormap_gmem_ptr(g_tensormaps)
+        tail_generic_ptr = self.tail_tensormap_generic_ptr(g_tensormaps)
+        # Acquire the descriptor in the TMA proxy before issuing the tail copy.
+        cpasync.fence_tma_desc_acquire(tail_gmem_ptr)
+        cute.copy(
+            tma_atom_o,
+            tOsO,
+            tOgO,
+            tma_desc_ptr=tail_generic_ptr,
+        )
+        cute.arch.cp_async_bulk_commit_group()
+
+    @cute.jit
+    def step(
+        self,
+        sO: cute.Tensor,
+        tma_atom_o: cute.CopyAtom,
+        tma_tensor_o: cute.Tensor,
+        g_tensormaps: cute.Tensor,
+        o_pipeline,
+        o_consumer_state,
+        work_desc,
+        o_head_idx: cutlass.Int32,
+        blk: cutlass.Int32,
+        num_blocks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+    ):
+        # Full tiles can use the base descriptor. A non-final packed sequence tail
+        # must shrink the seqlen dimension in a temporary descriptor so TMA OOB
+        # handling stops at this sequence instead of writing into the next one.
+        if blk == cutlass.Int32(0):
+            if not self.can_process(sO, work_desc, num_blocks - cutlass.Int32(1), num_blocks, num_seqs):
+                self.create_tensormap_for_tail(tma_atom_o, g_tensormaps, work_desc)
+
+        o_pipeline.consumer_wait(o_consumer_state)
+        if self.can_process(sO, work_desc, blk, num_blocks, num_seqs):
+            self.issue_store(
+                sO,
+                tma_atom_o,
+                tma_tensor_o,
+                work_desc,
+                o_head_idx,
+                blk,
+                o_consumer_state.index,
+            )
+        else:
+            self.issue_tail_store(
+                sO,
+                tma_atom_o,
+                tma_tensor_o,
+                g_tensormaps,
+                work_desc,
+                o_head_idx,
+                blk,
+                o_consumer_state.index,
+            )
+        # Retire the S2G bulk group before releasing/reusing this shared stage.
+        cute.arch.cp_async_bulk_wait_group(0)
+        o_pipeline.consumer_release(o_consumer_state)
+        o_consumer_state.advance()
+        return o_consumer_state
+
+    @cute.jit
+    def run(
+        self,
+        sO: cute.Tensor,
+        tma_atom_o: cute.CopyAtom,
+        tma_tensor_o: cute.Tensor,
+        g_tensormaps: cute.Tensor,
+        o_pipeline,
+        num_blocks: cutlass.Int32,
+        work_desc,
+        num_seqs: cutlass.Int32,
+        o_stage: int,
+        num_q_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+    ):
+        o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
+        o_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, o_stage)
+        for blk in cutlass.range(num_blocks, unroll=1):
+            o_consumer_state = self.step(
+                sO,
+                tma_atom_o,
+                tma_tensor_o,
+                g_tensormaps,
+                o_pipeline,
+                o_consumer_state,
+                work_desc,
+                o_head_idx,
+                blk,
+                num_blocks,
+                num_seqs,
+            )

--- a/cula/ops/gdn/sm90/compile_cache.py
+++ b/cula/ops/gdn/sm90/compile_cache.py
@@ -1,0 +1,70 @@
+# Copyright 2025-2026 FlashInfer team.
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+from collections.abc import Hashable
+
+import cutlass.cute as cute
+
+_in_mem_compile_cache: dict = {}
+
+
+def _as_options_tuple(options):
+    if options is None:
+        return ()
+    if isinstance(options, tuple):
+        return options
+    return (options,)
+
+
+class KeyedCompileMixin:
+    def manual_cache_key(self, *attr_names):
+        collected_attrs = tuple((attr_name, getattr(self, attr_name)) for attr_name in attr_names)
+        compile_key = (type(self).__mro__,) + collected_attrs
+        hash(compile_key)
+        setattr(self, "_KeyedCompileMixin_compile_key", compile_key)  # noqa: B010
+
+    def _get_compile_key(self):
+        compile_key = getattr(self, "_KeyedCompileMixin_compile_key", None)
+        if compile_key is None:
+            warnings.warn(
+                f"{type(self).__name__} is using automatic DSL compile-cache key generation; "
+                "call manual_cache_key(...) at the end of __init__ to avoid host launch overhead.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            collected_attrs = tuple(
+                (attr_name, attr_value)
+                for attr_name, attr_value in sorted(self.__dict__.items())
+                if not attr_name.startswith("_")
+            )
+            compile_key = (str(type(self).__mro__),) + tuple(collected_attrs)
+            try:
+                hash(compile_key)
+            except TypeError:
+                collected_attrs = tuple(
+                    (attr_name, attr_value) for attr_name, attr_value in collected_attrs if isinstance(attr_value, Hashable)
+                )
+                compile_key = (str(type(self).__mro__),) + tuple(collected_attrs)
+            setattr(self, "_KeyedCompileMixin_compile_key", compile_key)  # noqa: B010
+
+        return compile_key
+
+
+def _compile_options_key(options):
+    if options is None:
+        return None
+    options = _as_options_tuple(options)
+    return tuple((type(option), option.value) for option in options)
+
+
+def cached_compile(func, *args, compile_options=None, **kwargs):
+    cache_key = (func._get_compile_key(), _compile_options_key(compile_options))
+    compiled_fn = _in_mem_compile_cache.get(cache_key)
+
+    if compiled_fn is None:
+        compiled_fn = cute.compile[compile_options](func, *args, **kwargs)
+        _in_mem_compile_cache[cache_key] = compiled_fn
+
+    return compiled_fn

--- a/cula/ops/gdn/sm90/config.py
+++ b/cula/ops/gdn/sm90/config.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable host-side contract for the Hopper GDN prefill kernel."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+EXPECTED_CUTLASS_DSL_VERSION = "4.5.1"
+SM90_BACKEND_ID = "sm90_cutedsl_gdn"
+
+CHUNK_SIZE = 64
+HEAD_SIZE = 128
+THREADS_PER_CTA = 512
+
+
+class HeadMode(str, Enum):  # noqa: UP042 - Python 3.10 remains supported
+    MHA = "mha"
+    GQA = "gqa"
+    GVA = "gva"
+
+
+def classify_head_mode(num_q_heads: int, num_k_heads: int, num_v_heads: int) -> HeadMode:
+    """Validate the MHA, grouped-query, or grouped-value head relation."""
+
+    if min(num_q_heads, num_k_heads, num_v_heads) <= 0:
+        raise ValueError("head counts must be positive")
+    if num_q_heads == num_k_heads == num_v_heads:
+        return HeadMode.MHA
+    if num_k_heads == num_v_heads and num_q_heads > num_k_heads and num_q_heads % num_k_heads == 0:
+        return HeadMode.GQA
+    if num_q_heads == num_k_heads and num_v_heads > num_q_heads and num_v_heads % num_q_heads == 0:
+        return HeadMode.GVA
+    raise ValueError(
+        "SM90 GDN supports MHA (Hq=Hk=Hv), GQA (Hq multiple of Hk=Hv), or GVA (Hv multiple of Hq=Hk)",
+    )

--- a/cula/ops/gdn/sm90/delta_rule.py
+++ b/cula/ops/gdn/sm90/delta_rule.py
@@ -1,0 +1,2402 @@
+# Copyright 2025-2026 FlashInfer team.
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+from enum import IntEnum
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import torch
+from cutlass.cute.nvgpu import cpasync, warp, warpgroup
+
+from cula.utils import _get_cache_buf, get_device_sm_count
+
+from .alpha import AlphaProcessor
+from .collective_inverse_hmma import CollectiveInverse
+from .collective_store_tma import CollectiveStoreTma
+from .compile_cache import KeyedCompileMixin, cached_compile
+from .helpers import SM90, round_down, select_tensor_10
+from .schedule import WorkDesc
+
+# ─── Named-barrier IDs used by the compute kernel ────────────────────────────
+# Must not conflict with each other or with pipeline barrier storage.
+
+
+class NamedBarrier(IntEnum):
+    MATH_WG0 = 4  # OrderedMathBarriers: StreamkBarrier0
+    MATH_WG1 = 5  # OrderedMathBarriers: StreamkBarrier1
+    KK_SYNC = 13  # sync all 128 WG0 threads before collective_inverse
+
+
+class WarpGroupRole(IntEnum):
+    LDST = 0
+    MATH_STATE0 = 1
+    MATH_STATE1 = 2
+    MATH_AUX = 3
+
+
+class LoadStoreWarpRole(IntEnum):
+    STORE_O = 0
+    LOAD_QKV = 1
+    LOAD_BETA = 2
+    LOAD_ALPHA = 3
+
+
+class MathWarpGroupRole(IntEnum):
+    STATE0 = 0
+    STATE1 = 1
+    AUX = 2
+    KK = 0
+    QK = 1
+
+
+# ─── Warp-specialized delta-rule kernel ───────────────────────────────────────
+# Grid: (num_seqs * num_sab_heads, 1, 1)
+# Block: 512 threads → WG0=LD/ST, WG1/WG2=state math, WG3=aux math.
+#
+# needs_alpha / needs_beta / needs_init_state are class attributes set in __init__.
+# The JIT compiler specialises per instance, so they are compile-time booleans
+# inside the kernel without any parameter-passing trickery.
+
+
+class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
+    @staticmethod
+    def get_register_requirements(
+        max_threads_per_block: int,
+        min_blocks_per_multiprocessor: int,
+        num_state_mma_warp_groups: int,
+        threads_per_warp_group: int,
+    ) -> tuple[int, int, int]:
+        reg_alloc_granularity = 8
+        load_registers = 40 - 2 * reg_alloc_granularity
+        aux_registers = 128 - load_registers
+        total_registers = (
+            round_down(
+                64 * 1024 // min_blocks_per_multiprocessor,
+                max_threads_per_block * reg_alloc_granularity,
+            )
+            // threads_per_warp_group
+        )
+        state_mma_registers = round_down(
+            (total_registers - load_registers - aux_registers) // num_state_mma_warp_groups,
+            reg_alloc_granularity,
+        )
+        return (
+            min(248, load_registers),
+            min(248, state_mma_registers),
+            min(248, aux_registers),
+        )
+
+    @staticmethod
+    def can_implement(
+        num_q_heads: int,
+        num_k_heads: int,
+        num_v_heads: int,
+        head_size: int,
+        element_size: int,
+    ) -> bool:
+        ratio = num_q_heads // num_v_heads if num_q_heads > num_v_heads else num_v_heads // num_q_heads
+        is_gva_enabled = num_v_heads > num_q_heads
+
+        is_gqa_like = (
+            (num_k_heads == num_v_heads) and (num_q_heads == ratio * num_k_heads) and (num_q_heads == ratio * num_v_heads)
+        )
+        is_gva_like = (
+            (num_q_heads == num_k_heads) and (num_v_heads == ratio * num_q_heads) and (num_v_heads == ratio * num_k_heads)
+        )
+
+        alignment = 16 // element_size
+        return (
+            ((not is_gva_enabled and is_gqa_like) or (is_gva_enabled and is_gva_like))
+            and (head_size <= 128)
+            and ((head_size % alignment) == 0)
+        )
+
+    def __init__(
+        self,
+        needs_alpha: bool,
+        needs_beta: bool,
+        needs_init_state: bool,
+        needs_checkpointing: bool,
+        dtype: type[cutlass.Numeric] = cutlass.Float16,
+        acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+    ):
+        self.needs_alpha = needs_alpha
+        self.needs_beta = needs_beta
+        self.needs_init_state = needs_init_state
+        self.needs_checkpointing = needs_checkpointing
+        self.dtype = dtype
+        self.acc_dtype = acc_dtype
+        self.inverse_dtype = cutlass.Float16
+        self.BLK_Q = 64
+        self.BLK_KV = 64
+        self.D = 128
+        self.q_stage = 2
+        self.k_stage = 3
+        self.v_stage = 2
+        self.o_stage = 2
+        self.qk_stage = 2
+        self.kk_stage = 2
+        self.alpha_beta_stage = 5
+        self.manual_cache_key(
+            "needs_alpha",
+            "needs_beta",
+            "needs_init_state",
+            "needs_checkpointing",
+            "dtype",
+            "acc_dtype",
+            "inverse_dtype",
+            "BLK_Q",
+            "BLK_KV",
+            "D",
+            "q_stage",
+            "k_stage",
+            "v_stage",
+            "o_stage",
+            "qk_stage",
+            "kk_stage",
+            "alpha_beta_stage",
+        )
+
+    def get_next_work(
+        self,
+        cu_seqlens: cute.Tensor,
+        num_q_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+    ) -> WorkDesc:
+        bx, _, _ = cute.arch.block_idx()
+        seq_idx = bx // num_sab_heads
+        o_head_idx = bx % num_sab_heads
+        q_head_idx = o_head_idx * num_q_heads // num_sab_heads
+        v_head_idx = o_head_idx * num_v_heads // num_sab_heads
+        tok_start = cutlass.Int32(cu_seqlens[seq_idx])
+        tok_end = cutlass.Int32(cu_seqlens[seq_idx + 1])
+
+        return WorkDesc(
+            seq_idx=seq_idx,
+            private_q_head_idx=q_head_idx,
+            private_v_head_idx=v_head_idx,
+            tok_offset=tok_start,
+            seq_len=tok_end - tok_start,
+            tile_idx=cutlass.Int32(0),
+        )
+
+    # ─── Ordered 2-WG math barriers ───────────────────────────────────────────
+    # Alternates access between the two state-math warp groups.
+    # wg_idx: MathWarpGroupRole.KK or MathWarpGroupRole.QK.
+
+    @cute.jit
+    def _math_order_init(self, wg_idx: cutlass.Int32):
+        """Pre-arrive at WG0's barrier so WG0 is unblocked on the first wait."""
+        if wg_idx == MathWarpGroupRole.QK:
+            cute.arch.barrier_arrive(barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+
+    @cute.jit
+    def _math_order_wait(self, wg_idx: cutlass.Int32):
+        """Arrive+wait on this WG's own ordered barrier."""
+        if wg_idx == MathWarpGroupRole.KK:
+            cute.arch.barrier(barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+        else:
+            cute.arch.barrier(barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
+
+    @cute.jit
+    def _math_order_notify(self, wg_idx: cutlass.Int32):
+        """Arrive at the other WG's barrier to unblock it."""
+        if wg_idx == MathWarpGroupRole.KK:
+            cute.arch.barrier_arrive(barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
+        else:
+            cute.arch.barrier_arrive(barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+
+    # ─── kk_store_and_inv ─────────────────────────────────────────────────────
+
+    @cute.jit
+    def _kk_store_and_inv(
+        self,
+        tKKrKK: cute.Tensor,  # fp32 KK accumulator (from 128-thread kk_tiled_mma)
+        kk_tiled_mma,
+        kk_thread_idx: cutlass.Int32,
+        sKK_inv: cute.Tensor,  # (BlkKV, BlkKV) 8×8-tiled smem
+        sKK_opd: cute.Tensor,  # sKK_inv storage recast as Element for MMA operand
+        sBeta: cute.Tensor,  # (BlkKV, StagesBeta) - used when needs_beta
+        beta_pipe_idx: cutlass.Int32,
+        tKKcMkk: cute.Tensor,  # coordinate mapping for KK fragment
+    ):
+        """Store tKKrKK → sKK_inv, Inverse, optionally reload+beta."""
+        stsm_atom = cute.make_copy_atom(warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype)
+        tiled_store = cute.make_tiled_copy_C(stsm_atom, kk_tiled_mma)
+        thr_store = tiled_store.get_slice(kk_thread_idx)
+        tKKsKK = thr_store.partition_D(sKK_inv)
+        tKKrKK_cv = thr_store.retile(tKKrKK)
+        tKKrKK_inv = cute.make_fragment_like(tKKrKK_cv, self.inverse_dtype)
+        for i in cutlass.range_constexpr(cute.size(tKKrKK_cv)):
+            tKKrKK_inv[i] = self.inverse_dtype(tKKrKK_cv[i])
+        cute.copy(tiled_store, tKKrKK_inv, tKKsKK)
+
+        cute.arch.barrier(barrier_id=NamedBarrier.KK_SYNC, number_of_threads=128)
+        CollectiveInverse().run(sKK_inv, NamedBarrier.KK_SYNC)
+
+        if cutlass.const_expr(self.needs_beta or self.dtype != self.inverse_dtype):
+            cute.arch.barrier(barrier_id=NamedBarrier.KK_SYNC, number_of_threads=128)
+            ldsm_atom = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+                self.inverse_dtype,
+            )
+            tiled_load = cute.make_tiled_copy_C(ldsm_atom, kk_tiled_mma)
+            thr_load = tiled_load.get_slice(kk_thread_idx)
+            tKKrKK_cpy = cute.make_fragment_like(tKKrKK_inv)
+            tKKrKK_cvt = cute.make_fragment_like(tKKrKK_inv, self.dtype)
+            cute.copy(tiled_load, thr_load.partition_S(sKK_inv), tKKrKK_cpy)
+            tKKcMkk_cv = thr_load.retile(tKKcMkk)
+
+            for i in cutlass.range_constexpr(cute.size(tKKrKK_cpy)):
+                if cutlass.const_expr(self.needs_beta):
+                    _, t = tKKcMkk_cv[i]
+                    tKKrKK_cvt[i] = self.dtype(cutlass.Float32(tKKrKK_cpy[i]) * cutlass.Float32(sBeta[t, beta_pipe_idx]))
+                else:
+                    tKKrKK_cvt[i] = self.dtype(tKKrKK_cpy[i])
+
+            tKKsKK2 = thr_store.partition_D(sKK_opd)
+            cute.copy(tiled_store, tKKrKK_cvt, tKKsKK2)
+
+    # ─── qk_and_kk_epi ───────────────────────────────────────────────────────
+
+    @cute.jit
+    def qk_and_kk_epi(
+        self,
+        tQKrQK: cute.Tensor,
+        tKKrKK: cute.Tensor,
+        tQKcMqk: cute.Tensor,
+        tKKcMkk: cute.Tensor,
+        sAlpha: cute.Tensor,
+        sBeta: cute.Tensor,
+        alpha_stage: cutlass.Int32,
+        beta_stage: cutlass.Int32,
+        is_final_block: bool,
+        B: cutlass.Int32,
+        scale: cutlass.Float32,
+    ):
+        if cutlass.const_expr(self.needs_beta):
+            beta_row = sBeta[None, beta_stage]
+            for i in cutlass.range_constexpr(cute.size(tKKcMkk)):
+                s, _ = tKKcMkk[i]
+                tKKrKK[i] = tKKrKK[i] * cutlass.Float32(beta_row[s])
+
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_cumlog = sAlpha[None, AlphaProcessor.CUMSUM_LOG, alpha_stage]
+            for i in cutlass.range_constexpr(cute.size(tKKcMkk)):
+                # s, t = tKKcMkk[i]
+                s, t = tQKcMqk[i]
+                alpha = cute.math.exp2(
+                    cutlass.Float32(alpha_cumlog[s]) - cutlass.Float32(alpha_cumlog[t]),
+                    fastmath=True,
+                )
+                tQKrQK[i] = tQKrQK[i] * alpha * scale
+                tKKrKK[i] = tKKrKK[i] * alpha
+        else:
+            for i in cutlass.range_constexpr(cute.size(tQKrQK)):
+                tQKrQK[i] = tQKrQK[i] * scale
+
+        for i in cutlass.range_constexpr(cute.size(tKKcMkk)):
+            # s, t = tKKcMkk[i]
+            s, t = tQKcMqk[i]
+            pred = s >= t
+            tQKrQK[i] = tQKrQK[i] if pred else cutlass.Float32(0.0)
+            tKKrKK[i] = tKKrKK[i] if pred else cutlass.Float32(0.0)
+            if cutlass.const_expr(is_final_block):
+                pred = s < B and t < B
+                tQKrQK[i] = tQKrQK[i] if pred else cutlass.Float32(0.0)
+                tKKrKK[i] = tKKrKK[i] if pred else cutlass.Float32(0.0)
+
+    # ─── qk_store ─────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def qk_store(
+        self,
+        tQKrQK: cute.Tensor,
+        sQK: cute.Tensor,
+        qk_tiled_mma,
+        qk_thread_idx: cutlass.Int32,
+    ):
+        stsm_atom = cute.make_copy_atom(warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype)
+        qk_tiled_copy = cute.make_tiled_copy_C(stsm_atom, qk_tiled_mma)
+        qk_thr_copy = qk_tiled_copy.get_slice(qk_thread_idx)
+        tQKsQK = qk_thr_copy.partition_D(sQK)
+        tQKrQK_cvt = cute.make_fragment_like(tQKrQK, self.dtype)
+        tQKrQK_cvt_cv = qk_thr_copy.retile(tQKrQK_cvt)
+        for i in cutlass.range_constexpr(cute.size(tQKrQK)):
+            tQKrQK_cvt[i] = self.dtype(tQKrQK[i])
+        cute.copy(qk_tiled_copy, tQKrQK_cvt_cv, tQKsQK)
+
+    # ─── o1_epi ───────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def o1_epi(
+        self,
+        tOrO: cute.Tensor,
+        tOcO: cute.Tensor,
+        sAlpha: cute.Tensor,
+        alpha_stage: cutlass.Int32,
+        scale: cutlass.Float32,
+    ):
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_cpscale = sAlpha[None, AlphaProcessor.CUMPROD_SCALE, alpha_stage]
+            for i in cutlass.range_constexpr(cute.size(tOrO)):
+                _, tok_q = tOcO[i]
+                tOrO[i] = cutlass.Float32(alpha_cpscale[tok_q]) * tOrO[i]
+        else:
+            for i in cutlass.range_constexpr(cute.size(tOrO)):
+                tOrO[i] = scale * tOrO[i]
+
+    # ─── sk_epi ───────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def sk_epi(
+        self,
+        tSKrSK: cute.Tensor,
+        tSKcSK: cute.Tensor,
+        sAlpha: cute.Tensor,
+        alpha_stage: cutlass.Int32,
+    ):
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_cp = sAlpha[None, AlphaProcessor.CUMPROD, alpha_stage]
+            for i in cutlass.range_constexpr(cute.size(tSKrSK)):
+                _, tok_kv = tSKcSK[i]
+                tSKrSK[i] = tSKrSK[i] * cutlass.Float32(alpha_cp[tok_kv])
+
+    # ─── sk_load_v ────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def sk_load_v(
+        self,
+        tSKrSK: cute.Tensor,
+        sV_DS: cute.Tensor,
+        sk_tiled_copy_C,
+        sk_thr_copy_C,
+        v_stage: cutlass.Int32,
+    ) -> cute.Tensor:
+        tSKrV = cute.make_fragment_like(tSKrSK, self.dtype)
+        tSKrV_cv = sk_thr_copy_C.retile(tSKrV)
+        tSKsV = sk_thr_copy_C.partition_S(sV_DS)
+        cute.copy(sk_tiled_copy_C, tSKsV[None, None, None, v_stage], tSKrV_cv)
+        return tSKrV
+
+    # ─── kv_decay_v ───────────────────────────────────────────────────────────
+
+    @cute.jit
+    def kv_decay_v(
+        self,
+        tKVrV: cute.Tensor,
+        tKVcV: cute.Tensor,
+        sAlpha: cute.Tensor,
+        alpha_stage: cutlass.Int32,
+        is_final_block: bool,
+        B: cutlass.Int32,
+    ):
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_cumlog = sAlpha[None, AlphaProcessor.CUMSUM_LOG, alpha_stage]
+            block_log = cutlass.Float32(alpha_cumlog[B - cutlass.Int32(1)])
+            for i in cutlass.range_constexpr(cute.size(tKVrV)):
+                _, tok = tKVcV[i]
+                coeff = cute.math.exp2(block_log - cutlass.Float32(alpha_cumlog[tok]), fastmath=True)
+                if cutlass.const_expr(is_final_block):
+                    if tok >= B:
+                        coeff = cutlass.Float32(0.0)
+                tKVrV[i] = self.dtype(cutlass.Float32(tKVrV[i]) * coeff)
+        else:
+            for i in cutlass.range_constexpr(cute.size(tKVrV)):
+                _, tok = tKVcV[i]
+                if cutlass.const_expr(is_final_block):
+                    if tok >= B:
+                        tKVrV[i] = self.dtype(0.0)
+
+    # ─── o_store ──────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def o_store(
+        self,
+        tOrO: cute.Tensor,
+        tOsO: cute.Tensor,
+        o_tiled_copy_r2s,
+        o_thr_copy_r2s,
+    ):
+        tOrO_f16 = cute.make_fragment_like(tOrO, self.dtype)
+        for i in cutlass.range_constexpr(cute.size(tOrO)):
+            tOrO_f16[i] = self.dtype(tOrO[i])
+        tOrO_cv = o_thr_copy_r2s.retile(tOrO_f16)
+        cute.arch.fence_view_async_shared()
+        cute.copy(o_tiled_copy_r2s, tOrO_cv, tOsO)
+        cute.arch.fence_view_async_shared()
+
+    # ─── TMA load helpers ────────────────────────────────────────────────────
+
+    @cute.jit
+    def load_qkv_tma(
+        self,
+        sQ_SD: cute.Tensor,
+        sK_DS: cute.Tensor,
+        sV_DS: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        tma_tensor_q: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        tma_tensor_v: cute.Tensor,
+        q_pipeline,
+        q_producer_state,
+        k_pipeline,
+        k_producer_state,
+        v_pipeline,
+        v_producer_state,
+        blk: cutlass.Int32,
+        tok_start: cutlass.Int32,
+        q_head_idx: cutlass.Int32,
+        k_head_idx: cutlass.Int32,
+        v_head_idx: cutlass.Int32,
+    ):
+        blk_tok = tok_start + blk * cutlass.Int32(self.BLK_KV)
+
+        sK = sK_DS[None, None, k_producer_state.index]
+        mK = cute.domain_offset(
+            (cutlass.Int32(0), blk_tok),
+            tma_tensor_k[None, None, k_head_idx],
+        )
+        gK = cute.zipped_divide(mK, (self.D, self.BLK_KV))[((None, None), (cutlass.Int32(0), cutlass.Int32(0)))]
+        tKsK, tKgK = cpasync.tma_partition(
+            tma_atom_k,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sK, 0, 2),
+            cute.group_modes(gK, 0, 2),
+        )
+        k_pipeline.producer_acquire(k_producer_state)
+        cute.copy(
+            tma_atom_k,
+            tKgK,
+            tKsK,
+            tma_bar_ptr=k_pipeline.producer_get_barrier(k_producer_state),
+        )
+        k_pipeline.producer_commit(k_producer_state)
+        k_producer_state.advance()
+
+        sQ = sQ_SD[None, None, q_producer_state.index]
+        mQ = cute.domain_offset(
+            (blk_tok, cutlass.Int32(0)),
+            tma_tensor_q[None, None, q_head_idx],
+        )
+        gQ = cute.zipped_divide(mQ, (self.BLK_Q, self.D))[((None, None), (cutlass.Int32(0), cutlass.Int32(0)))]
+        tQsQ, tQgQ = cpasync.tma_partition(
+            tma_atom_q,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sQ, 0, 2),
+            cute.group_modes(gQ, 0, 2),
+        )
+        q_pipeline.producer_acquire(q_producer_state)
+        cute.copy(
+            tma_atom_q,
+            tQgQ,
+            tQsQ,
+            tma_bar_ptr=q_pipeline.producer_get_barrier(q_producer_state),
+        )
+        q_pipeline.producer_commit(q_producer_state)
+        q_producer_state.advance()
+
+        sV = sV_DS[None, None, v_producer_state.index]
+        mV = cute.domain_offset(
+            (cutlass.Int32(0), blk_tok),
+            tma_tensor_v[None, None, v_head_idx],
+        )
+        gV = cute.zipped_divide(mV, (self.D, self.BLK_KV))[((None, None), (cutlass.Int32(0), cutlass.Int32(0)))]
+        tVsV, tVgV = cpasync.tma_partition(
+            tma_atom_v,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sV, 0, 2),
+            cute.group_modes(gV, 0, 2),
+        )
+        v_pipeline.producer_acquire(v_producer_state)
+        cute.copy(
+            tma_atom_v,
+            tVgV,
+            tVsV,
+            tma_bar_ptr=v_pipeline.producer_get_barrier(v_producer_state),
+        )
+        v_pipeline.producer_commit(v_producer_state)
+        v_producer_state.advance()
+        return q_producer_state, k_producer_state, v_producer_state
+
+    # ─── load_alpha ───────────────────────────────────────────────────────────
+    # Scalar alpha load with neutral padding for the ragged tail.
+    # Caller must sync before calling AlphaProcessor on the loaded data.
+
+    @cute.jit
+    def load_alpha(
+        self,
+        sAlpha: cute.Tensor,
+        g_alpha: cute.Tensor,
+        blk_tok: cutlass.Int32,
+        tok_end: cutlass.Int32,
+        sab_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        alpha_stage: cutlass.Int32,
+    ):
+        lane_id = cute.arch.lane_idx()
+        sAlpha_k = sAlpha[None, None, alpha_stage]
+        num_iters = self.BLK_Q // 32
+        for i in cutlass.range_constexpr(num_iters):
+            row = cutlass.Int32(i * 32) + lane_id
+            tok = blk_tok + row
+            if tok < tok_end:
+                sAlpha_k[row, AlphaProcessor.CUMSUM_LOG] = g_alpha[tok * num_sab_heads + sab_head_idx]
+            else:
+                sAlpha_k[row, AlphaProcessor.CUMSUM_LOG] = cutlass.Float32(1.0)
+
+    # ─── load_beta ────────────────────────────────────────────────────────────
+    # Scalar beta load with zero padding for the ragged tail.
+
+    @cute.jit
+    def load_beta(
+        self,
+        sBeta: cute.Tensor,
+        g_beta: cute.Tensor,
+        blk_tok: cutlass.Int32,
+        tok_end: cutlass.Int32,
+        sab_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        beta_stage: cutlass.Int32,
+    ):
+        lane_id = cute.arch.lane_idx()
+        sBeta_k = sBeta[None, beta_stage]
+        num_iters = self.BLK_KV // 32
+        for i in cutlass.range_constexpr(num_iters):
+            row = cutlass.Int32(i * 32) + lane_id
+            tok = blk_tok + row
+            if tok < tok_end:
+                sBeta_k[row] = g_beta[tok * num_sab_heads + sab_head_idx]
+            else:
+                sBeta_k[row] = cutlass.Float32(0.0)
+
+    # ─── kv_load / kv_store ───────────────────────────────────────────────────
+
+    @cute.jit
+    def kv_load(
+        self,
+        tKVrKV: cute.Tensor,
+        gKV: cute.Tensor,
+        kv_tiled_mma,
+        thread_idx: cutlass.Int32,
+    ):
+        copy_atom_kv = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), gKV.element_type)
+        tiled_copy_kv = cute.make_tiled_copy_C(copy_atom_kv, kv_tiled_mma)
+        thr_copy_kv = tiled_copy_kv.get_slice(thread_idx)
+        tKVgKV = thr_copy_kv.partition_S(select_tensor_10(gKV))
+        cute.copy(tiled_copy_kv, tKVgKV, tKVrKV)
+
+    @cute.jit
+    def kv_store(
+        self,
+        tKVrKV: cute.Tensor,
+        gKV: cute.Tensor,
+        kv_tiled_mma,
+        thread_idx: cutlass.Int32,
+    ):
+        copy_atom_kv = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), gKV.element_type)
+        tiled_copy_kv = cute.make_tiled_copy_C(copy_atom_kv, kv_tiled_mma)
+        thr_copy_kv = tiled_copy_kv.get_slice(thread_idx)
+        tKVgKV = thr_copy_kv.partition_D(select_tensor_10(gKV))
+        cute.copy(tiled_copy_kv, tKVrKV, tKVgKV)
+
+    @cute.jit
+    def maybe_store_checkpoint(
+        self,
+        tKVrKV: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
+        checkpoint_every_n_tokens: cutlass.Int32,
+        kv_tiled_mma,
+        thread_idx: cutlass.Int32,
+        seq_idx: cutlass.Int32,
+        o_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        block_end: cutlass.Int32,
+        seq_len: cutlass.Int32,
+    ):
+        if cutlass.const_expr(self.needs_checkpointing):
+            if block_end <= seq_len and block_end % checkpoint_every_n_tokens == cutlass.Int32(0):
+                checkpoint_idx = (
+                    cutlass.Int32(checkpoint_cu_starts[seq_idx]) + block_end // checkpoint_every_n_tokens - cutlass.Int32(1)
+                )
+                checkpoint_layout = cute.make_ordered_layout(
+                    (self.D, self.D, num_sab_heads, total_checkpoints),
+                    order=(0, 1, 2, 3),
+                )
+                mCheckpoint = cute.make_tensor(g_state_checkpoints.iterator, checkpoint_layout)
+                gCheckpointKV = mCheckpoint[None, None, o_head_idx, checkpoint_idx]
+                self.kv_store(tKVrKV, gCheckpointKV, kv_tiled_mma, thread_idx)
+
+    # ─── compute_loop_body ───────────────────────────────────────────────────
+    # Called by Math WGs (tidx >= 128) for one block iteration.
+
+    @cute.jit
+    def compute_loop_body(
+        self,
+        # Smem tensors (staged; caller indexes the active stage)
+        sQ_SD: cute.Tensor,  # (BlkQ, D, StagesQ)  – row-major atom, swizzled
+        sK_SD: cute.Tensor,  # (BlkKV, D, StagesK) – same atom
+        sK_DS: cute.Tensor,  # (D, BlkKV, StagesK) – K transposed
+        sV_DS: cute.Tensor,  # (D, BlkKV, StagesV) – V transposed
+        sQK: cute.Tensor,  # (BlkQ, BlkKV, StagesQK)
+        sKK_inv: cute.Tensor,  # (BlkKV, BlkKV, StagesKK)
+        sKK_opd: cute.Tensor,  # sKK_inv storage recast as Element
+        sO: cute.Tensor,  # O output smem (staged)
+        sAlpha: cute.Tensor,  # (BlkQ, AlphaProcessor.NUM_CHANNELS, StagesAlpha) or zero-shaped
+        kv_tiled_mma,
+        # Mainloop pipelines and active read states
+        q_pipeline,
+        q_consumer_state,
+        k_pipeline,
+        k_consumer_state,
+        v_pipeline,
+        v_consumer_state,
+        o_pipeline,
+        o_producer_state,
+        qk_pipeline,
+        qk_consumer_state,
+        kk_pipeline,
+        kk_consumer_state,
+        alpha_pipeline,
+        alpha_consumer_state,
+        # Compile-time flags
+        is_first_block: bool,
+        is_final_block: bool,
+        # Valid token count for masking on final block
+        B: cutlass.Int32,
+        # Running KV state (D×D fp32, in registers across all blocks)
+        tKVrKV: cute.Tensor,
+        # Scale factor
+        scale: cutlass.Float32,
+        # WG role: MathWarpGroupRole.STATE0 or MathWarpGroupRole.STATE1.
+        wg_idx: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx - cutlass.Int32(128)  # relative to compute threads
+        # ── TiledMMAs ─────────────────────────────────────────────────────────
+        blk_q = cute.size(sQ_SD, mode=[0])
+        blk_kv = cute.size(sK_SD, mode=[0])
+        d = cute.size(sQ_SD, mode=[1])
+        mma_atom_o1 = cute.make_mma_atom(
+            warpgroup.MmaF16BF16Op(
+                self.dtype,
+                self.acc_dtype,
+                (64, blk_q, 16),
+                warpgroup.OperandSource.RMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
+            )
+        )
+        mma_atom_o2 = cute.make_mma_atom(
+            warpgroup.MmaF16BF16Op(
+                self.dtype,
+                self.acc_dtype,
+                (64, blk_q, 16),
+                warpgroup.OperandSource.RMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
+            )
+        )
+        mma_atom_sk = cute.make_mma_atom(
+            warpgroup.MmaF16BF16Op(
+                self.dtype,
+                self.acc_dtype,
+                (64, blk_kv, 16),
+                warpgroup.OperandSource.RMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
+            )
+        )
+        mma_atom_newv = cute.make_mma_atom(
+            warpgroup.MmaF16BF16Op(
+                self.dtype,
+                self.acc_dtype,
+                (64, blk_kv, 16),
+                warpgroup.OperandSource.RMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
+            )
+        )
+
+        # O1/O2/SK/NewV: two state warpgroups cooperate as in the C++ Hopper GMMA path.
+        o1_tiled_mma = cute.make_tiled_mma(mma_atom_o1, cute.make_layout((2, 1, 1)))
+        o2_tiled_mma = cute.make_tiled_mma(mma_atom_o2, cute.make_layout((2, 1, 1)))
+        sk_tiled_mma = cute.make_tiled_mma(mma_atom_sk, cute.make_layout((2, 1, 1)))
+        newv_tiled_mma = cute.make_tiled_mma(mma_atom_newv, cute.make_layout((2, 1, 1)))
+
+        # ── Thread slices ─────────────────────────────────────────────────────
+        sk_thr_mma = sk_tiled_mma.get_slice(thread_idx)
+        newv_thr_mma = newv_tiled_mma.get_slice(thread_idx)
+        o1_thr_mma = o1_tiled_mma.get_slice(thread_idx)
+        o2_thr_mma = o2_tiled_mma.get_slice(thread_idx)
+        kv_thr_mma = kv_tiled_mma.get_slice(thread_idx)
+
+        # ── Copy atoms ────────────────────────────────────────────────────────
+        ldsm_t4 = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4), self.dtype)
+
+        # ── SK copies ─────────────────────────────────────────────────────────
+        # SK C: V loaded from sV_DS (col-major D×BlkKV) with LDSM_T.
+        sk_tiled_copy_C = cute.make_tiled_copy_C(ldsm_t4, sk_tiled_mma)
+        sk_thr_copy_C = sk_tiled_copy_C.get_slice(thread_idx)
+        tSKsK = sk_thr_mma.partition_B(sK_SD)
+        tSKrK = sk_thr_mma.make_fragment_B(tSKsK)
+
+        # ── NewV copies ───────────────────────────────────────────────────────
+        tNewVsB = newv_thr_mma.partition_B(sKK_opd)
+        tNewVrB = newv_thr_mma.make_fragment_B(tNewVsB)
+
+        # ── KV copies ─────────────────────────────────────────────────────────
+        tKVsK = kv_thr_mma.partition_B(sK_DS)
+        tKVrK = kv_thr_mma.make_fragment_B(tKVsK)
+
+        # ── O1/O2 copies ──────────────────────────────────────────────────────
+        tOsQ = o1_thr_mma.partition_B(sQ_SD)
+        tOrQ = o1_thr_mma.make_fragment_B(tOsQ)
+        tOsQK = o2_thr_mma.partition_B(sQK)
+        tOrQK = o2_thr_mma.make_fragment_B(tOsQK)
+
+        # ── O store (R→S STSM) ────────────────────────────────────────────────
+        o_stsm = cute.make_copy_atom(warp.StMatrix8x8x16bOp(transpose=True, num_matrices=4), self.dtype)
+        o_tiled_copy_r2s = cute.make_tiled_copy_C(o_stsm, o1_tiled_mma)
+        o_thr_copy_r2s = o_tiled_copy_r2s.get_slice(thread_idx)
+        tOsO = o_thr_copy_r2s.partition_D(sO)
+
+        # ── Coordinate tensors for masking / alpha/beta indexing ──────────────
+        cO = cute.make_identity_tensor((d, blk_q))
+        tOcO = o1_thr_mma.partition_C(cO)
+        cSK = cute.make_identity_tensor((d, blk_kv))
+        tSKcSK = sk_thr_mma.partition_C(cSK)
+        cV = cute.make_identity_tensor((d, blk_kv))
+        tKVcV = kv_thr_mma.partition_A(cV)
+
+        # ── O1: KV_state @ Q (both state WGs, skip on first block) ───────────
+        q_pipeline.consumer_wait(q_consumer_state)
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_pipeline.consumer_wait(alpha_consumer_state)
+            cute.arch.fence_view_async_shared()
+        tOrO = o1_thr_mma.make_fragment_C(o1_thr_mma.partition_shape_C((d, blk_q)))
+        if cutlass.const_expr(not is_first_block):
+            tOrKV = SM90.make_acc_into_op(tKVrKV, o1_tiled_mma, self.dtype)
+            SM90.warpgroup_fence_operand(tOrKV)
+            SM90.warpgroup_fence_operand(tOrO)
+            cute.nvgpu.warpgroup.fence()
+            self._math_order_wait(wg_idx)
+            SM90.wgmma_gemm_zero_acc(
+                o1_tiled_mma,
+                tOrO,
+                tOrKV,
+                tOrQ[None, None, None, q_consumer_state.index],
+            )
+            cute.nvgpu.warpgroup.commit_group()
+            self._math_order_notify(wg_idx)
+            cute.nvgpu.warpgroup.wait_group(0)
+            self.o1_epi(tOrO, tOcO, sAlpha, alpha_consumer_state.index, scale)
+        q_pipeline.consumer_release(q_consumer_state)
+        q_consumer_state.advance()
+
+        # ── SK: KV_state @ K^T (result negated below via V - SK) ─────────────
+        k_pipeline.consumer_wait(k_consumer_state)
+        tSKrSK = sk_thr_mma.make_fragment_C(sk_thr_mma.partition_shape_C((d, blk_kv)))
+        if cutlass.const_expr(not is_first_block):
+            tSKrS = SM90.make_acc_into_op(tKVrKV, sk_tiled_mma, self.dtype)
+            SM90.warpgroup_fence_operand(tSKrSK)
+            SM90.warpgroup_fence_operand(tSKrS)
+            cute.nvgpu.warpgroup.fence()
+            self._math_order_wait(wg_idx)
+            SM90.wgmma_gemm_zero_acc(
+                sk_tiled_mma,
+                tSKrSK,
+                tSKrS,
+                tSKrK[None, None, None, k_consumer_state.index],
+            )
+            cute.nvgpu.warpgroup.commit_group()
+            self._math_order_notify(wg_idx)
+            cute.nvgpu.warpgroup.wait_group(0)
+
+        # ── Load V from smem ──────────────────────────────────────────────────
+        v_pipeline.consumer_wait(v_consumer_state)
+        tSKrV = self.sk_load_v(
+            tSKrSK,
+            sV_DS,
+            sk_tiled_copy_C,
+            sk_thr_copy_C,
+            v_consumer_state.index,
+        )
+
+        # sk_epi + V - SK  (SK=0 on first block, so V - SK = V)
+        if cutlass.const_expr(not is_first_block):
+            self.sk_epi(tSKrSK, tSKcSK, sAlpha, alpha_consumer_state.index)
+            for i in cutlass.range_constexpr(cute.size(tSKrV)):
+                tSKrV[i] = tSKrV[i] - self.dtype(tSKrSK[i])
+
+        # ── NewV = (V - SK) @ T^T  (ordered: WG0 first) ──────────────────────
+        tNewVrA = SM90.make_acc_into_op(tSKrV, newv_tiled_mma, self.dtype)
+        tNewVrC = newv_thr_mma.make_fragment_C(newv_thr_mma.partition_shape_C((d, blk_kv)))
+        kk_pipeline.consumer_wait(kk_consumer_state)
+        SM90.warpgroup_fence_operand(tNewVrA)
+        SM90.warpgroup_fence_operand(tNewVrC)
+        cute.nvgpu.warpgroup.fence()
+        self._math_order_wait(wg_idx)
+        SM90.wgmma_gemm_zero_acc(
+            newv_tiled_mma,
+            tNewVrC,
+            tNewVrA,
+            tNewVrB[None, None, None, kk_consumer_state.index],
+        )
+        cute.nvgpu.warpgroup.commit_group()
+        self._math_order_notify(wg_idx)
+        cute.nvgpu.warpgroup.wait_group(0)
+        # Release the exact V stage that was waited above, after the last
+        # register copy/WGMMA dependency, and only then advance the ring state.
+        v_pipeline.consumer_release(v_consumer_state)
+        v_consumer_state.advance()
+        kk_pipeline.consumer_release(kk_consumer_state)
+        kk_consumer_state.advance()
+
+        # ── O2 = O1 + NewV @ QK  (ordered: WG0 first) ────────────────────────
+        tOrV_or_tKVrV = SM90.make_acc_into_op(tNewVrC, kv_tiled_mma, self.dtype)
+        qk_pipeline.consumer_wait(qk_consumer_state)
+        SM90.warpgroup_fence_operand(tOrV_or_tKVrV)
+        SM90.warpgroup_fence_operand(tOrO)
+        cute.nvgpu.warpgroup.fence()
+        self._math_order_wait(wg_idx)
+        SM90.wgmma_gemm(
+            o2_tiled_mma,
+            tOrO,
+            tOrV_or_tKVrV,
+            tOrQK[None, None, None, qk_consumer_state.index],
+            not is_first_block,
+        )
+        cute.nvgpu.warpgroup.commit_group()
+        self._math_order_notify(wg_idx)
+        cute.nvgpu.warpgroup.wait_group(0)
+        qk_pipeline.consumer_release(qk_consumer_state)
+        qk_consumer_state.advance()
+
+        # ── O store to smem ───────────────────────────────────────────────────
+        o_pipeline.producer_acquire(o_producer_state)
+        self.o_store(
+            tOrO,
+            tOsO[None, None, None, o_producer_state.index],
+            o_tiled_copy_r2s,
+            o_thr_copy_r2s,
+        )
+        o_pipeline.producer_commit(o_producer_state)
+        o_producer_state.advance()
+
+        # ── KV state update ───────────────────────────────────────────────────
+        block_coeff = cutlass.Float32(1.0)
+        if cutlass.const_expr(self.needs_alpha):
+            block_coeff = cutlass.Float32(
+                sAlpha[
+                    B - cutlass.Int32(1),
+                    AlphaProcessor.CUMPROD,
+                    alpha_consumer_state.index,
+                ]
+            )
+
+        for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
+            tKVrKV[i] = block_coeff * tKVrKV[i]
+
+        self.kv_decay_v(tOrV_or_tKVrV, tKVcV, sAlpha, alpha_consumer_state.index, is_final_block, B)
+
+        # KV += NewV @ K
+        SM90.warpgroup_fence_operand(tOrV_or_tKVrV)
+        SM90.warpgroup_fence_operand(tKVrKV)
+        cute.nvgpu.warpgroup.fence()
+        self._math_order_wait(wg_idx)
+        SM90.wgmma_gemm(
+            kv_tiled_mma,
+            tKVrKV,
+            tOrV_or_tKVrV,
+            tKVrK[None, None, None, k_consumer_state.index],
+            True,
+        )
+        cute.nvgpu.warpgroup.commit_group()
+        self._math_order_notify(wg_idx)
+        cute.nvgpu.warpgroup.wait_group(0)
+        k_pipeline.consumer_release(k_consumer_state)
+        k_consumer_state.advance()
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_pipeline.consumer_release(alpha_consumer_state)
+            alpha_consumer_state.advance()
+        return (
+            q_consumer_state,
+            k_consumer_state,
+            v_consumer_state,
+            o_producer_state,
+            qk_consumer_state,
+            kk_consumer_state,
+            alpha_consumer_state,
+        )
+
+    # ─── Warp role entry points ──────────────────────────────────────────────
+    # Each warp-specialized role owns and advances its own pipeline loop.
+
+    @cute.jit
+    def run_load_qkv_role(
+        self,
+        sQ_SD: cute.Tensor,
+        sK_DS: cute.Tensor,
+        sV_DS: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        tma_tensor_q: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        tma_tensor_v: cute.Tensor,
+        q_pipeline,
+        k_pipeline,
+        v_pipeline,
+        num_blocks: cutlass.Int32,
+        tok_start: cutlass.Int32,
+        q_head_idx: cutlass.Int32,
+        k_head_idx: cutlass.Int32,
+        v_head_idx: cutlass.Int32,
+    ):
+        q_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.q_stage)
+        k_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.k_stage)
+        v_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.v_stage)
+        for blk in cutlass.range(num_blocks, unroll=1):
+            (
+                q_producer_state,
+                k_producer_state,
+                v_producer_state,
+            ) = self.load_qkv_tma(
+                sQ_SD,
+                sK_DS,
+                sV_DS,
+                tma_atom_q,
+                tma_tensor_q,
+                tma_atom_k,
+                tma_tensor_k,
+                tma_atom_v,
+                tma_tensor_v,
+                q_pipeline,
+                q_producer_state,
+                k_pipeline,
+                k_producer_state,
+                v_pipeline,
+                v_producer_state,
+                blk,
+                tok_start,
+                q_head_idx,
+                k_head_idx,
+                v_head_idx,
+            )
+
+    @cute.jit
+    def run_load_alpha_role(
+        self,
+        sAlpha: cute.Tensor,
+        g_alpha: cute.Tensor,
+        alpha_pipeline,
+        scale: cutlass.Float32,
+        num_blocks: cutlass.Int32,
+        tok_start: cutlass.Int32,
+        tok_end: cutlass.Int32,
+        sab_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+    ):
+        alpha_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.alpha_beta_stage)
+        for blk in cutlass.range(num_blocks, unroll=1):
+            blk_tok = tok_start + blk * cutlass.Int32(self.BLK_Q)
+            if cutlass.const_expr(self.needs_alpha):
+                alpha_pipeline.producer_acquire(alpha_producer_state)
+                cute.arch.fence_view_async_shared()
+                self.load_alpha(
+                    sAlpha,
+                    g_alpha,
+                    blk_tok,
+                    tok_end,
+                    sab_head_idx,
+                    num_sab_heads,
+                    alpha_producer_state.index,
+                )
+                AlphaProcessor().run(sAlpha[None, None, alpha_producer_state.index], scale)
+                cute.arch.fence_view_async_shared()
+                alpha_pipeline.producer_commit(alpha_producer_state)
+                alpha_producer_state.advance()
+
+    @cute.jit
+    def run_load_beta_role(
+        self,
+        sBeta: cute.Tensor,
+        g_beta: cute.Tensor,
+        beta_pipeline,
+        num_blocks: cutlass.Int32,
+        tok_start: cutlass.Int32,
+        tok_end: cutlass.Int32,
+        sab_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+    ):
+        beta_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.alpha_beta_stage)
+        for blk in cutlass.range(num_blocks, unroll=1):
+            blk_tok = tok_start + blk * cutlass.Int32(self.BLK_KV)
+            if cutlass.const_expr(self.needs_beta):
+                beta_pipeline.producer_acquire(beta_producer_state)
+                cute.arch.fence_view_async_shared()
+                self.load_beta(
+                    sBeta,
+                    g_beta,
+                    blk_tok,
+                    tok_end,
+                    sab_head_idx,
+                    num_sab_heads,
+                    beta_producer_state.index,
+                )
+                cute.arch.fence_view_async_shared()
+                beta_pipeline.producer_commit(beta_producer_state)
+                beta_producer_state.advance()
+
+    @cute.jit
+    def run_state_math_role(
+        self,
+        sQ_SD: cute.Tensor,
+        sK_SD: cute.Tensor,
+        sK_DS: cute.Tensor,
+        sV_DS: cute.Tensor,
+        sQK: cute.Tensor,
+        sKK_inv: cute.Tensor,
+        sKK_opd: cute.Tensor,
+        sO: cute.Tensor,
+        sAlpha: cute.Tensor,
+        q_pipeline,
+        k_pipeline,
+        v_pipeline,
+        o_pipeline,
+        qk_pipeline,
+        kk_pipeline,
+        alpha_pipeline,
+        g_state: cute.Tensor,
+        g_init_state: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
+        work_desc: WorkDesc,
+        scale: cutlass.Float32,
+        wg_idx: cutlass.Int32,
+        math_tidx: cutlass.Int32,
+        num_blocks: cutlass.Int32,
+        num_q_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
+    ):
+        self._math_order_init(wg_idx)
+        q_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.q_stage)
+        k_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.k_stage)
+        v_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.v_stage)
+        o_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.o_stage)
+        qk_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.qk_stage)
+        kk_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.kk_stage)
+        alpha_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+
+        kv_tiled_mma = cute.make_tiled_mma(
+            cute.make_mma_atom(
+                warpgroup.MmaF16BF16Op(
+                    self.dtype,
+                    self.acc_dtype,
+                    (64, self.D, 16),
+                    warpgroup.OperandSource.RMEM,
+                    cute.nvgpu.OperandMajorMode.K,
+                    cute.nvgpu.OperandMajorMode.MN,
+                )
+            ),
+            cute.make_layout((2, 1, 1)),
+        )
+        kv_thr_mma = kv_tiled_mma.get_slice(math_tidx)
+        tKVrKV = kv_thr_mma.make_fragment_C(kv_thr_mma.partition_shape_C((self.D, self.D)))
+        tKVrKV.fill(self.acc_dtype(0.0))
+
+        state_layout = cute.make_ordered_layout((self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3))
+        o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
+        mState = cute.make_tensor(g_state.iterator, state_layout)
+        gStateKV = mState[None, None, o_head_idx, work_desc.seq_idx]
+        if cutlass.const_expr(self.needs_init_state):
+            mInitState = cute.make_tensor(g_init_state.iterator, state_layout)
+            gInitKV = mInitState[None, None, o_head_idx, work_desc.seq_idx]
+            self.kv_load(tKVrKV, gInitKV, kv_tiled_mma, math_tidx)
+
+        first_B = work_desc.seq_len
+        if first_B > cutlass.Int32(self.BLK_KV):
+            first_B = cutlass.Int32(self.BLK_KV)
+        if cutlass.const_expr(self.needs_init_state):
+            (
+                q_consumer_state,
+                k_consumer_state,
+                v_consumer_state,
+                o_producer_state,
+                qk_consumer_state,
+                kk_consumer_state,
+                alpha_consumer_state,
+            ) = self.compute_loop_body(
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
+                kv_tiled_mma,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                o_pipeline,
+                o_producer_state,
+                qk_pipeline,
+                qk_consumer_state,
+                kk_pipeline,
+                kk_consumer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                False,
+                True,
+                first_B,
+                tKVrKV,
+                scale,
+                wg_idx,
+            )
+        else:
+            (
+                q_consumer_state,
+                k_consumer_state,
+                v_consumer_state,
+                o_producer_state,
+                qk_consumer_state,
+                kk_consumer_state,
+                alpha_consumer_state,
+            ) = self.compute_loop_body(
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
+                kv_tiled_mma,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                o_pipeline,
+                o_producer_state,
+                qk_pipeline,
+                qk_consumer_state,
+                kk_pipeline,
+                kk_consumer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                True,
+                True,
+                first_B,
+                tKVrKV,
+                scale,
+                wg_idx,
+            )
+        self.maybe_store_checkpoint(
+            tKVrKV,
+            g_state_checkpoints,
+            checkpoint_cu_starts,
+            checkpoint_every_n_tokens,
+            kv_tiled_mma,
+            math_tidx,
+            work_desc.seq_idx,
+            o_head_idx,
+            num_sab_heads,
+            total_checkpoints,
+            cutlass.Int32(self.BLK_KV),
+            work_desc.seq_len,
+        )
+
+        for blk in cutlass.range(cutlass.Int32(1), num_blocks - cutlass.Int32(1), cutlass.Int32(1), unroll=1):
+            (
+                q_consumer_state,
+                k_consumer_state,
+                v_consumer_state,
+                o_producer_state,
+                qk_consumer_state,
+                kk_consumer_state,
+                alpha_consumer_state,
+            ) = self.compute_loop_body(
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
+                kv_tiled_mma,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                o_pipeline,
+                o_producer_state,
+                qk_pipeline,
+                qk_consumer_state,
+                kk_pipeline,
+                kk_consumer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                False,
+                False,
+                cutlass.Int32(self.BLK_KV),
+                tKVrKV,
+                scale,
+                wg_idx,
+            )
+            self.maybe_store_checkpoint(
+                tKVrKV,
+                g_state_checkpoints,
+                checkpoint_cu_starts,
+                checkpoint_every_n_tokens,
+                kv_tiled_mma,
+                math_tidx,
+                work_desc.seq_idx,
+                o_head_idx,
+                num_sab_heads,
+                total_checkpoints,
+                (blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV),
+                work_desc.seq_len,
+            )
+
+        if num_blocks != cutlass.Int32(1):
+            last_blk = num_blocks - cutlass.Int32(1)
+            last_B = work_desc.seq_len - last_blk * cutlass.Int32(self.BLK_KV)
+            (
+                q_consumer_state,
+                k_consumer_state,
+                v_consumer_state,
+                o_producer_state,
+                qk_consumer_state,
+                kk_consumer_state,
+                alpha_consumer_state,
+            ) = self.compute_loop_body(
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
+                kv_tiled_mma,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                o_pipeline,
+                o_producer_state,
+                qk_pipeline,
+                qk_consumer_state,
+                kk_pipeline,
+                kk_consumer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                False,
+                True,
+                last_B,
+                tKVrKV,
+                scale,
+                wg_idx,
+            )
+            self.maybe_store_checkpoint(
+                tKVrKV,
+                g_state_checkpoints,
+                checkpoint_cu_starts,
+                checkpoint_every_n_tokens,
+                kv_tiled_mma,
+                math_tidx,
+                work_desc.seq_idx,
+                o_head_idx,
+                num_sab_heads,
+                total_checkpoints,
+                (last_blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV),
+                work_desc.seq_len,
+            )
+        self.kv_store(tKVrKV, gStateKV, kv_tiled_mma, math_tidx)
+
+    @cute.jit
+    def run_aux_loop_body(
+        self,
+        sQK: cute.Tensor,
+        sKK_inv: cute.Tensor,
+        sKK_opd: cute.Tensor,
+        sAlpha: cute.Tensor,
+        sBeta: cute.Tensor,
+        q_pipeline,
+        q_consumer_state,
+        k_pipeline,
+        k_consumer_state,
+        qk_pipeline,
+        qk_producer_state,
+        kk_pipeline,
+        kk_producer_state,
+        alpha_pipeline,
+        alpha_consumer_state,
+        beta_pipeline,
+        beta_consumer_state,
+        work_desc: WorkDesc,
+        scale: cutlass.Float32,
+        blk: cutlass.Int32,
+        is_final_block: bool,
+        qk_tiled_mma,
+        kk_tiled_mma,
+        tQKrQ: cute.Tensor,
+        tQKrK: cute.Tensor,
+        tKKrA: cute.Tensor,
+        tKKrB: cute.Tensor,
+        tQKcMqk: cute.Tensor,
+        tKKcMkk: cute.Tensor,
+        aux_tidx: cutlass.Int32,
+    ):
+        B = cutlass.Int32(self.BLK_KV)
+        if cutlass.const_expr(is_final_block):
+            B = work_desc.seq_len - blk * cutlass.Int32(self.BLK_KV)
+
+        k_pipeline.consumer_wait(k_consumer_state)
+
+        tKKrKK = kk_tiled_mma.get_slice(aux_tidx).make_fragment_C(
+            kk_tiled_mma.get_slice(aux_tidx).partition_shape_C((self.BLK_KV, self.BLK_KV))
+        )
+        cute.nvgpu.warpgroup.fence()
+        SM90.wgmma_gemm_zero_acc(
+            kk_tiled_mma,
+            tKKrKK,
+            tKKrA[None, None, None, k_consumer_state.index],
+            tKKrB[None, None, None, k_consumer_state.index],
+        )
+        cute.nvgpu.warpgroup.commit_group()
+
+        q_pipeline.consumer_wait(q_consumer_state)
+        tQKrQK = qk_tiled_mma.get_slice(aux_tidx).make_fragment_C(
+            qk_tiled_mma.get_slice(aux_tidx).partition_shape_C((self.BLK_Q, self.BLK_KV))
+        )
+        cute.nvgpu.warpgroup.fence()
+        SM90.wgmma_gemm_zero_acc(
+            qk_tiled_mma,
+            tQKrQK,
+            tQKrQ[None, None, None, q_consumer_state.index],
+            tQKrK[None, None, None, k_consumer_state.index],
+        )
+        cute.nvgpu.warpgroup.commit_group()
+        cute.nvgpu.warpgroup.wait_group(0)
+
+        k_pipeline.consumer_release(k_consumer_state)
+        k_consumer_state.advance()
+        q_pipeline.consumer_release(q_consumer_state)
+        q_consumer_state.advance()
+
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_pipeline.consumer_wait(alpha_consumer_state)
+        if cutlass.const_expr(self.needs_beta):
+            beta_pipeline.consumer_wait(beta_consumer_state)
+        cute.arch.fence_view_async_shared()
+
+        self.qk_and_kk_epi(
+            tQKrQK,
+            tKKrKK,
+            tQKcMqk,
+            tKKcMkk,
+            sAlpha,
+            sBeta,
+            alpha_consumer_state.index,
+            beta_consumer_state.index,
+            is_final_block,
+            B,
+            scale,
+        )
+
+        kk_pipeline.producer_acquire(kk_producer_state)
+        self._kk_store_and_inv(
+            tKKrKK,
+            kk_tiled_mma,
+            aux_tidx,
+            sKK_inv[None, None, kk_producer_state.index],
+            sKK_opd[None, None, kk_producer_state.index],
+            sBeta,
+            beta_consumer_state.index,
+            tKKcMkk,
+        )
+        cute.arch.fence_view_async_shared()
+        kk_pipeline.producer_commit(kk_producer_state)
+        kk_producer_state.advance()
+
+        qk_pipeline.producer_acquire(qk_producer_state)
+        self.qk_store(
+            tQKrQK,
+            sQK[None, None, qk_producer_state.index],
+            qk_tiled_mma,
+            aux_tidx,
+        )
+        cute.arch.fence_view_async_shared()
+        qk_pipeline.producer_commit(qk_producer_state)
+        qk_producer_state.advance()
+
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_pipeline.consumer_release(alpha_consumer_state)
+            alpha_consumer_state.advance()
+        if cutlass.const_expr(self.needs_beta):
+            beta_pipeline.consumer_release(beta_consumer_state)
+            beta_consumer_state.advance()
+
+        return (
+            q_consumer_state,
+            k_consumer_state,
+            qk_producer_state,
+            kk_producer_state,
+            alpha_consumer_state,
+            beta_consumer_state,
+        )
+
+    @cute.jit
+    def run_aux_math_role(
+        self,
+        sQ_SD: cute.Tensor,
+        sK_SD: cute.Tensor,
+        sQK: cute.Tensor,
+        sKK_inv: cute.Tensor,
+        sKK_opd: cute.Tensor,
+        sAlpha: cute.Tensor,
+        sBeta: cute.Tensor,
+        q_pipeline,
+        k_pipeline,
+        qk_pipeline,
+        kk_pipeline,
+        alpha_pipeline,
+        beta_pipeline,
+        work_desc: WorkDesc,
+        scale: cutlass.Float32,
+        math_tidx: cutlass.Int32,
+        num_blocks: cutlass.Int32,
+    ):
+        aux_tidx = math_tidx % cutlass.Int32(128)
+
+        qk_tiled_mma = cute.make_tiled_mma(
+            cute.make_mma_atom(
+                warpgroup.MmaF16BF16Op(
+                    self.dtype,
+                    self.acc_dtype,
+                    (self.BLK_Q, self.BLK_KV, 16),
+                    warpgroup.OperandSource.SMEM,
+                    cute.nvgpu.OperandMajorMode.K,
+                    cute.nvgpu.OperandMajorMode.K,
+                )
+            ),
+            cute.make_layout((1, 1, 1)),
+        )
+        kk_tiled_mma = cute.make_tiled_mma(
+            cute.make_mma_atom(
+                warpgroup.MmaF16BF16Op(
+                    self.dtype,
+                    self.acc_dtype,
+                    (self.BLK_KV, self.BLK_KV, 16),
+                    warpgroup.OperandSource.SMEM,
+                    cute.nvgpu.OperandMajorMode.K,
+                    cute.nvgpu.OperandMajorMode.K,
+                )
+            ),
+            cute.make_layout((1, 1, 1)),
+        )
+
+        qk_thr_mma = qk_tiled_mma.get_slice(aux_tidx)
+        kk_thr_mma = kk_tiled_mma.get_slice(aux_tidx)
+
+        tQKsQ = qk_thr_mma.partition_A(sQ_SD)
+        tQKsK = qk_thr_mma.partition_B(sK_SD)
+        tQKrQ = qk_thr_mma.make_fragment_A(tQKsQ)
+        tQKrK = qk_thr_mma.make_fragment_B(tQKsK)
+
+        tKKsA = kk_thr_mma.partition_A(sK_SD)
+        tKKsB = kk_thr_mma.partition_B(sK_SD)
+        tKKrA = kk_thr_mma.make_fragment_A(tKKsA)
+        tKKrB = kk_thr_mma.make_fragment_B(tKKsB)
+
+        cMqk = cute.make_identity_tensor((self.BLK_Q, self.BLK_KV))
+        tQKcMqk = qk_thr_mma.partition_C(cMqk)
+        tKKcMkk = kk_thr_mma.partition_C(cMqk)
+
+        q_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.q_stage)
+        k_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.k_stage)
+        qk_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.qk_stage)
+        kk_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.kk_stage)
+        alpha_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+        beta_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+
+        for blk in cutlass.range(num_blocks - cutlass.Int32(1), unroll=1):
+            (
+                q_consumer_state,
+                k_consumer_state,
+                qk_producer_state,
+                kk_producer_state,
+                alpha_consumer_state,
+                beta_consumer_state,
+            ) = self.run_aux_loop_body(
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sAlpha,
+                sBeta,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                qk_pipeline,
+                qk_producer_state,
+                kk_pipeline,
+                kk_producer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                beta_pipeline,
+                beta_consumer_state,
+                work_desc,
+                scale,
+                blk,
+                False,
+                qk_tiled_mma,
+                kk_tiled_mma,
+                tQKrQ,
+                tQKrK,
+                tKKrA,
+                tKKrB,
+                tQKcMqk,
+                tKKcMkk,
+                aux_tidx,
+            )
+
+        last_blk = num_blocks - cutlass.Int32(1)
+        (
+            q_consumer_state,
+            k_consumer_state,
+            qk_producer_state,
+            kk_producer_state,
+            alpha_consumer_state,
+            beta_consumer_state,
+        ) = self.run_aux_loop_body(
+            sQK,
+            sKK_inv,
+            sKK_opd,
+            sAlpha,
+            sBeta,
+            q_pipeline,
+            q_consumer_state,
+            k_pipeline,
+            k_consumer_state,
+            qk_pipeline,
+            qk_producer_state,
+            kk_pipeline,
+            kk_producer_state,
+            alpha_pipeline,
+            alpha_consumer_state,
+            beta_pipeline,
+            beta_consumer_state,
+            work_desc,
+            scale,
+            last_blk,
+            True,
+            qk_tiled_mma,
+            kk_tiled_mma,
+            tQKrQ,
+            tQKrK,
+            tKKrA,
+            tKKrB,
+            tQKcMqk,
+            tKKcMkk,
+            aux_tidx,
+        )
+
+    # ─── Kernel entry point ───────────────────────────────────────────────────
+
+    @cute.jit
+    def __call__(
+        self,
+        g_q: cute.Tensor,
+        g_k: cute.Tensor,
+        g_v: cute.Tensor,
+        g_o: cute.Tensor,
+        g_alpha: cute.Tensor,
+        g_beta: cute.Tensor,
+        g_state: cute.Tensor,
+        g_init_state: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
+        g_tensormaps: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        scale: cutlass.Float32,
+        num_q_heads: cutlass.Int32,
+        num_k_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
+        grid_x: int,
+        stream,
+    ):
+        qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_SW128,
+            self.dtype,
+        )
+        q_storage_layout = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_Q, self.D, self.q_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        q_smem_layout = cute.slice_(q_storage_layout, (None, None, 0))
+        k_storage_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.k_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        k_storage_layout_ds = cute.select(k_storage_layout_sd, [1, 0, 2])
+        v_storage_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.v_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        v_storage_layout_ds = cute.select(v_storage_layout_sd, [1, 0, 2])
+        k_smem_layout = cute.slice_(k_storage_layout_ds, (None, None, 0))
+        v_smem_layout = cute.slice_(v_storage_layout_ds, (None, None, 0))
+        o_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.MN_SW32,
+            self.dtype,
+        )
+        o_storage_layout = cute.tile_to_shape(
+            o_smem_layout_atom,
+            (self.D, self.BLK_Q, self.o_stage),
+            order=(1, 0, 2),
+        )
+        o_smem_layout = cute.slice_(o_storage_layout, (None, None, 0))
+
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_q, tma_tensor_q = cpasync.make_tiled_tma_atom(tma_load_op, g_q, q_smem_layout, (self.BLK_Q, self.D))
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(tma_load_op, g_k, k_smem_layout, (self.D, self.BLK_KV))
+        tma_atom_v, tma_tensor_v = cpasync.make_tiled_tma_atom(tma_load_op, g_v, v_smem_layout, (self.D, self.BLK_KV))
+
+        tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
+        tma_atom_o, tma_tensor_o = cpasync.make_tiled_tma_atom(tma_store_op, g_o, o_smem_layout, (self.D, self.BLK_Q))
+
+        dtype_bytes = self.dtype.width // 8
+        self.tma_load_q_bytes = cute.size(q_smem_layout) * dtype_bytes
+        self.tma_load_k_bytes = cute.size(k_smem_layout) * dtype_bytes
+        self.tma_load_v_bytes = cute.size(v_smem_layout) * dtype_bytes
+
+        qk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
+        qk_storage_layout = cute.tile_to_shape(qk_layout_atom, (self.BLK_Q, self.BLK_KV, self.qk_stage), order=(0, 1, 2))
+        kk_storage_layout = cute.tile_to_shape(qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.kk_stage), order=(0, 1, 2))
+        alpha_storage_layout = cute.make_layout((self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage))
+        beta_storage_layout = cute.make_layout((self.BLK_KV, self.alpha_beta_stage))
+
+        @cute.struct
+        class SharedStorage:
+            q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.q_stage * 2]
+            k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.k_stage * 2]
+            v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.v_stage * 2]
+            o_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.o_stage * 2]
+            qk_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.qk_stage * 2]
+            kk_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.kk_stage * 2]
+            alpha_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.alpha_beta_stage * 2]
+            beta_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.alpha_beta_stage * 2]
+
+            smem_q: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(q_storage_layout)],
+                128,
+            ]
+            smem_k: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)],
+                128,
+            ]
+            smem_v: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(v_storage_layout_sd)],
+                128,
+            ]
+            smem_qk: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(qk_storage_layout)],
+                16,
+            ]
+            smem_kk: cute.struct.Align[
+                cute.struct.MemRange[self.inverse_dtype, cute.cosize(kk_storage_layout)],
+                16,
+            ]
+            smem_o: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(o_storage_layout)],
+                128,
+            ]
+            smem_alpha: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(alpha_storage_layout)],
+                16,
+            ]
+            smem_beta: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_storage_layout)],
+                16,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.kernel(
+            g_alpha,
+            g_beta,
+            tma_atom_q,
+            tma_tensor_q,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_o,
+            tma_tensor_o,
+            g_state,
+            g_init_state,
+            g_state_checkpoints,
+            checkpoint_cu_starts,
+            g_tensormaps,
+            cu_seqlens,
+            scale,
+            num_q_heads,
+            num_k_heads,
+            num_v_heads,
+            num_sab_heads,
+            num_seqs,
+            total_checkpoints,
+            checkpoint_every_n_tokens,
+        ).launch(
+            grid=(grid_x, 1, 1),
+            block=(512, 1, 1),
+            max_number_threads=(512, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        g_alpha: cute.Tensor,
+        g_beta: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        tma_tensor_q: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        tma_tensor_v: cute.Tensor,
+        tma_atom_o: cute.CopyAtom,
+        tma_tensor_o: cute.Tensor,
+        g_state: cute.Tensor,
+        g_init_state: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
+        g_tensormaps: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        scale: cutlass.Float32,
+        num_q_heads: cutlass.Int32,
+        num_k_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
+    ):
+        NUM_LOAD_WARP_GROUPS = 1
+        NUM_STATE_MMA_WARP_GROUPS = 2
+        NUM_AUX_MMA_WARP_GROUPS = 1
+        THREADS_PER_WARP_GROUP = 128
+        WARPS_PER_WARP_GROUP = 4
+        MIN_BLOCKS_PER_MP = 1
+        MAX_THREADS_PER_BLOCK = (
+            NUM_LOAD_WARP_GROUPS + NUM_STATE_MMA_WARP_GROUPS + NUM_AUX_MMA_WARP_GROUPS
+        ) * THREADS_PER_WARP_GROUP
+        (
+            load_registers,
+            state_mma_registers,
+            aux_mma_registers,
+        ) = self.get_register_requirements(
+            MAX_THREADS_PER_BLOCK,
+            MIN_BLOCKS_PER_MP,
+            NUM_STATE_MMA_WARP_GROUPS,
+            THREADS_PER_WARP_GROUP,
+        )
+
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group_idx = cute.arch.make_warp_uniform(tidx // cutlass.Int32(THREADS_PER_WARP_GROUP))
+        ldst_warp_role = cute.arch.make_warp_uniform(warp_idx % cutlass.Int32(WARPS_PER_WARP_GROUP))
+
+        if warp_idx == LoadStoreWarpRole.LOAD_QKV:
+            cpasync.prefetch_descriptor(tma_atom_q)
+            cpasync.prefetch_descriptor(tma_atom_k)
+            cpasync.prefetch_descriptor(tma_atom_v)
+            cpasync.prefetch_descriptor(tma_atom_o)
+
+        work_desc = self.get_next_work(
+            cu_seqlens,
+            num_q_heads,
+            num_v_heads,
+            num_sab_heads,
+        )
+        # Keep the absolute packed-buffer end. Tail loads and stores must stop
+        # here rather than treating the next packed sequence as valid padding.
+        tok_end = work_desc.tok_offset + work_desc.seq_len
+        num_blocks = (work_desc.seq_len + cutlass.Int32(self.BLK_KV) - cutlass.Int32(1)) // cutlass.Int32(self.BLK_KV)
+
+        # math_tidx / wg_idx: valid for Math WG threads; LdSt WG gets negative values (unused)
+        math_tidx = tidx - cutlass.Int32(THREADS_PER_WARP_GROUP)
+        wg_idx = math_tidx // cutlass.Int32(THREADS_PER_WARP_GROUP)
+
+        # ── Smem allocation ───────────────────────────────────────────────────
+        allocator = cutlass.utils.SmemAllocator()
+        storage = allocator.allocate(self.shared_storage)
+
+        qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_SW128,
+            self.dtype,
+        )
+        q_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_Q, self.D, self.q_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        sQ_SD = storage.smem_q.get_tensor(q_layout_sd.outer, swizzle=q_layout_sd.inner)
+
+        k_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.k_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        # K has one physical shared-memory allocation and two consumer views:
+        # (T,D) for QK/SK and (D,T) for KV. Selecting modes changes only the
+        # logical layout; it does not transpose or duplicate the stored bytes.
+        k_layout_ds = cute.select(k_layout_sd, [1, 0, 2])
+        sK_SD = storage.smem_k.get_tensor(k_layout_sd.outer, swizzle=k_layout_sd.inner)
+        sK_DS = storage.smem_k.get_tensor(k_layout_ds.outer, swizzle=k_layout_ds.inner)
+
+        v_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.v_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        v_layout_ds = cute.select(v_layout_sd, [1, 0, 2])
+        sV_DS = storage.smem_v.get_tensor(v_layout_ds.outer, swizzle=v_layout_ds.inner)
+
+        qk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
+        qk_layout = cute.tile_to_shape(qk_layout_atom, (self.BLK_Q, self.BLK_KV, self.qk_stage), order=(0, 1, 2))
+        sQK = storage.smem_qk.get_tensor(qk_layout)
+
+        kk_layout = cute.tile_to_shape(qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.kk_stage), order=(0, 1, 2))
+        sKK_inv = storage.smem_kk.get_tensor(kk_layout)
+        kk_opd_ptr = cute.recast_ptr(storage.smem_kk.data_ptr(), dtype=self.dtype)
+        sKK_opd = cute.make_tensor(kk_opd_ptr, kk_layout)
+
+        o_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.MN_SW32,
+            self.dtype,
+        )
+        o_layout = cute.tile_to_shape(
+            o_smem_layout_atom,
+            (self.D, self.BLK_Q, self.o_stage),
+            order=(1, 0, 2),
+        )
+        sO = storage.smem_o.get_tensor(o_layout.outer, swizzle=o_layout.inner)
+        alpha_layout = cute.make_layout((self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage))
+        sAlpha = storage.smem_alpha.get_tensor(alpha_layout)
+
+        beta_layout = cute.make_layout((self.BLK_KV, self.alpha_beta_stage))
+        sBeta = storage.smem_beta.get_tensor(beta_layout)
+
+        load_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+        # Counts encode actual mbarrier arrivals. PipelineTmaAsync release is
+        # signalled by one lane per consumer warp, while ordinary async
+        # pipelines count every participating thread.
+        qk_load_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            (NUM_STATE_MMA_WARP_GROUPS + NUM_AUX_MMA_WARP_GROUPS) * WARPS_PER_WARP_GROUP,
+        )
+        v_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            NUM_STATE_MMA_WARP_GROUPS * WARPS_PER_WARP_GROUP,
+        )
+        vector_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        alpha_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            (NUM_AUX_MMA_WARP_GROUPS + NUM_STATE_MMA_WARP_GROUPS) * THREADS_PER_WARP_GROUP,
+        )
+        beta_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, NUM_AUX_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP
+        )
+        o_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, NUM_STATE_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP)
+        o_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        q_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.q_mbar_ptr.data_ptr(),
+            num_stages=self.q_stage,
+            producer_group=load_producer_group,
+            consumer_group=qk_load_consumer_group,
+            tx_count=self.tma_load_q_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        k_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.k_mbar_ptr.data_ptr(),
+            num_stages=self.k_stage,
+            producer_group=load_producer_group,
+            consumer_group=qk_load_consumer_group,
+            tx_count=self.tma_load_k_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        v_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.v_mbar_ptr.data_ptr(),
+            num_stages=self.v_stage,
+            producer_group=load_producer_group,
+            consumer_group=v_consumer_group,
+            tx_count=self.tma_load_v_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        o_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.o_mbar_ptr.data_ptr(),
+            num_stages=self.o_stage,
+            producer_group=o_producer_group,
+            consumer_group=o_consumer_group,
+        )
+        qk_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.qk_mbar_ptr.data_ptr(),
+            num_stages=self.qk_stage,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                NUM_AUX_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP,
+            ),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                NUM_STATE_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP,
+            ),
+        )
+        kk_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.kk_mbar_ptr.data_ptr(),
+            num_stages=self.kk_stage,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                NUM_AUX_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP,
+            ),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                NUM_STATE_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP,
+            ),
+        )
+        alpha_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.alpha_mbar_ptr.data_ptr(),
+            num_stages=self.alpha_beta_stage,
+            producer_group=vector_producer_group,
+            consumer_group=alpha_consumer_group,
+        )
+        beta_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.beta_mbar_ptr.data_ptr(),
+            num_stages=self.alpha_beta_stage,
+            producer_group=vector_producer_group,
+            consumer_group=beta_consumer_group,
+        )
+        cute.arch.mbarrier_init_fence()
+        cute.arch.sync_threads()
+
+        if work_desc.seq_len != cutlass.Int32(0) and warp_group_idx == WarpGroupRole.LDST:
+            cute.arch.setmaxregister_decrease(load_registers)
+            if ldst_warp_role == LoadStoreWarpRole.LOAD_QKV:
+                self.run_load_qkv_role(
+                    sQ_SD,
+                    sK_DS,
+                    sV_DS,
+                    tma_atom_q,
+                    tma_tensor_q,
+                    tma_atom_k,
+                    tma_tensor_k,
+                    tma_atom_v,
+                    tma_tensor_v,
+                    q_pipeline,
+                    k_pipeline,
+                    v_pipeline,
+                    num_blocks,
+                    work_desc.tok_offset,
+                    work_desc.q_head_idx(),
+                    work_desc.k_head_idx(num_q_heads, num_v_heads),
+                    work_desc.v_head_idx(),
+                )
+            elif ldst_warp_role == LoadStoreWarpRole.STORE_O:
+                CollectiveStoreTma(self.BLK_Q, self.D).run(
+                    sO,
+                    tma_atom_o,
+                    tma_tensor_o,
+                    g_tensormaps,
+                    o_pipeline,
+                    num_blocks,
+                    work_desc,
+                    num_seqs,
+                    self.o_stage,
+                    num_q_heads,
+                    num_v_heads,
+                )
+            elif ldst_warp_role == LoadStoreWarpRole.LOAD_BETA:
+                self.run_load_beta_role(
+                    sBeta,
+                    g_beta,
+                    beta_pipeline,
+                    num_blocks,
+                    work_desc.tok_offset,
+                    tok_end,
+                    work_desc.o_head_idx(num_q_heads, num_v_heads),
+                    num_sab_heads,
+                )
+            elif ldst_warp_role == LoadStoreWarpRole.LOAD_ALPHA:
+                self.run_load_alpha_role(
+                    sAlpha,
+                    g_alpha,
+                    alpha_pipeline,
+                    scale,
+                    num_blocks,
+                    work_desc.tok_offset,
+                    tok_end,
+                    work_desc.o_head_idx(num_q_heads, num_v_heads),
+                    num_sab_heads,
+                )
+        elif work_desc.seq_len != cutlass.Int32(0):
+            if warp_group_idx == WarpGroupRole.MATH_AUX:
+                cute.arch.setmaxregister_decrease(aux_mma_registers)
+                self.run_aux_math_role(
+                    sQ_SD,
+                    sK_SD,
+                    sQK,
+                    sKK_inv,
+                    sKK_opd,
+                    sAlpha,
+                    sBeta,
+                    q_pipeline,
+                    k_pipeline,
+                    qk_pipeline,
+                    kk_pipeline,
+                    alpha_pipeline,
+                    beta_pipeline,
+                    work_desc,
+                    scale,
+                    math_tidx,
+                    num_blocks,
+                )
+            else:
+                cute.arch.setmaxregister_increase(state_mma_registers)
+                self.run_state_math_role(
+                    sQ_SD,
+                    sK_SD,
+                    sK_DS,
+                    sV_DS,
+                    sQK,
+                    sKK_inv,
+                    sKK_opd,
+                    sO,
+                    sAlpha,
+                    q_pipeline,
+                    k_pipeline,
+                    v_pipeline,
+                    o_pipeline,
+                    qk_pipeline,
+                    kk_pipeline,
+                    alpha_pipeline,
+                    g_state,
+                    g_init_state,
+                    g_state_checkpoints,
+                    checkpoint_cu_starts,
+                    work_desc,
+                    scale,
+                    wg_idx,
+                    math_tidx,
+                    num_blocks,
+                    num_q_heads,
+                    num_v_heads,
+                    num_sab_heads,
+                    num_seqs,
+                    total_checkpoints,
+                    checkpoint_every_n_tokens,
+                )
+
+
+# ─── Host compile and launch entry points ───────────────────────────────────
+
+
+_compiled_delta_rule_variants: dict[tuple[bool, bool, bool, bool, type], object] = {}
+
+
+def _compile_delta_rule_variant(
+    needs_alpha: bool,
+    needs_beta: bool,
+    needs_init_state: bool,
+    needs_checkpointing: bool,
+    kernel_dtype: type[cutlass.Numeric],
+):
+    """Compile one dynamic-shape TVM-FFI launch ABI for direct Torch calls."""
+
+    total_tokens = cute.sym_int()
+    num_q_heads = cute.sym_int()
+    num_k_heads = cute.sym_int()
+    num_v_heads = cute.sym_int()
+    num_o_heads = cute.sym_int()
+
+    q_fake = cute.runtime.make_fake_tensor(
+        kernel_dtype,
+        (total_tokens, 128, num_q_heads),
+        (cute.sym_int(), 1, 128),
+        assumed_align=16,
+    )
+    k_fake = cute.runtime.make_fake_tensor(
+        kernel_dtype,
+        (128, total_tokens, num_k_heads),
+        (1, cute.sym_int(), 128),
+        assumed_align=16,
+    )
+    v_fake = cute.runtime.make_fake_tensor(
+        kernel_dtype,
+        (128, total_tokens, num_v_heads),
+        (1, cute.sym_int(), 128),
+        assumed_align=16,
+    )
+    o_fake = cute.runtime.make_fake_tensor(
+        kernel_dtype,
+        (128, total_tokens, num_o_heads),
+        (1, cute.sym_int(), 128),
+        assumed_align=16,
+    )
+
+    def fake_vector(dtype, assumed_align: int):
+        return cute.runtime.make_fake_compact_tensor(
+            dtype,
+            (cute.sym_int(),),
+            assumed_align=assumed_align,
+        )
+
+    alpha_fake = fake_vector(cutlass.Float32, 16) if needs_alpha else None
+    beta_fake = fake_vector(cutlass.Float32, 16) if needs_beta else None
+    state_fake = fake_vector(cutlass.Float32, 16)
+    init_state_fake = fake_vector(cutlass.Float32, 16) if needs_init_state else None
+    state_checkpoints_fake = fake_vector(cutlass.Float32, 16) if needs_checkpointing else None
+    checkpoint_cu_fake = fake_vector(cutlass.Int64, 8) if needs_checkpointing else None
+    tensormaps_fake = fake_vector(cutlass.Uint8, 128)
+    cu_fake = fake_vector(cutlass.Int64, 8)
+    stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    delta_rule_kernel = _FullyFusedDeltaRuleSm90(
+        needs_alpha,
+        needs_beta,
+        needs_init_state,
+        needs_checkpointing,
+        kernel_dtype,
+    )
+    return cached_compile(
+        delta_rule_kernel,
+        q_fake,
+        k_fake,
+        v_fake,
+        o_fake,
+        alpha_fake,
+        beta_fake,
+        state_fake,
+        init_state_fake,
+        state_checkpoints_fake,
+        checkpoint_cu_fake,
+        tensormaps_fake,
+        cu_fake,
+        cutlass.Float32(1.0),
+        cutlass.Int32(1),
+        cutlass.Int32(1),
+        cutlass.Int32(1),
+        cutlass.Int32(1),
+        cutlass.Int32(1),
+        cutlass.Int32(1),
+        cutlass.Int32(0),
+        1,
+        stream_fake,
+        compile_options=(cute.GPUArch("sm_90a"), cute.EnableTVMFFI(True)),
+    )
+
+
+def _get_compiled_delta_rule_variant(
+    needs_alpha: bool,
+    needs_beta: bool,
+    needs_init_state: bool,
+    needs_checkpointing: bool,
+    kernel_dtype: type[cutlass.Numeric],
+):
+    key = (
+        needs_alpha,
+        needs_beta,
+        needs_init_state,
+        needs_checkpointing,
+        kernel_dtype,
+    )
+    compiled = _compiled_delta_rule_variants.get(key)
+    if compiled is None:
+        compiled = _compile_delta_rule_variant(*key)
+        _compiled_delta_rule_variants[key] = compiled
+    return compiled
+
+
+def run_delta_rule_prefill(
+    o: torch.Tensor,  # (total_seqlen, num_o_heads, D) fp16/bf16, output
+    state: torch.Tensor,  # (num_seqs, num_sab_heads, D, D) fp32, output
+    q: torch.Tensor,  # (total_seqlen, num_q_heads, D)
+    k: torch.Tensor,  # (total_seqlen, num_k_heads, D)
+    v: torch.Tensor,  # (total_seqlen, num_v_heads, D)
+    init_state: torch.Tensor | None,  # (num_seqs, num_sab_heads, D, D) fp32, optional
+    alpha: torch.Tensor | None,
+    beta: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,  # (num_seqs+1,) int64
+    scale: float,
+    state_checkpoints: torch.Tensor | None = None,
+    checkpoint_cu_starts: torch.Tensor | None = None,
+    checkpoint_every_n_tokens: int = 0,
+):
+    D = q.shape[-1]
+
+    num_seqs = cu_seqlens.shape[0] - 1
+    num_q_heads = q.shape[1]
+    num_k_heads = k.shape[1]
+    num_v_heads = v.shape[1]
+    num_sab_heads = max(num_q_heads, num_v_heads)
+
+    if not _FullyFusedDeltaRuleSm90.can_implement(num_q_heads, num_k_heads, num_v_heads, D, q.element_size()):
+        raise RuntimeError("can_implement failed")
+    if D != 128:
+        raise RuntimeError(f"DSL kernel only supports D=128, got {D}")
+
+    needs_alpha = alpha is not None
+    needs_beta = beta is not None
+    needs_init_state = init_state is not None
+    needs_checkpointing = checkpoint_every_n_tokens > 0
+    kernel_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+    }.get(q.dtype)
+    if kernel_dtype is None:
+        raise RuntimeError(f"DSL kernel only supports fp16/bf16 inputs, got {q.dtype}")
+
+    if k.dtype != q.dtype or v.dtype != q.dtype or o.dtype != q.dtype:
+        raise RuntimeError(f"q/k/v/o dtypes must match, got {q.dtype}, {k.dtype}, {v.dtype}, {o.dtype}")
+    if alpha is not None and alpha.dtype != torch.float32:
+        raise RuntimeError(f"alpha must have dtype torch.float32, got {alpha.dtype}")
+    if beta is not None and beta.dtype != torch.float32:
+        raise RuntimeError(f"beta must have dtype torch.float32, got {beta.dtype}")
+    if init_state is not None and init_state.dtype != torch.float32:
+        raise RuntimeError(f"init_state must have dtype torch.float32, got {init_state.dtype}")
+    if state.dtype != torch.float32:
+        raise RuntimeError(f"state must have dtype torch.float32, got {state.dtype}")
+    if cu_seqlens.dtype != torch.int64:
+        raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
+
+    for name, tensor in (
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("o", o),
+        ("state", state),
+        ("cu_seqlens", cu_seqlens),
+    ):
+        if not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+    for name, tensor in (("alpha", alpha), ("beta", beta), ("init_state", init_state)):
+        if tensor is not None and not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+
+    total_seqlen = q.shape[0]
+    num_o_heads = o.shape[1]
+    q_tma = q.as_strided(
+        (total_seqlen, D, num_q_heads),
+        (num_q_heads * D, 1, D),
+    )
+    k_tma = k.as_strided(
+        (D, total_seqlen, num_k_heads),
+        (1, num_k_heads * D, D),
+    )
+    v_tma = v.as_strided(
+        (D, total_seqlen, num_v_heads),
+        (1, num_v_heads * D, D),
+    )
+    o_tma = o.as_strided(
+        (D, total_seqlen, num_o_heads),
+        (1, num_o_heads * D, D),
+    )
+    total_checkpoints = state_checkpoints.shape[0] if needs_checkpointing else 1
+
+    # TensorMap slots are private per physical SM. The 185,728-byte shared
+    # storage limits this 512-thread specialization to one active CTA/SM, and
+    # each CTA retires its S2G bulk group before exit. Revisit this cache if a
+    # future resource layout permits more than one resident CTA per SM.
+    workspace_size = get_device_sm_count(q.device) * 128
+    tensormaps_t = _get_cache_buf("gdn_prefill_tensormaps", workspace_size, q.device)
+
+    compiled_delta_rule_kernel = _get_compiled_delta_rule_variant(
+        needs_alpha,
+        needs_beta,
+        needs_init_state,
+        needs_checkpointing,
+        kernel_dtype,
+    )
+    # The fake-tensor compile surface defines a TVM-FFI ABI. Pass Torch
+    # tensors directly so steady-state launches avoid per-call DLPack wrappers;
+    # the current PyTorch stream is supplied by the TVM-FFI environment.
+    compiled_delta_rule_kernel(
+        q_tma,
+        k_tma,
+        v_tma,
+        o_tma,
+        alpha.reshape(-1) if needs_alpha else None,
+        beta.reshape(-1) if needs_beta else None,
+        state.reshape(-1),
+        init_state.reshape(-1) if needs_init_state else None,
+        state_checkpoints.reshape(-1) if needs_checkpointing else None,
+        checkpoint_cu_starts if needs_checkpointing else None,
+        tensormaps_t,
+        cu_seqlens,
+        cutlass.Float32(scale),
+        cutlass.Int32(num_q_heads),
+        cutlass.Int32(num_k_heads),
+        cutlass.Int32(num_v_heads),
+        cutlass.Int32(num_sab_heads),
+        cutlass.Int32(num_seqs),
+        cutlass.Int32(total_checkpoints),
+        cutlass.Int32(checkpoint_every_n_tokens),
+        num_seqs * num_sab_heads,
+    )

--- a/cula/ops/gdn/sm90/helpers.py
+++ b/cula/ops/gdn/sm90/helpers.py
@@ -1,0 +1,383 @@
+# Copyright 2025-2026 FlashInfer team.
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import cutlass
+import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
+import cutlass.cute as cute
+from cutlass._mlir.dialects import llvm
+from cutlass.cute import core as cute_core
+from cutlass.cute.atom import Trait, make_atom
+from cutlass.cute.nvgpu import warp, warpgroup
+from cutlass.cute.typing import Shape
+from cutlass.cutlass_dsl import T
+
+
+def round_down(a: int, b: int) -> int:
+    return (a // b) * b
+
+
+@dataclass(frozen=True)
+class WarpMmaTF32Op(warp.WarpMmaOp):
+    shape_mnk: Shape
+
+    def __post_init__(self) -> None:
+        if self.shape_mnk != (16, 8, 8):
+            raise ValueError(f"WarpMmaTF32Op only supports (16, 8, 8), got {self.shape_mnk}")
+
+    def _make_trait(self, *, loc=None, ip=None, **kwargs):
+        shape_mnk = cute_core._pack_shape(self.shape_mnk, loc=loc, ip=ip)
+        ty = _cute_nvgpu_ir.MmaAtomSM80Type.get(
+            shape_mnk.type.attribute,
+            cutlass.TFloat32.mlir_type,
+            cutlass.TFloat32.mlir_type,
+            cutlass.Float32.mlir_type,
+        )
+        return WarpMmaTF32Trait(make_atom(ty, loc=loc, ip=ip))
+
+    def _verify_fragment_A(self, input, *, loc=None, ip=None):
+        return True
+
+    def _verify_fragment_B(self, input, *, loc=None, ip=None):
+        return True
+
+
+class WarpMmaTF32Trait(Trait):
+    pass
+
+
+class TF32:
+    @staticmethod
+    @cute.jit
+    def round_to_tf32_f32(value: cutlass.Float32) -> cutlass.Float32:
+        bits = llvm.inline_asm(
+            T.i32(),
+            [value.ir_value()],
+            "cvt.rz.tf32.f32 $0, $1;",
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+        return cutlass.Float32(llvm.bitcast(T.f32(), bits))
+
+    @staticmethod
+    @cute.jit
+    def convert_fp32_to_tf32_residual(tensor: cute.Tensor):
+        residual = cute.make_rmem_tensor_like(tensor, cutlass.Float32)
+        for i in cutlass.range_constexpr(cute.size(residual)):
+            value = tensor[i]
+            residual[i] = value - TF32.round_to_tf32_f32(value)
+        return cute.recast_tensor(residual, cutlass.TFloat32)
+
+    @staticmethod
+    @cute.jit
+    def convert_tf32_c_to_kpermuted_a(tCrC: cute.Tensor, tCrA: cute.Tensor):
+        for i in cutlass.range(cute.size(tCrA), unroll_full=True):
+            tCrA[i] = tCrC[i]
+        for m in cutlass.range_constexpr(cute.size(tCrA, mode=[1])):
+            for k in cutlass.range_constexpr(cute.size(tCrA, mode=[2])):
+                tmp = tCrA[(1, 0), m, k]
+                tCrA[(1, 0), m, k] = tCrA[(0, 1), m, k]
+                tCrA[(0, 1), m, k] = tmp
+
+    @staticmethod
+    @cute.jit
+    def load_tf32_kpermuted_b(
+        tCrB: cute.Tensor,
+        sB_NK: cute.Tensor,
+        lane_idx: cutlass.Int32,
+    ):
+        sB_8x8 = cute.flat_divide(sB_NK, (8, 8))
+        n = lane_idx // 4
+        k = lane_idx - n * 4
+        for iter_n in cutlass.range_constexpr(cute.size(tCrB, mode=[1])):
+            for iter_k in cutlass.range_constexpr(cute.size(tCrB, mode=[2])):
+                tCrB[0, iter_n, iter_k] = sB_8x8[n, k * 2, iter_n, iter_k]
+                tCrB[1, iter_n, iter_k] = sB_8x8[n, k * 2 + 1, iter_n, iter_k]
+
+
+@cute.jit
+def select_tensor_10(t: cute.Tensor) -> cute.Tensor:
+    """select_tensor<1,0>: swap first two modes of a 2-D tensor."""
+    return cute.make_tensor(
+        t.iterator.align(t.iterator.max_alignment),
+        cute.make_layout(
+            (t.layout.shape[1], t.layout.shape[0]) + t.layout.shape[2:],
+            stride=(t.layout.stride[1], t.layout.stride[0]) + t.layout.stride[2:],
+        ),
+    )
+
+
+@cute.jit
+def smid():
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [],
+            "mov.u32 $0, %smid;",
+            "=r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def tensormap_replace_global_dim_1(
+    tensormap_ptr: cute.Pointer,
+    new_val: cutlass.Int32,
+):
+    ptr_i64 = tensormap_ptr.toint().ir_value()
+    llvm.inline_asm(
+        None,
+        [ptr_i64, new_val.ir_value()],
+        "tensormap.replace.tile.global_dim.global.b1024.b32 [$0], 1, $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@cute.jit
+def load_tensor_as_c(
+    sTensor: cute.Tensor,
+    tiled_mma,
+    thread_idx: cutlass.Int32,
+    c_shape,
+    src_dtype,
+    is_src_n_major: bool,
+    dst_dtype=None,
+) -> cute.Tensor:
+    if cutlass.const_expr(dst_dtype is None):
+        dst_dtype = src_dtype
+    if cutlass.const_expr(is_src_n_major):
+        ldsm_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), src_dtype)
+    else:
+        ldsm_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4), src_dtype)
+    tiled_copy = cute.make_tiled_copy_C(ldsm_atom, tiled_mma)
+    thr_copy = tiled_copy.get_slice(thread_idx)
+    tCrSrc = cute.make_rmem_tensor(tiled_mma.partition_shape_C(c_shape), src_dtype)
+    tCrSrc_cv = thr_copy.retile(tCrSrc)
+    tCsC = thr_copy.partition_S(sTensor)
+    cute.copy(tiled_copy, tCsC, tCrSrc_cv)
+    if cutlass.const_expr(dst_dtype is src_dtype):
+        return tCrSrc
+    tCrC = cute.make_rmem_tensor_like(tCrSrc, dst_dtype)
+    for i in cutlass.range(cute.size(tCrC), unroll_full=True):
+        tCrC[i] = dst_dtype(tCrSrc[i])
+    return tCrC
+
+
+@cute.jit
+def load_tensor_as_a(
+    sTensor: cute.Tensor,
+    tiled_mma,
+    thread_idx: cutlass.Int32,
+    a_shape,
+    src_dtype,
+    is_src_k_major: bool,
+    dst_dtype=None,
+) -> cute.Tensor:
+    if cutlass.const_expr(dst_dtype is None):
+        dst_dtype = src_dtype
+    if cutlass.const_expr(is_src_k_major):
+        ldsm_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), src_dtype)
+    else:
+        ldsm_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4), src_dtype)
+    tiled_copy = cute.make_tiled_copy_A(ldsm_atom, tiled_mma)
+    thr_copy = tiled_copy.get_slice(thread_idx)
+    tArSrc = cute.make_rmem_tensor(tiled_mma.partition_shape_A(a_shape), src_dtype)
+    tArSrc_cv = thr_copy.retile(tArSrc)
+    tAsA = thr_copy.partition_S(sTensor)
+    cute.copy(tiled_copy, tAsA, tArSrc_cv)
+    if cutlass.const_expr(dst_dtype is src_dtype):
+        return tArSrc
+    tArA = cute.make_rmem_tensor_like(tArSrc, dst_dtype)
+    for i in cutlass.range(cute.size(tArA), unroll_full=True):
+        tArA[i] = dst_dtype(tArSrc[i])
+    return tArA
+
+
+@cute.jit
+def load_tensor_as_b(
+    sTensor: cute.Tensor,
+    tiled_mma,
+    thread_idx: cutlass.Int32,
+    b_shape,
+    src_dtype,
+    is_src_k_major: bool,
+    dst_dtype=None,
+) -> cute.Tensor:
+    if cutlass.const_expr(dst_dtype is None):
+        dst_dtype = src_dtype
+    if cutlass.const_expr(is_src_k_major):
+        ldsm_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), src_dtype)
+    else:
+        ldsm_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4), src_dtype)
+    tiled_copy = cute.make_tiled_copy_B(ldsm_atom, tiled_mma)
+    thr_copy = tiled_copy.get_slice(thread_idx)
+    tBrSrc = cute.make_rmem_tensor(tiled_mma.partition_shape_B(b_shape), src_dtype)
+    tBrSrc_cv = thr_copy.retile(tBrSrc)
+    tBsB = thr_copy.partition_S(sTensor)
+    cute.copy(tiled_copy, tBsB, tBrSrc_cv)
+    if cutlass.const_expr(dst_dtype is src_dtype):
+        return tBrSrc
+    tBrB = cute.make_rmem_tensor_like(tBrSrc, dst_dtype)
+    for i in cutlass.range(cute.size(tBrB), unroll_full=True):
+        tBrB[i] = dst_dtype(tBrSrc[i])
+    return tBrB
+
+
+class SM80:
+    @staticmethod
+    @cute.jit
+    def convert_c_layout_to_a_layout(c_layout, tiled_mma):
+        c_frag_atom_size = cute.size(c_layout, mode=[0])
+        a_frag_atom_size = cute.size(tiled_mma.tv_layout_A, mode=[1])
+        ratio = a_frag_atom_size // c_frag_atom_size
+        if cutlass.const_expr(ratio == 1):
+            return c_layout
+
+        divided = cute.logical_divide(c_layout, (None, None, ratio))
+        frag_layout = cute.flatten(
+            cute.make_layout(
+                (divided.shape[0], divided.shape[2][0]),
+                stride=(divided.stride[0], divided.stride[2][0]),
+            )
+        )
+        return cute.make_layout(
+            (frag_layout.shape, divided.shape[1], divided.shape[2][1]),
+            stride=(
+                frag_layout.stride,
+                divided.stride[1],
+                divided.stride[2][1],
+            ),
+        )
+
+    @staticmethod
+    @cute.jit
+    def make_acc_into_op(acc: cute.Tensor, tiled_mma, dtype) -> cute.Tensor:
+        operand = cute.make_fragment_like(
+            SM80.convert_c_layout_to_a_layout(acc.layout, tiled_mma),
+            dtype,
+        )
+        operand_as_acc = cute.make_tensor(operand.iterator, acc.layout)
+        operand_as_acc.store(acc.load().to(dtype))
+        return operand
+
+
+class SM90:
+    @staticmethod
+    @cute.jit
+    def wgmma_gemm(
+        tiled_mma,
+        C: cute.Tensor,
+        A: cute.Tensor,
+        B: cute.Tensor,
+        accumulate: bool,
+    ):
+        for k_block_idx in cutlass.range(cute.size(A, mode=[2]), unroll_full=True):
+            tiled_mma.set(
+                warpgroup.Field.ACCUMULATE,
+                accumulate or k_block_idx != 0,
+            )
+            cute.gemm(
+                tiled_mma,
+                C,
+                A[None, None, k_block_idx],
+                B[None, None, k_block_idx],
+                C,
+            )
+
+    @staticmethod
+    @cute.jit
+    def wgmma_gemm_zero_acc(
+        tiled_mma,
+        C: cute.Tensor,
+        A: cute.Tensor,
+        B: cute.Tensor,
+    ):
+        SM90.wgmma_gemm(tiled_mma, C, A, B, False)
+
+    @staticmethod
+    @cute.jit
+    def _warpgroup_fence_reg_f32(reg: cutlass.Float32) -> cutlass.Float32:
+        return cutlass.Float32(
+            llvm.inline_asm(
+                T.f32(),
+                [reg.ir_value()],
+                "",
+                "=f,0",
+                has_side_effects=True,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    @staticmethod
+    @cute.jit
+    def _warpgroup_fence_reg_u32(reg: cutlass.Uint32) -> cutlass.Uint32:
+        return cutlass.Uint32(
+            llvm.inline_asm(
+                T.i32(),
+                [reg.ir_value()],
+                "",
+                "=r,0",
+                has_side_effects=True,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    @staticmethod
+    @cute.jit
+    def warpgroup_fence_operand(frg: cute.Tensor):
+        if cutlass.const_expr(frg.element_type is cutlass.Float32):
+            f32_frg = cute.recast_tensor(frg, cutlass.Float32)
+            for i in cutlass.range(cute.size(f32_frg), unroll_full=True):
+                f32_frg[i] = SM90._warpgroup_fence_reg_f32(f32_frg[i])
+        else:
+            u32_frg = cute.recast_tensor(frg, cutlass.Uint32)
+            for i in cutlass.range(cute.size(u32_frg), unroll_full=True):
+                u32_frg[i] = SM90._warpgroup_fence_reg_u32(u32_frg[i])
+
+    @staticmethod
+    @cute.jit
+    def convert_c_layout_to_a_layout(c_layout, operand_layout):
+        return cute.make_layout(
+            (
+                operand_layout,
+                c_layout.shape[1],
+                (
+                    c_layout.shape[2],
+                    cute.size(c_layout, mode=[0]) // cute.size(operand_layout),
+                ),
+            ),
+            stride=(
+                c_layout.stride[0],
+                c_layout.stride[1],
+                (
+                    c_layout.stride[2],
+                    cute.size(operand_layout, mode=[2]) * c_layout.stride[0][2],
+                ),
+            ),
+        )
+
+    @staticmethod
+    @cute.jit
+    def make_acc_into_op(acc: cute.Tensor, tiled_mma, dtype) -> cute.Tensor:
+        operand = cute.make_rmem_tensor_like(
+            SM90.convert_c_layout_to_a_layout(
+                acc.layout,
+                tiled_mma.tv_layout_A.shape[1],
+            ),
+            dtype,
+        )
+        operand_as_acc = cute.make_tensor(operand.iterator, acc.layout)
+        operand_as_acc.store(acc.load().to(dtype))
+        return operand

--- a/cula/ops/gdn/sm90/launch.py
+++ b/cula/ops/gdn/sm90/launch.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Production host adapter for the upstream-derived SM90 GDN CuTe DSL kernel."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from .config import HEAD_SIZE
+from .delta_rule import run_delta_rule_prefill
+
+if TYPE_CHECKING:
+    from cula.gdn.prefill import _GDNPrefillInputs
+
+
+def launch_sm90_gdn_prefill(inputs: _GDNPrefillInputs) -> None:
+    """Launch the 512-thread SM90 CuTe DSL port without a C++ fallback."""
+
+    with torch.cuda.device(inputs.q.device):
+        cu_seqlens = inputs.cu_seqlens
+        if cu_seqlens.dtype != torch.int64:
+            cu_seqlens = cu_seqlens.to(torch.int64)
+        if not cu_seqlens.is_contiguous():
+            cu_seqlens = cu_seqlens.contiguous()
+
+        final_state = inputs.output_state
+        if final_state is None:
+            final_state = torch.empty(
+                (
+                    inputs.num_seqs,
+                    inputs.output.shape[1],
+                    HEAD_SIZE,
+                    HEAD_SIZE,
+                ),
+                dtype=torch.float32,
+                device=inputs.q.device,
+            )
+
+        run_delta_rule_prefill(
+            inputs.output,
+            final_state,
+            inputs.q,
+            inputs.k,
+            inputs.v,
+            inputs.initial_state,
+            inputs.alpha,
+            inputs.beta,
+            cu_seqlens,
+            inputs.scale,
+        )

--- a/cula/ops/gdn/sm90/schedule.py
+++ b/cula/ops/gdn/sm90/schedule.py
@@ -1,0 +1,51 @@
+# Copyright 2025-2026 FlashInfer team.
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import cutlass
+import cutlass.cute as cute
+
+
+@dataclass
+class WorkDesc:
+    # coord
+    seq_idx: cutlass.Int32
+    private_q_head_idx: cutlass.Int32
+    private_v_head_idx: cutlass.Int32
+    tok_offset: cutlass.Int32
+
+    # shape
+    seq_len: cutlass.Int32
+
+    # update by mainloop
+    tile_idx: cutlass.Int32
+
+    def is_valid(self, num_seqs: cutlass.Int32):
+        return self.seq_idx >= cutlass.Int32(0) and self.seq_idx < num_seqs
+
+    def q_head_idx(self):
+        return self.private_q_head_idx
+
+    @staticmethod
+    @cute.jit
+    def is_gva(num_q_heads: cutlass.Int32, num_v_heads: cutlass.Int32):
+        return num_v_heads > num_q_heads
+
+    @cute.jit
+    def k_head_idx(self, num_q_heads: cutlass.Int32, num_v_heads: cutlass.Int32):
+        k_head_idx = self.private_v_head_idx
+        if WorkDesc.is_gva(num_q_heads, num_v_heads):
+            k_head_idx = self.private_q_head_idx
+        return k_head_idx
+
+    def v_head_idx(self):
+        return self.private_v_head_idx
+
+    @cute.jit
+    def o_head_idx(self, num_q_heads: cutlass.Int32, num_v_heads: cutlass.Int32):
+        o_head_idx = self.private_q_head_idx
+        if WorkDesc.is_gva(num_q_heads, num_v_heads):
+            o_head_idx = self.private_v_head_idx
+        return o_head_idx

--- a/docs/gdn_sm90_api.md
+++ b/docs/gdn_sm90_api.md
@@ -1,0 +1,131 @@
+# GDN Prefill API on Hopper SM90
+
+cuLA provides a packed variable-length Gated DeltaNet (GDN) prefill kernel for
+NVIDIA Hopper GPUs. The implementation is written in CuTe DSL, launches one
+512-thread CTA for each `(sequence, output_head)` pair, and does not load the
+cuLA C++ extension or require FlashInfer headers at runtime.
+
+## Requirements
+
+- NVIDIA compute capability 9.0 (Hopper SM90, including H20 and H100)
+- Python 3.10 or newer
+- CUDA and PyTorch versions supported by the surrounding cuLA installation
+- `nvidia-cutlass-dsl==4.5.1`
+
+The SM90 GDN entry point checks the GPU capability and installed CuTe DSL
+version before compilation. It does not fall back to another implementation
+when either requirement is missing.
+
+## API
+
+```python
+from cula.gdn import chunk_gated_delta_rule
+```
+
+The input tensors use packed-token layouts:
+
+| Argument | Dtype | Shape | Meaning |
+|---|---|---|---|
+| `q` | BF16 | `[total_tokens, Hq, 128]` | queries |
+| `k` | BF16 | `[total_tokens, Hk, 128]` | keys |
+| `v` | BF16 | `[total_tokens, Hv, 128]` | values |
+| `g` | FP32 | `[total_tokens, Ho]` | positive, finite forget factors; `None` means one |
+| `beta` | FP32 | `[total_tokens, Ho]` | finite update factors; `None` means one |
+| `cu_seqlens` | INT32 or INT64 | `[num_sequences + 1]` | packed sequence prefixes |
+| `initial_state` | FP32 | `[num_sequences, Ho, 128, 128]` | optional state in `[V,K]` orientation |
+
+`Ho = max(Hq, Hv)`. Supported head relationships are:
+
+- MHA: `Hq = Hk = Hv`;
+- GQA: `Hq` is an integer multiple of `Hk = Hv`;
+- GVA: `Hv` is an integer multiple of `Hq = Hk`.
+
+All tensors must be contiguous, CUDA-resident on the same device, and at least
+16-byte aligned. Every packed sequence must contain at least one token.
+`cu_seqlens[0]` must be zero and its final value must equal `total_tokens`.
+These CUDA-resident values are trusted caller preconditions on the default fast
+path so that each request does not force device-to-host synchronization.
+
+For debugging or input-pipeline validation, pass `validate_inputs=True`. This
+explicitly copies `cu_seqlens` to the host and checks its endpoints and strictly
+increasing contents, and synchronously verifies that `g` is finite and positive
+and `beta` is finite. Do not enable this diagnostic option in latency-sensitive
+steady-state execution.
+
+The output is BF16 `[total_tokens, Ho, 128]`. With
+`output_final_state=True`, the function returns `(output, final_state)` where
+`final_state` is FP32 `[num_sequences, Ho, 128, 128]` in public `[V,K]`
+orientation. Callers may supply preallocated contiguous `output` and
+`output_state` buffers.
+
+## Example
+
+```python
+import torch
+
+from cula.gdn import chunk_gated_delta_rule
+
+device = "cuda"
+seq_lens = (5, 3)
+total_tokens = sum(seq_lens)
+heads = 2
+
+q = torch.randn(total_tokens, heads, 128, device=device, dtype=torch.bfloat16)
+k = torch.randn_like(q)
+v = torch.randn_like(q)
+g = torch.rand(total_tokens, heads, device=device, dtype=torch.float32) * 0.1 + 0.85
+beta = torch.rand(total_tokens, heads, device=device, dtype=torch.float32)
+cu_seqlens = torch.tensor([0, 5, 8], device=device, dtype=torch.int64)
+
+output, final_state = chunk_gated_delta_rule(
+    q,
+    k,
+    v,
+    g=g,
+    beta=beta,
+    cu_seqlens=cu_seqlens,
+    output_final_state=True,
+)
+```
+
+Pass a returned `final_state` as `initial_state` in a later call to continue a
+sequence. The state orientation is unchanged between calls.
+
+## Unsupported behavior
+
+- zero-length packed sequences;
+- head size other than 128;
+- FP16, FP8, or FP32 Q/K/V inputs;
+- Q/K L2 normalization inside this kernel;
+- intermediate state checkpoints (`state_checkpoints`,
+  `checkpoint_cu_starts`, or nonzero `checkpoint_every_n_tokens`);
+- decode, backward, or non-SM90 execution;
+- implicit fallback to a C++ or FlashInfer kernel.
+
+Unsupported metadata fails before launch with `ValueError`, `TypeError`,
+`NotImplementedError`, or `RuntimeError` rather than silently selecting a
+different backend. Device-resident value constraints are caller preconditions
+unless the explicit synchronous `validate_inputs=True` diagnostic is enabled.
+
+## Canonical benchmark
+
+From the repository root, run:
+
+```bash
+python benchmarks/bench_gdn_prefill.py --output gdn-sm90-benchmark.json
+```
+
+The default command always executes the complete canonical matrix:
+
+- fixed length: `B={1,2}`, `T={512,1024,4096,8192,16384}`;
+- variable length: `num_sequences={10,20}`,
+  `total_tokens={4096,8192,16384}`, and
+  `distribution={uniform,random,skewed}`;
+- `Hq=Hk=Hv=64`, head size 128, BF16 Q/K/V.
+
+Compilation and first-call setup are excluded from the reported CUDA-event
+mean. Use `--list-matrix` to inspect all 28 deterministic rows without running
+CUDA work.
+
+For the thread roles, pipeline stages, shared-memory layout, and recurrent-state
+dataflow, see [GDN SM90 Pipeline](gdn_sm90_pipeline.md).

--- a/docs/gdn_sm90_pipeline.md
+++ b/docs/gdn_sm90_pipeline.md
@@ -1,0 +1,154 @@
+# Fully Fused GDN Prefill SM90 Pipeline
+
+> 文件: `cula/ops/gdn/sm90/delta_rule.py`
+> 类名: `_FullyFusedDeltaRuleSm90`
+
+## 计算公式
+
+内核以 64 token 为一个 chunk，融合 Gated DeltaNet 的块内辅助矩阵、输出和
+recurrent state 更新。对当前 chunk 的 $Q,K,V$，核心步骤为：
+
+$$A_{QK} = QK^T, \qquad A_{KK} = KK^T$$
+
+$$T = \operatorname{tril}(I + \Gamma \odot A_{KK}), \qquad
+T^{-1} = \operatorname{inverse}(T)$$
+
+$$V_{new} = (V^T - S_{prev}K^T)T^{-1}$$
+
+$$O^T = S_{prev}Q^T + V_{new}A_{QK}^T$$
+
+$$S_{new} = \operatorname{decay}(S_{prev}) + V_{new}K$$
+
+其中 $\Gamma$ 由 `alpha` 的 chunk 内前缀积构造，`beta` 在三角逆的前后按行、
+按列应用。公开 state 始终采用 `[sequence, output_head, V, K]` 的 FP32 布局。
+
+## 线程布局
+
+每个 CTA 对应一个 `(sequence, output_head)`，按顺序处理该序列的所有 chunk。
+
+| Warp Group / Warp | 角色 | 职责 |
+|---|---|---|
+| WG0, warp 0 | Store O | TMA S2G 写回输出 |
+| WG0, warp 1 | Load QKV | TMA G2S 加载 Q、K、V |
+| WG0, warp 2 | Load Beta | 标量加载 beta，尾块补零 |
+| WG0, warp 3 | Load Alpha | 标量加载 alpha、前缀积和 scale，尾块补一 |
+| WG1 | State Math 0 | 持有一半 FP32 state，执行 O1、SK、NewV、O2 和 state 更新 |
+| WG2 | State Math 1 | 持有另一半 FP32 state，与 WG1 按 named barrier 有序协作 |
+| WG3 | Auxiliary Math | WGMMA 计算 QK/KK、三角变换和 64×64 collective inverse |
+
+**总线程**: 512（16 warps，4 个 warp group）
+
+**Grid**: `(num_sequences * num_output_heads, 1, 1)`
+
+**寄存器目标**: Load/Store=24，State Math=192，Auxiliary Math=104
+
+**驻留目标**: 每个 SM 1 个 CTA
+
+## MMA 操作
+
+| MMA | 逻辑 Tiler (M,N,K) | A 操作数 | B 操作数 | 输出 | 用途 |
+|---|---|---|---|---|---|
+| QK | (64, 64, 128) | Q — SMEM | K — SMEM | FP32 acc | 块内 query-key 分数 |
+| KK | (64, 64, 128) | K — SMEM | K — SMEM | FP32 acc | 构造下三角传递矩阵 |
+| O1 | (128, 64, 128) | State — RMEM/BF16 | Q — SMEM | FP32 acc | 历史 state 对输出的贡献 |
+| SK | (128, 64, 128) | State — RMEM/BF16 | K — SMEM | FP32 acc | 历史 state 对 V 的修正 |
+| NewV | (128, 64, 64) | V-SK — RMEM/BF16 | inverse(KK) — SMEM | FP32 acc | 生成 chunk 更新值 |
+| O2 | (128, 64, 64) | NewV — RMEM/BF16 | QK — SMEM | FP32 acc | chunk 内输出贡献 |
+| KV | (128, 128, 64) | NewV — RMEM/BF16 | K — SMEM | FP32 acc | 更新 recurrent state |
+
+WG1/WG2 的完整 FP32 state 常驻寄存器并跨 chunk 传递；需要作为 WGMMA 操作数时
+才转换为 BF16。两个 state warp group 使用 named barrier 4/5 保证对共享数学阶段
+的访问顺序。
+
+## Pipeline 阶段
+
+```text
+ WG0 Load/Store             WG3 Auxiliary Math             WG1/WG2 State Math
+       │                            │                               │
+ K,Q,V ├── TMA G2S ────────────────┼──────────────────────────────>│
+ alpha ├── prefix products ───────>│                               │
+ beta  ├──────────────────────────>│                               │
+       │                            │ QK / KK WGMMA                  │
+       │                            │ triangular epilogue            │
+       │                            │ collective inverse             │
+       │                            ├── sQK / sKK_inv ─────────────>│
+       │                            │                               │ O1 = State@Q
+       │                            │                               │ SK = State@K
+       │                            │                               │ NewV=(V-SK)@inv
+       │                            │                               │ O2=NewV@QK
+       │                            │                               │ update State
+       │<───────────────────────────┼──────────── sO ───────────────┤
+       └── TMA S2G O               │                               │
+```
+
+### Pipeline 深度
+
+| Pipeline | Stages | 方向 | 用途 |
+|---|---:|---|---|
+| Q | 2 | Load → Aux/State | Query TMA G2S |
+| K | 3 | Load → Aux/State | Key TMA G2S；同一物理缓冲提供 `(T,D)` / `(D,T)` 两种视图 |
+| V | 2 | Load → State | Value TMA G2S |
+| O | 2 | State → Store | 输出写回前的 SMEM staging |
+| QK | 2 | Aux → State | QK BF16 发布 |
+| KK inverse | 2 | Aux → State | 三角逆 BF16 发布 |
+| Alpha | 5 | Load → Aux/State | 前缀积、缩放和 state decay |
+| Beta | 5 | Load → Aux | 三角矩阵 beta 修正 |
+
+## 内存分配
+
+### RMEM
+
+| 区域 | 持有者 | 用途 |
+|---|---|---|
+| State tile 0 | WG1 | 完整 FP32 state 的一半，跨所有 chunk 保持 |
+| State tile 1 | WG2 | 完整 FP32 state 的另一半，跨所有 chunk 保持 |
+| QK / KK acc | WG3 | 辅助 WGMMA 的 FP32 累加器 |
+| O / SK / NewV / KV acc | WG1/WG2 | 输出和 state 更新的 FP32 累加器 |
+
+### SMEM（约 185,728 bytes）
+
+| 缓冲 | Stages | 用途 |
+|---|---:|---|
+| `sQ` | 2 | Query |
+| `sK` | 3 | Key；一个物理分配、两个逻辑视图 |
+| `sV` | 2 | Value |
+| `sO` | 2 | Output staging |
+| `sQK` | 2 | QK 的 BF16 发布缓冲 |
+| `sKK_inv` / `sKK_opd` | 2 | 同一物理缓冲的 FP16 inverse 与 BF16 operand 视图 |
+| `sAlpha` | 5 | alpha 前缀积、累计积和 scale 通道 |
+| `sBeta` | 5 | beta |
+
+## 主循环流程
+
+每个 CTA 固定处理一个 sequence/head work unit，不使用 persistent 动态调度：
+
+1. WG0 按 `K → Q → V` 顺序发起当前 chunk 的 TMA 加载，同时准备 alpha/beta。
+2. WG3 执行 QK 和 KK WGMMA，应用 causal/tail mask 与 alpha/beta 传递系数。
+3. WG3 对 64×64 下三角矩阵执行 `8 → 16 → 32 → 64` collective inverse，
+   再将 QK 和 inverse 以 BF16 发布给 state warp groups。
+4. WG1/WG2 从寄存器 state 计算 O1、SK、NewV、O2，并把有效 token 的输出写入
+   `sO`。
+5. WG1/WG2 对 state 施加 chunk decay，再累加 `NewV @ K`；最后一个 chunk 后按需
+   写回 FP32 final state。
+6. Store warp 只在绝对 packed `seq_end` 范围内提交 TMA store，等待 bulk group
+   完成后退出。
+
+尾块的 alpha padding 为 1、beta padding 为 0，避免 padding token 改变 state。
+
+## Varlen / Head 模式
+
+- 输入采用 packed varlen 布局，`cu_seqlens` 为每个 CTA 给出绝对 token 边界。
+- 支持 MHA：`Hq = Hk = Hv`。
+- 支持 GQA：`Hq` 是 `Hk = Hv` 的整数倍。
+- 支持 GVA：`Hv` 是 `Hq = Hk` 的整数倍。
+- output head 映射到对应的 query/key/value head；CTA 之间不共享 recurrent state。
+
+## 关键优化
+
+- **FP32 register-carried state**：避免每个 chunk 将 128×128 state 往返 GMEM/SMEM。
+- **四 warp-group 专职分工**：加载/写回、辅助矩阵、两半 state 数学可流水重叠。
+- **K 单分配双视图**：QK/SK 使用 `(T,D)`，KV 使用 `(D,T)`，不做物理转置或复制。
+- **Collective inverse**：按 8、16、32、64 分级构造三角逆，使用整个 auxiliary WG。
+- **明确的尾块语义**：alpha/beta 使用中性 padding，TMA 读写限定在当前 packed
+  sequence 的绝对边界内。
+- **无 fallback**：公开 API 只调度这个 SM90 CuTe DSL backend。

--- a/tests/gdn/__init__.py
+++ b/tests/gdn/__init__.py
@@ -1,0 +1,1 @@
+"""GDN test support package."""

--- a/tests/gdn/collective_inverse_reference.py
+++ b/tests/gdn/collective_inverse_reference.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Independent staged-FP16 host reference for the 64x64 collective inverse.
+
+The reference consumes the physical KK tile directly: the physical diagonal
+is discarded, the strict upper triangle must already be exact zero, and a
+ragged tail is promoted from zero padding to identity padding.
+
+Every shared-memory or accumulator-to-operand half store in the device
+collective is represented by an explicit FP16 round. The matrix products use
+FP32 accumulation. The final 32-to-64 merge also preserves the two separately
+rounded K=16 partial products before their FP16 reduction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+MATRIX_SIZE = 64
+BASE_BLOCK_SIZE = 8
+STAGE_SIZES = (8, 16, 32, 64)
+
+
+@dataclass(frozen=True)
+class CollectiveInverseReference:
+    """Staged operand, stage snapshots, and final inverse for one KK tile."""
+
+    staged_kk_physical: torch.Tensor
+    normalized_operand: torch.Tensor
+    stage_8: torch.Tensor
+    stage_16: torch.Tensor
+    stage_32: torch.Tensor
+    inverse: torch.Tensor
+    inverse_residual: float
+
+
+def _require_cpu_matrix(kk_physical: torch.Tensor) -> None:
+    if kk_physical.device.type != "cpu":
+        raise ValueError("kk_physical must be a CPU tensor")
+    if kk_physical.shape != (MATRIX_SIZE, MATRIX_SIZE):
+        raise ValueError(f"kk_physical must have shape ({MATRIX_SIZE}, {MATRIX_SIZE})")
+    if not kk_physical.is_floating_point():
+        raise ValueError("kk_physical must use a floating-point dtype")
+
+
+def _round_fp16(value: torch.Tensor) -> torch.Tensor:
+    """Model one device FP32-to-FP16 register or shared-memory store."""
+
+    return value.to(torch.float16)
+
+
+def _validate_physical_contract(staged: torch.Tensor, valid_tokens: int) -> None:
+    row = torch.arange(MATRIX_SIZE)[:, None]
+    col = torch.arange(MATRIX_SIZE)[None, :]
+    active_strict_lower = (row < valid_tokens) & (col < valid_tokens) & (row > col)
+    active_diagonal = (row == col) & (row < valid_tokens)
+
+    # The diagonal is deliberately excluded because the device collective
+    # replaces its physical value with one before inversion.
+    if not bool(torch.isfinite(staged[active_strict_lower]).all()):
+        raise ValueError("active strict-lower kk_physical entries must remain finite after FP16 staging")
+
+    must_be_zero = ~(active_strict_lower | active_diagonal)
+    if not bool((staged[must_be_zero] == 0).all()):
+        raise ValueError("kk_physical upper triangle and ragged off-diagonal tail must be exact zero")
+
+
+def _normalize_operand(staged: torch.Tensor) -> torch.Tensor:
+    """Replace the garbage diagonal by identity and retain strict lower data."""
+
+    identity = torch.eye(MATRIX_SIZE, dtype=torch.float16)
+    return torch.tril(staged, diagonal=-1) + identity
+
+
+def _inverse_unit_lower_8x8(block: torch.Tensor) -> torch.Tensor:
+    """Model warp-shuffle row elimination for one 8x8 block."""
+
+    rows = block.to(torch.float32).clone()
+    for src_row in range(BASE_BLOCK_SIZE - 1):
+        source_prefix = rows[src_row, :src_row].clone()
+        for target_row in range(src_row + 1, BASE_BLOCK_SIZE):
+            row_scale = -rows[target_row, src_row].clone()
+            if src_row:
+                rows[target_row, :src_row] += row_scale * source_prefix
+            rows[target_row, src_row] = row_scale
+    return _round_fp16(rows)
+
+
+def _merge_inverse_blocks(working: torch.Tensor, block_size: int) -> torch.Tensor:
+    """Apply one blockwise ``-inv(D) C inv(A)`` hierarchy level."""
+
+    merged = working.clone()
+    combined_size = 2 * block_size
+    for start in range(0, MATRIX_SIZE, combined_size):
+        middle = start + block_size
+        end = start + combined_size
+        a_inv = working[start:middle, start:middle]
+        coupling = working[middle:end, start:middle]
+        d_inv = working[middle:end, middle:end]
+
+        # Convert the first FP32 HMMA accumulator into a half operand before
+        # multiplying by inv(A).
+        d_c = _round_fp16(-(d_inv.float() @ coupling.float()))
+        if block_size == 32:
+            # Four warps split the final second GEMM at K=16.  Each partial is
+            # rounded before one warp reloads and reduces the pair to FP16.
+            split = block_size // 2
+            partial_0 = _round_fp16(d_c[:, :split].float() @ a_inv[:split, :].float())
+            partial_1 = _round_fp16(d_c[:, split:].float() @ a_inv[split:, :].float())
+            lower_left = _round_fp16(partial_0.float() + partial_1.float())
+        else:
+            lower_left = _round_fp16(d_c.float() @ a_inv.float())
+        merged[middle:end, start:middle] = lower_left
+    return merged
+
+
+def inverse_residual(operand: torch.Tensor, inverse: torch.Tensor) -> float:
+    """Return ``max(abs(operand @ inverse - I))`` with FP32 accumulation."""
+
+    _require_cpu_matrix(operand)
+    _require_cpu_matrix(inverse)
+    identity = torch.eye(MATRIX_SIZE, dtype=torch.float32)
+    residual = operand.float() @ inverse.float() - identity
+    return float(residual.abs().max().item())
+
+
+def collective_inverse_reference(
+    kk_physical: torch.Tensor,
+    valid_tokens: int,
+) -> CollectiveInverseReference:
+    """Compute the staged 64x64 half collective inverse.
+
+    Args:
+        kk_physical: One physical inclusive-lower KK tile.  The active
+            diagonal may contain arbitrary values, including non-finite
+            garbage, because the inverse replaces it by identity.  Upper and
+            every ragged-tail entry must be exact zero.
+        valid_tokens: Number of active rows and columns in ``[1, 64]``.
+    """
+
+    _require_cpu_matrix(kk_physical)
+    if not 0 < valid_tokens <= MATRIX_SIZE:
+        raise ValueError(f"valid_tokens must be in [1, {MATRIX_SIZE}]")
+
+    staged = _round_fp16(kk_physical)
+    _validate_physical_contract(staged, valid_tokens)
+    normalized = _normalize_operand(staged)
+
+    stage_8 = normalized.clone()
+    for start in range(0, MATRIX_SIZE, BASE_BLOCK_SIZE):
+        end = start + BASE_BLOCK_SIZE
+        stage_8[start:end, start:end] = _inverse_unit_lower_8x8(normalized[start:end, start:end])
+
+    stage_16 = _merge_inverse_blocks(stage_8, 8)
+    stage_32 = _merge_inverse_blocks(stage_16, 16)
+    stage_64 = _merge_inverse_blocks(stage_32, 32)
+    residual = inverse_residual(normalized, stage_64)
+
+    return CollectiveInverseReference(
+        staged_kk_physical=staged,
+        normalized_operand=normalized,
+        stage_8=stage_8,
+        stage_16=stage_16,
+        stage_32=stage_32,
+        inverse=stage_64,
+        inverse_residual=residual,
+    )

--- a/tests/gdn/published_aux_reference.py
+++ b/tests/gdn/published_aux_reference.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Independent host reference for the kernel's published auxiliary operands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from .collective_inverse_reference import MATRIX_SIZE, collective_inverse_reference
+
+
+@dataclass(frozen=True)
+class PublishedAuxReference:
+    """Final consumer operands after the kernel's two BF16 publication stores."""
+
+    qk_bf16: torch.Tensor
+    inverse_kk_beta_bf16: torch.Tensor
+    staged_inverse_fp16: torch.Tensor
+
+
+def published_aux_reference(
+    qk_epilogue: torch.Tensor,
+    kk_physical: torch.Tensor,
+    beta: torch.Tensor,
+    valid_tokens: int,
+) -> PublishedAuxReference:
+    """Apply the kernel's post-inverse ``beta[col]`` and BF16 stores."""
+
+    for name, tensor in (("qk_epilogue", qk_epilogue), ("kk_physical", kk_physical)):
+        if tensor.device.type != "cpu":
+            raise ValueError(f"{name} must be a CPU tensor")
+        if tensor.shape != (MATRIX_SIZE, MATRIX_SIZE):
+            raise ValueError(f"{name} must have shape ({MATRIX_SIZE}, {MATRIX_SIZE})")
+        if not tensor.is_floating_point():
+            raise ValueError(f"{name} must use a floating-point dtype")
+    if beta.device.type != "cpu":
+        raise ValueError("beta must be a CPU tensor")
+    if beta.ndim != 1 or beta.numel() != MATRIX_SIZE:
+        raise ValueError(f"beta must have shape ({MATRIX_SIZE},)")
+    if not beta.is_floating_point():
+        raise ValueError("beta must use a floating-point dtype")
+    if not 0 < valid_tokens <= MATRIX_SIZE:
+        raise ValueError(f"valid_tokens must be in [1, {MATRIX_SIZE}]")
+    if not bool((beta[valid_tokens:] == 0).all()):
+        raise ValueError("beta's ragged tail must use the kernel's zero padding")
+
+    inverse = collective_inverse_reference(kk_physical, valid_tokens).inverse
+    inverse_kk_beta = inverse.float() * beta.float()[None, :]
+    return PublishedAuxReference(
+        qk_bf16=qk_epilogue.to(torch.bfloat16),
+        inverse_kk_beta_bf16=inverse_kk_beta.to(torch.bfloat16),
+        staged_inverse_fp16=inverse,
+    )

--- a/tests/gdn/test_prefill_sm90.py
+++ b/tests/gdn/test_prefill_sm90.py
@@ -1,0 +1,665 @@
+# Copyright 2026 Ant Group Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+
+from cula.gdn import (
+    chunk_gated_delta_rule,
+    get_sm90_gdn_prefill_backend,
+    get_sm90_gdn_prefill_backend_identity,
+    is_sm90_gdn_prefill_available,
+)
+from cula.ops.gdn.sm90.config import (
+    HEAD_SIZE,
+    SM90_BACKEND_ID,
+    THREADS_PER_CTA,
+)
+
+from .published_aux_reference import published_aux_reference
+
+OUTPUT_SENTINEL = -123.0
+STATE_SENTINEL = -987654.0
+OUTPUT_GUARD_TOKENS = 64
+STATE_GUARD_SEQS = 1
+OUTPUT_RTOL = 1e-2
+OUTPUT_ATOL = 1e-2
+STATE_RTOL = 1e-3
+STATE_ATOL = 5e-3
+
+
+@dataclass(frozen=True)
+class GDNCase:
+    case_id: str
+    seq_lens: tuple[int, ...]
+    heads: tuple[int, int, int]
+    alpha: str
+    beta: str
+    initial_state: bool
+    final_state: bool
+
+
+CORRECTNESS_CASES = (
+    GDNCase("C01", (5, 3), (2, 2, 2), "random", "random", False, False),
+    GDNCase("C02", (5, 3), (4, 1, 1), "random", "random", True, True),
+    GDNCase("C03", (5, 3), (1, 1, 2), "random", "random", False, True),
+    GDNCase("C04", (1, 63, 64, 65), (2, 2, 2), "random", "random", False, False),
+    GDNCase("C05", (70,), (2, 2, 2), "random", "random", False, False),
+    GDNCase("C06", (70,), (2, 2, 2), "random", "random", True, True),
+    GDNCase("C07", (64,), (2, 2, 2), "constant-0.1", "random", False, False),
+    GDNCase("C08", (65,), (2, 2, 2), "absent", "random", False, False),
+    GDNCase("C09", (65,), (2, 2, 2), "random", "absent", True, False),
+    GDNCase("C10", (65,), (2, 2, 2), "absent", "absent", False, True),
+    GDNCase("C11", (4,), (16, 16, 32), "random", "random", True, True),
+    GDNCase("C12", (512,), (64, 64, 64), "random", "random", False, False),
+    GDNCase("C13", (127, 385), (64, 64, 64), "random", "random", False, False),
+    GDNCase("C14", (127, 128, 129), (1, 1, 2), "random", "random", True, True),
+)
+CASE_BY_ID = {case.case_id: case for case in CORRECTNESS_CASES}
+
+
+def _is_sm90() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() == (9, 0)
+
+
+def _head_indices(heads: tuple[int, int, int], device: torch.device) -> tuple[torch.Tensor, ...]:
+    num_q_heads, _, num_v_heads = heads
+    num_o_heads = max(num_q_heads, num_v_heads)
+    output_head = torch.arange(num_o_heads, device=device)
+    if num_q_heads >= num_v_heads:
+        q_index = output_head
+        kv_index = output_head // (num_q_heads // num_v_heads)
+        return q_index, kv_index, kv_index
+    qk_index = output_head // (num_v_heads // num_q_heads)
+    return qk_index, qk_index, output_head
+
+
+def _matmul(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    if a.dtype in (torch.float16, torch.bfloat16) or b.dtype in (torch.float16, torch.bfloat16):
+        return a.float() @ b.float()
+    return a @ b
+
+
+@torch.inference_mode()
+def _blockwise_reference(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    alpha: torch.Tensor,
+    beta: torch.Tensor,
+    seq_lens: tuple[int, ...],
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent PyTorch form of the kernel's 64-token block recurrence."""
+
+    device = q.device
+    q_index, k_index, v_index = _head_indices(
+        (q.shape[1], k.shape[1], v.shape[1]),
+        device,
+    )
+    q_mapped = q[:, q_index].float()
+    k_mapped = k[:, k_index].float()
+    v_mapped = v[:, v_index].float()
+    num_o_heads = q_mapped.shape[1]
+    output = torch.empty_like(v_mapped)
+    final_state = torch.empty(
+        (len(seq_lens), num_o_heads, HEAD_SIZE, HEAD_SIZE),
+        dtype=torch.float32,
+        device=device,
+    )
+    offset = 0
+    for seq_idx, seq_len in enumerate(seq_lens):
+        state = (
+            initial_state[seq_idx].float().clone()
+            if initial_state is not None
+            else torch.zeros(
+                (num_o_heads, HEAD_SIZE, HEAD_SIZE),
+                dtype=torch.float32,
+                device=device,
+            )
+        )
+        chunk_start = offset
+        seq_end = offset + seq_len
+        while chunk_start < seq_end:
+            valid = min(64, seq_end - chunk_start)
+            chunk_end = chunk_start + valid
+            q_chunk = torch.zeros(
+                (64, num_o_heads, HEAD_SIZE),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            k_chunk = torch.zeros_like(q_chunk)
+            v_chunk = torch.zeros_like(q_chunk)
+            q_chunk[:valid] = q_mapped[chunk_start:chunk_end].to(torch.bfloat16)
+            k_chunk[:valid] = k_mapped[chunk_start:chunk_end].to(torch.bfloat16)
+            v_chunk[:valid] = v_mapped[chunk_start:chunk_end].to(torch.bfloat16)
+            alpha_chunk = torch.ones((64, num_o_heads), dtype=torch.float32, device=device)
+            beta_chunk = torch.zeros_like(alpha_chunk)
+            alpha_chunk[:valid] = alpha[chunk_start:chunk_end]
+            beta_chunk[:valid] = beta[chunk_start:chunk_end]
+
+            alpha_hs = alpha_chunk.T
+            log_alpha = torch.log(alpha_hs + 1e-10)
+            prefix_log = torch.cumsum(log_alpha, dim=-1)
+            gamma_hss = prefix_log[:, :, None] - prefix_log[:, None, :]
+            gamma_hs1 = prefix_log[:, :, None]
+            q_hsq = q_chunk.permute(1, 0, 2)
+            k_hsk = k_chunk.permute(1, 0, 2)
+            v_hsv = v_chunk.permute(1, 0, 2)
+            beta_hs1 = beta_chunk.T[:, :, None]
+
+            transfer = torch.exp(gamma_hss)
+            causal = torch.ones((64, 64), dtype=torch.bool, device=device).tril()
+            active = causal.clone()
+            active[valid:, :] = False
+            active[:, valid:] = False
+            qk_epilogue = torch.where(
+                active[None, :, :],
+                _matmul(q_hsq, k_hsk.transpose(-2, -1)) * transfer * scale,
+                0.0,
+            )
+            kk_physical = torch.where(
+                active[None, :, :],
+                _matmul(k_hsk, k_hsk.transpose(-2, -1)) * transfer * beta_hs1,
+                0.0,
+            )
+            qk_published: list[torch.Tensor] = []
+            kk_published: list[torch.Tensor] = []
+            beta_host = beta_chunk.T.cpu()
+            for head_idx in range(num_o_heads):
+                published = published_aux_reference(
+                    qk_epilogue[head_idx].cpu(),
+                    kk_physical[head_idx].cpu(),
+                    beta_host[head_idx],
+                    valid,
+                )
+                qk_published.append(published.qk_bf16)
+                kk_published.append(published.inverse_kk_beta_bf16)
+            qk_bf16 = torch.stack(qk_published).to(device)
+            kk_bf16 = torch.stack(kk_published).to(device)
+
+            has_prior_state = initial_state is not None or chunk_start != offset
+            v_hvt = v_hsv.transpose(-1, -2).float()
+            if has_prior_state:
+                rounded_state = state.to(torch.bfloat16).float()
+                output_hvt = _matmul(rounded_state, q_hsq.transpose(-1, -2))
+                output_hvt *= torch.exp(gamma_hs1).transpose(-1, -2) * scale
+                sk_hvt = _matmul(rounded_state, k_hsk.transpose(-1, -2))
+                residual_hvt = v_hvt - sk_hvt * torch.exp(gamma_hs1).transpose(-1, -2)
+            else:
+                output_hvt = torch.zeros_like(v_hvt)
+                residual_hvt = v_hvt
+            new_v_hvt = _matmul(
+                residual_hvt.to(torch.bfloat16),
+                kk_bf16.transpose(-1, -2),
+            )
+            output_hvt += _matmul(
+                new_v_hvt.to(torch.bfloat16),
+                qk_bf16.transpose(-1, -2),
+            )
+            chunk_output = output_hvt.transpose(-1, -2).permute(1, 0, 2)
+            output[chunk_start:chunk_end] = chunk_output[:valid]
+
+            alpha_prefix = torch.exp(gamma_hs1).transpose(-1, -2)
+            alpha_last = alpha_prefix[:, :, -1:]
+            decayed_new_v = new_v_hvt * (alpha_last / alpha_prefix)
+            state = state * alpha_last
+            state += _matmul(decayed_new_v.to(torch.bfloat16), k_hsk)
+            chunk_start += 64
+        final_state[seq_idx] = state
+        offset += seq_len
+    return output.to(torch.bfloat16), final_state
+
+
+def _make_case_inputs(case: GDNCase) -> dict[str, Any]:
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    total_tokens = sum(case.seq_lens)
+    num_q_heads, num_k_heads, num_v_heads = case.heads
+    num_o_heads = max(num_q_heads, num_v_heads)
+    q = (torch.randn(total_tokens, num_q_heads, HEAD_SIZE, device=device) * 0.03).to(torch.bfloat16)
+    k = (torch.randn(total_tokens, num_k_heads, HEAD_SIZE, device=device) * 0.01).to(torch.bfloat16)
+    v = (torch.randn(total_tokens, num_v_heads, HEAD_SIZE, device=device) * 0.1).to(torch.bfloat16)
+    alpha_value = torch.rand(total_tokens, num_o_heads, dtype=torch.float32, device=device) * 0.1 + 0.85
+    if case.alpha == "constant-0.1":
+        alpha_value.fill_(0.1)
+    beta_value = torch.rand(total_tokens, num_o_heads, dtype=torch.float32, device=device) * 0.5
+    initial_state = None
+    if case.initial_state:
+        initial_state = (
+            torch.randn(
+                len(case.seq_lens),
+                num_o_heads,
+                HEAD_SIZE,
+                HEAD_SIZE,
+                dtype=torch.float32,
+                device=device,
+            )
+            * 0.005
+        )
+
+    output_storage = torch.full(
+        (total_tokens + 2 * OUTPUT_GUARD_TOKENS, num_o_heads, HEAD_SIZE),
+        OUTPUT_SENTINEL,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    output = output_storage[OUTPUT_GUARD_TOKENS : OUTPUT_GUARD_TOKENS + total_tokens]
+    state_storage = None
+    output_state = None
+    if case.final_state:
+        state_storage = torch.full(
+            (len(case.seq_lens) + 2 * STATE_GUARD_SEQS, num_o_heads, HEAD_SIZE, HEAD_SIZE),
+            STATE_SENTINEL,
+            dtype=torch.float32,
+            device=device,
+        )
+        output_state = state_storage[STATE_GUARD_SEQS : STATE_GUARD_SEQS + len(case.seq_lens)]
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(case.seq_lens).cumsum(0).tolist()],
+        dtype=torch.int64,
+        device=device,
+    )
+    return {
+        "q": q,
+        "k": k,
+        "v": v,
+        "alpha": None if case.alpha == "absent" else alpha_value,
+        "alpha_value": torch.ones_like(alpha_value) if case.alpha == "absent" else alpha_value,
+        "beta": None if case.beta == "absent" else beta_value,
+        "beta_value": torch.ones_like(beta_value) if case.beta == "absent" else beta_value,
+        "initial_state": initial_state,
+        "output_storage": output_storage,
+        "output": output,
+        "state_storage": state_storage,
+        "output_state": output_state,
+        "cu_seqlens": cu_seqlens,
+    }
+
+
+def run_correctness_case(case: GDNCase) -> dict[str, float | str | bool | list[int]]:
+    inputs = _make_case_inputs(case)
+    scale = 1.0 / math.sqrt(HEAD_SIZE)
+    expected_output, expected_state = _blockwise_reference(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        alpha=inputs["alpha_value"],
+        beta=inputs["beta_value"],
+        seq_lens=case.seq_lens,
+        initial_state=inputs["initial_state"],
+        scale=scale,
+    )
+    actual = chunk_gated_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        g=inputs["alpha"],
+        beta=inputs["beta"],
+        scale=scale,
+        initial_state=inputs["initial_state"],
+        output_final_state=case.final_state,
+        cu_seqlens=inputs["cu_seqlens"],
+        output=inputs["output"],
+        output_state=inputs["output_state"],
+    )
+    if case.final_state:
+        actual_output, actual_state = actual
+    else:
+        actual_output = actual
+        actual_state = None
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        actual_output,
+        expected_output,
+        rtol=OUTPUT_RTOL,
+        atol=OUTPUT_ATOL,
+    )
+    output_error = (actual_output.float() - expected_output.float()).abs()
+    state_max = 0.0
+    state_mean = 0.0
+    if actual_state is not None:
+        torch.testing.assert_close(
+            actual_state,
+            expected_state,
+            rtol=STATE_RTOL,
+            atol=STATE_ATOL,
+        )
+        state_error = (actual_state - expected_state).abs()
+        state_max = float(state_error.max().item())
+        state_mean = float(state_error.mean().item())
+
+    output_storage = inputs["output_storage"]
+    assert bool((output_storage[:OUTPUT_GUARD_TOKENS] == OUTPUT_SENTINEL).all())
+    assert bool((output_storage[-OUTPUT_GUARD_TOKENS:] == OUTPUT_SENTINEL).all())
+    state_storage = inputs["state_storage"]
+    if state_storage is not None:
+        assert bool((state_storage[:STATE_GUARD_SEQS] == STATE_SENTINEL).all())
+        assert bool((state_storage[-STATE_GUARD_SEQS:] == STATE_SENTINEL).all())
+
+    return {
+        "case_id": case.case_id,
+        "status": "PASS",
+        "seq_lens": list(case.seq_lens),
+        "input_profile": "seed0-q0.03-k0.01-v0.1",
+        "output_max_abs_error": float(output_error.max().item()),
+        "output_mean_abs_error": float(output_error.mean().item()),
+        "state_max_abs_error": state_max,
+        "state_mean_abs_error": state_mean,
+        "output_redzone_validated": True,
+        "state_redzone_validated": state_storage is not None,
+        "backend_id": get_sm90_gdn_prefill_backend_identity(),
+        "fallback_used": False,
+    }
+
+
+REPO_ROOT = Path(__file__).parents[2]
+
+
+def _source(path: str) -> str:
+    return (REPO_ROOT / path).read_text()
+
+
+def test_public_dispatch_uses_only_the_sm90_cutedsl_backend() -> None:
+    public_source = _source("cula/gdn/prefill.py")
+    launch_source = _source("cula/ops/gdn/sm90/launch.py")
+    assert get_sm90_gdn_prefill_backend() == "dsl"
+    assert get_sm90_gdn_prefill_backend_identity() == SM90_BACKEND_ID
+    assert "cudac" not in public_source
+    assert "cudac" not in launch_source
+    assert "gdn_fwd_prefill_sm90" not in public_source
+    assert "gdn_fwd_prefill_sm90" not in launch_source
+    assert "block=(512, 1, 1)" in _source("cula/ops/gdn/sm90/delta_rule.py")
+    assert THREADS_PER_CTA == 512
+
+
+def test_gdn_backend_uses_ops_layout() -> None:
+    public_root = REPO_ROOT / "cula" / "gdn"
+    backend_root = REPO_ROOT / "cula" / "ops" / "gdn" / "sm90"
+    assert not (public_root / "sm90").exists()
+    assert (backend_root / "delta_rule.py").is_file()
+    assert (backend_root / "launch.py").is_file()
+    for path in public_root.rglob("*.py"):
+        assert "import cutlass" not in path.read_text(), path
+
+
+def test_product_source_has_no_cpp_or_flashinfer_dispatch() -> None:
+    source_roots = (REPO_ROOT / "cula" / "gdn", REPO_ROOT / "cula" / "ops" / "gdn")
+    sources = {
+        path.relative_to(REPO_ROOT): path.read_text() for source_root in source_roots for path in source_root.rglob("*.py")
+    }
+    assert sources
+    for path, source in sources.items():
+        assert "gdn_fwd_prefill_sm90" not in source, path
+        assert "import flashinfer" not in source, path
+        assert "from flashinfer" not in source, path
+        assert "cula.cudac" not in source, path
+
+
+def test_gdn_prefill_benchmark_matrix_is_exact() -> None:
+    from benchmarks.bench_gdn_prefill import build_gdn_prefill_matrix
+
+    rows = build_gdn_prefill_matrix(0)
+    fixed = {(row.batch_size, row.seq_len) for row in rows if row.mode == "fixed"}
+    varlen = {(row.num_seqs, row.total_tokens, row.distribution) for row in rows if row.mode == "varlen"}
+    assert len(rows) == 28
+    assert fixed == {(batch_size, seq_len) for batch_size in (1, 2) for seq_len in (512, 1024, 4096, 8192, 16384)}
+    assert varlen == {
+        (num_seqs, total_tokens, distribution)
+        for num_seqs in (10, 20)
+        for total_tokens in (4096, 8192, 16384)
+        for distribution in ("uniform", "random", "skewed")
+    }
+    assert all(sum(row.seq_lens) == row.total_tokens for row in rows)
+    assert all(all(length > 0 for length in row.seq_lens) for row in rows)
+
+
+@pytest.mark.skipif(not _is_sm90(), reason="GDN prefill requires Hopper SM90")
+@pytest.mark.parametrize("case", CORRECTNESS_CASES, ids=lambda case: case.case_id)
+def test_correctness_matrix(case: GDNCase) -> None:
+    assert not any(name == "cula.cudac" or name.startswith("cula._cudac") for name in sys.modules)
+    result = run_correctness_case(case)
+    assert result["status"] == "PASS"
+    assert result["backend_id"] == SM90_BACKEND_ID
+    assert result["fallback_used"] is False
+
+
+@pytest.mark.parametrize("device", ["cpu", torch.device("cpu")])
+def test_availability_rejects_non_cuda_device_without_query(
+    monkeypatch: pytest.MonkeyPatch,
+    device: str | torch.device,
+) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    def unexpected_query(_device: torch.device | int | str) -> None:
+        raise AssertionError("non-CUDA device reached get_device_properties")
+
+    monkeypatch.setattr(torch.cuda, "get_device_properties", unexpected_query)
+    assert is_sm90_gdn_prefill_available(device) is False
+
+
+@pytest.mark.skipif(not _is_sm90(), reason="GDN prefill requires Hopper SM90")
+def test_public_api_opt_in_validation_rejects_zero_length_sequences() -> None:
+    inputs = _make_case_inputs(CASE_BY_ID["C01"])
+    zero_length = torch.tensor([0, 0, 8], dtype=torch.int64, device="cuda")
+    with pytest.raises(ValueError, match="zero-length"):
+        chunk_gated_delta_rule(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            cu_seqlens=zero_length,
+            validate_inputs=True,
+        )
+
+
+@pytest.mark.skipif(not _is_sm90(), reason="content validation requires H20/SM90 inputs")
+def test_public_api_opt_in_content_validation_observes_inplace_mutations() -> None:
+    inputs = _make_case_inputs(CASE_BY_ID["C01"])
+    chunk_gated_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        g=inputs["alpha"],
+        beta=inputs["beta"],
+        cu_seqlens=inputs["cu_seqlens"],
+        output=inputs["output"],
+        validate_inputs=True,
+    )
+
+    inputs["cu_seqlens"][1] = 0
+    with pytest.raises(ValueError, match="zero-length"):
+        chunk_gated_delta_rule(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            g=inputs["alpha"],
+            beta=inputs["beta"],
+            cu_seqlens=inputs["cu_seqlens"],
+            output=inputs["output"],
+            validate_inputs=True,
+        )
+    inputs["cu_seqlens"].copy_(torch.tensor([0, 5, 8], device="cuda"))
+
+    inputs["alpha"][0, 0] = torch.nan
+    with pytest.raises(ValueError, match="strictly positive"):
+        chunk_gated_delta_rule(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            g=inputs["alpha"],
+            beta=inputs["beta"],
+            cu_seqlens=inputs["cu_seqlens"],
+            output=inputs["output"],
+            validate_inputs=True,
+        )
+    inputs["alpha"][0, 0] = 1.0
+
+    inputs["beta"][0, 0] = torch.nan
+    with pytest.raises(ValueError, match="finite update"):
+        chunk_gated_delta_rule(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            g=inputs["alpha"],
+            beta=inputs["beta"],
+            cu_seqlens=inputs["cu_seqlens"],
+            output=inputs["output"],
+            validate_inputs=True,
+        )
+
+
+@pytest.mark.skipif(not _is_sm90(), reason="host-sync trace requires H20/SM90")
+def test_default_fast_path_avoids_host_sync_for_fresh_input_tensors() -> None:
+    inputs = _make_case_inputs(CASE_BY_ID["C01"])
+    chunk_gated_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        g=inputs["alpha"],
+        beta=inputs["beta"],
+        cu_seqlens=inputs["cu_seqlens"],
+        output=inputs["output"],
+    )
+    torch.cuda.synchronize()
+
+    fresh = {name: tensor.clone() for name, tensor in inputs.items() if isinstance(tensor, torch.Tensor)}
+    with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU]) as trace:
+        chunk_gated_delta_rule(
+            fresh["q"],
+            fresh["k"],
+            fresh["v"],
+            g=fresh["alpha"],
+            beta=fresh["beta"],
+            cu_seqlens=fresh["cu_seqlens"],
+            output=fresh["output"],
+        )
+    torch.cuda.synchronize()
+
+    cpu_ops = {event.key for event in trace.events()}
+    forbidden = {"aten::_local_scalar_dense", "aten::_to_copy", "aten::isfinite", "aten::gt"}
+    assert cpu_ops.isdisjoint(forbidden), sorted(cpu_ops & forbidden)
+    assert bool(torch.isfinite(fresh["output"]).all())
+
+
+@pytest.mark.skipif(not _is_sm90(), reason="TVM-FFI environment stream requires H20/SM90")
+def test_public_api_uses_current_nondefault_stream() -> None:
+    case = CASE_BY_ID["C01"]
+    inputs = _make_case_inputs(case)
+    expected, _ = _blockwise_reference(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        alpha=inputs["alpha_value"],
+        beta=inputs["beta_value"],
+        seq_lens=case.seq_lens,
+        initial_state=None,
+        scale=1.0 / math.sqrt(HEAD_SIZE),
+    )
+    torch.cuda.synchronize()
+
+    output = torch.full_like(inputs["output"], torch.nan)
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        actual = chunk_gated_delta_rule(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            g=inputs["alpha"],
+            beta=inputs["beta"],
+            cu_seqlens=inputs["cu_seqlens"],
+            output=output,
+        )
+        finished = torch.cuda.Event()
+        finished.record()
+    finished.synchronize()
+
+    assert bool(torch.isfinite(actual).all())
+    torch.testing.assert_close(actual, expected, rtol=OUTPUT_RTOL, atol=OUTPUT_ATOL)
+
+
+@pytest.mark.skipif(not _is_sm90(), reason="GDN prefill requires Hopper SM90")
+def test_repeated_launch_is_deterministic_and_keeps_redzones() -> None:
+    case = CASE_BY_ID["C05"]
+    inputs = _make_case_inputs(case)
+    hashes: list[int] = []
+    for _ in range(10):
+        inputs["output_storage"].fill_(OUTPUT_SENTINEL)
+        actual = chunk_gated_delta_rule(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            g=inputs["alpha"],
+            beta=inputs["beta"],
+            cu_seqlens=inputs["cu_seqlens"],
+            output=inputs["output"],
+        )
+        torch.cuda.synchronize()
+        hashes.append(hash(actual.detach().cpu().view(torch.uint16).numpy().tobytes()))
+        assert bool((inputs["output_storage"][:OUTPUT_GUARD_TOKENS] == OUTPUT_SENTINEL).all())
+        assert bool((inputs["output_storage"][-OUTPUT_GUARD_TOKENS:] == OUTPUT_SENTINEL).all())
+    assert len(set(hashes)) == 1
+
+
+@pytest.mark.skipif(not _is_sm90(), reason="GDN prefill requires Hopper SM90")
+def test_two_call_continuation_matches_one_call() -> None:
+    case = CASE_BY_ID["C06"]
+    inputs = _make_case_inputs(case)
+    kwargs = {
+        "g": inputs["alpha"],
+        "beta": inputs["beta"],
+        "initial_state": inputs["initial_state"],
+        "output_final_state": True,
+    }
+    full_output, full_state = chunk_gated_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        cu_seqlens=inputs["cu_seqlens"],
+        **kwargs,
+    )
+    split = 64
+    first_output, first_state = chunk_gated_delta_rule(
+        inputs["q"][:split].contiguous(),
+        inputs["k"][:split].contiguous(),
+        inputs["v"][:split].contiguous(),
+        g=inputs["alpha"][:split].contiguous(),
+        beta=inputs["beta"][:split].contiguous(),
+        initial_state=inputs["initial_state"],
+        output_final_state=True,
+        cu_seqlens=torch.tensor([0, split], dtype=torch.int64, device="cuda"),
+    )
+    second_output, second_state = chunk_gated_delta_rule(
+        inputs["q"][split:].contiguous(),
+        inputs["k"][split:].contiguous(),
+        inputs["v"][split:].contiguous(),
+        g=inputs["alpha"][split:].contiguous(),
+        beta=inputs["beta"][split:].contiguous(),
+        initial_state=first_state,
+        output_final_state=True,
+        cu_seqlens=torch.tensor([0, 70 - split], dtype=torch.int64, device="cuda"),
+    )
+    torch.cuda.synchronize()
+    continued_output = torch.cat((first_output, second_output), dim=0)
+    torch.testing.assert_close(
+        continued_output,
+        full_output,
+        rtol=OUTPUT_RTOL,
+        atol=OUTPUT_ATOL,
+    )
+    torch.testing.assert_close(
+        second_state,
+        full_state,
+        rtol=STATE_RTOL,
+        atol=STATE_ATOL,
+    )


### PR DESCRIPTION
## 📌 Description

This PR adds a Hopper SM90 Gated DeltaNet prefill path implemented entirely in
CuTe DSL.

- ports the upstream 512-thread TMA/WGMMA warp-specialized algorithm into
  `cula.ops.gdn.sm90` while preserving upstream authorship and provenance;
- exposes packed variable-length BF16 prefill through
  `cula.gdn.chunk_gated_delta_rule`, including optional gates, initial/final
  state, MHA, GQA, and GVA head mappings;
- keeps the product path independent of the cuLA C++ extension and FlashInfer
  headers/submodules at runtime;
- adds the exact 28-row Issue #76 benchmark, independent PyTorch reference
  tests, safety coverage, and Hopper user documentation.

## 🔍 Related Issues

Closes #76.

## Issue checklist

| Issue requirement | Delivery |
| --- | --- |
| Port Hopper kernels through CuTe DSL | `cula/ops/gdn/sm90/` implements the SM90a 512-thread TMA/WGMMA kernel and direct TVM-FFI launch path. |
| Adapt the Python interface | `cula.gdn.chunk_gated_delta_rule` validates packed inputs and exposes optional gates and recurrent state. |
| Add benchmarks | `benchmarks/bench_gdn_prefill.py` defaults to all 10 fixed and 18 packed-varlen rows from the issue. |
| Validate performance | H20 three-backend, three-process comparison: `0.993329822x` geometric mean and `1.147581166x` worst row versus frozen upstream C++; all 28 rows pass the `1.10x` / `1.25x` gates. |
| Add unit tests | Independent blockwise reference plus C01–C14, head mappings, tails, redzones, repeat, continuation, and stream behavior. |
| Update documentation | README quick start, repository layout, API/requirements guide, and pipeline guide. |

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [ ] I have run the repository-wide pre-commit hook set.
- [x] Ruff lint and format checks pass for every changed Python file.
- [x] `git diff --check` passes.

## 🧪 Tests

- [x] H20/SM90 product suite: `22 passed`.
- [x] C01–C14 correctness, no-C++ dispatch, non-default stream,
  repeat/continuation, and output/state redzones pass.
- [x] Compute Sanitizer C04 ragged-tail gate: memcheck and synccheck report
  zero errors; racecheck reports zero hazards.
- [x] Source manifest matches before and after validation (`182/182` files).
- [x] Fresh SM90a codegen: 512 threads, 100 WGMMA/HGMMA, 22 TMA,
  128 registers, zero stack/spill/local memory, and one active CTA/SM.

## ⚡ Performance

Measured on one idle NVIDIA H20-3e with BF16 `Hq=Hk=Hv=64`, `D=128`, 20
warmups and 100 CUDA-event timed iterations per row. Each backend ran in three
independent processes; each table entry is the median of the three process
averages. Compilation and first-call setup are excluded. A ratio below `1.0x`
means the CuTe DSL kernel is faster.

| Check | Limit | Result |
| --- | ---: | ---: |
| DSL / frozen FlashInfer geometric mean | `<= 1.10x` | `0.993329822x` |
| Worst row | `<= 1.25x` | `1.147581166x` (`fixed-b1-t512`) |
| Coverage | 28 rows/backend | DSL, migrated CUTLASS, and frozen FlashInfer each `28/28` |

| Workload group | Rows | DSL / FlashInfer geomean | DSL / migrated CUTLASS geomean | Max DSL / FlashInfer |
| --- | ---: | ---: | ---: | ---: |
| Fixed length | 10 | `1.003484x` | `0.972185x` | `1.147581x` |
| Packed variable length | 18 | `0.987733x` | `0.976909x` | `0.999400x` |
| **Overall** | **28** | **`0.993330x`** | **`0.975219x`** | **`1.147581x`** |

<details>
<summary>Full 28-row median latency table</summary>

| Row | CuTe DSL ms | Migrated CUTLASS ms | Frozen FlashInfer ms | DSL / FlashInfer |
| --- | ---: | ---: | ---: | ---: |
| `fixed-b1-t512` | 0.058701 | 0.056546 | 0.051152 | 1.147581x |
| `fixed-b1-t1024` | 0.097943 | 0.106133 | 0.099455 | 0.984794x |
| `fixed-b1-t4096` | 0.373638 | 0.383458 | 0.377599 | 0.989509x |
| `fixed-b1-t8192` | 0.741560 | 0.754011 | 0.748508 | 0.990718x |
| `fixed-b1-t16384` | 1.477579 | 1.499711 | 1.494760 | 0.988506x |
| `fixed-b2-t512` | 0.100763 | 0.110224 | 0.102313 | 0.984847x |
| `fixed-b2-t1024` | 0.192742 | 0.202722 | 0.195238 | 0.987216x |
| `fixed-b2-t4096` | 0.743809 | 0.757794 | 0.751203 | 0.990157x |
| `fixed-b2-t8192` | 1.480442 | 1.497819 | 1.492454 | 0.991951x |
| `fixed-b2-t16384` | 2.951255 | 2.984504 | 2.980956 | 0.990037x |
| `varlen-n10-t4096-uniform` | 0.385270 | 0.400514 | 0.392410 | 0.981806x |
| `varlen-n10-t4096-random` | 0.354295 | 0.365720 | 0.358675 | 0.987790x |
| `varlen-n10-t4096-skewed` | 0.351345 | 0.361929 | 0.355406 | 0.988573x |
| `varlen-n10-t8192-uniform` | 0.696737 | 0.713239 | 0.705871 | 0.987060x |
| `varlen-n10-t8192-random` | 0.668328 | 0.683563 | 0.675664 | 0.989143x |
| `varlen-n10-t8192-skewed` | 0.653087 | 0.665490 | 0.659418 | 0.990399x |
| `varlen-n10-t16384-uniform` | 1.366857 | 1.383636 | 1.378220 | 0.991755x |
| `varlen-n10-t16384-random` | 1.273788 | 1.291183 | 1.285643 | 0.990779x |
| `varlen-n10-t16384-skewed` | 1.247147 | 1.264023 | 1.258424 | 0.991039x |
| `varlen-n20-t4096-uniform` | 0.430677 | 0.447858 | 0.439974 | 0.978869x |
| `varlen-n20-t4096-random` | 0.408003 | 0.420942 | 0.413756 | 0.986093x |
| `varlen-n20-t4096-skewed` | 0.401375 | 0.413276 | 0.406397 | 0.987642x |
| `varlen-n20-t8192-uniform` | 0.725918 | 0.747053 | 0.739044 | 0.982240x |
| `varlen-n20-t8192-random` | 0.701505 | 0.721255 | 0.713559 | 0.983107x |
| `varlen-n20-t8192-skewed` | 0.707668 | 0.714869 | 0.708092 | 0.999400x |
| `varlen-n20-t16384-uniform` | 1.315303 | 1.338503 | 1.331811 | 0.987604x |
| `varlen-n20-t16384-random` | 1.345815 | 1.369917 | 1.363760 | 0.986842x |
| `varlen-n20-t16384-skewed` | 1.298094 | 1.317645 | 1.312225 | 0.989232x |

</details>

All backend/process inputs are byte-identical. The canonical benchmark can be
reproduced with:

```bash
python benchmarks/bench_gdn_prefill.py --output gdn-sm90-issue76.json
```

## Reviewer Notes

- The kernel is adapted from FlashInfer's Apache-2.0 SM90 CuTe DSL rewrite:
  original rewrite `eb31811856e07f3c5fc94a7aaafeaeaabd954f4f`, imported source
  `97996a4123924140d28a3079292535aa534eba92`, and frozen C++ oracle
  `41e5aa29a0e218bde2e2045316ed88e3f4dc8ca2`.
- The imported revision includes the corrected final-tail `s < B and t < B`
  predicate and explicit compile-cache key; cuLA supplies the public API,
  packaging, tests, benchmark, and documentation around the upstream kernel.
- The SM90 path requires `nvidia-cutlass-dsl==4.5.1` and fails explicitly on an
  unsupported GPU or DSL version; it never silently falls back to C++.
- Intermediate state checkpoints, zero-length packed sequences, non-BF16
  Q/K/V, head sizes other than 128, decode, and backward are intentionally out
  of scope and documented as unsupported.
- The changes are split by product responsibility: implementation,
  correctness/benchmark coverage, and documentation.
