### PR TITLE
feat(cp): add opt-in NVSHMEM CP state handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,38 @@ print(f'Final state shape: {final_state.shape}')  # [2, 32, 128, 128]
 - `beta` supports both `float32` and `bfloat16`; `initial_state` must be `float32`.
 - `cu_seqlens` (for variable-length sequences) must be `int32`.
 
+### NVSHMEM CP overlap
+
+cuLA provides an opt-in NVSHMEM CP-overlap backend for KDA preprocessing. In the
+validated CP=2 path, it writes the producer state directly into symmetric
+memory, publishes readiness with an NVSHMEM signal, and transfers only the
+V-state consumed by the successor.
+
+```bash
+export CULA_CP_OVERLAP=1
+export CULA_CP_COMM_BACKEND=nvshmem
+export CULA_CP_NVSHMEM_READY_WAIT=1
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export NVSHMEM_DISABLE_CUDA_VMM=1
+export NVSHMEM_SYMMETRIC_SIZE=256M
+```
+
+The default remains the FLA path because `CULA_CP_OVERLAP` defaults to `0`. The
+validated NVSHMEM-overlap path uses eager execution, a global CP group of size
+two, one global sequence, and the rank-0-to-rank-1 predecessor relationship. The
+GB200 validation used `NVSHMEM_DISABLE_CUDA_VMM=1`; cuLA does not override this
+installation-specific setting.
+
+Run the integrated correctness check with:
+
+```bash
+torchrun --standalone --nproc-per-node=2 \
+  benchmarks/check_cp_predecessor_nvshmem.py
+```
+
+See [the focused benchmark note](docs/cp_overlap/nvshmem_predecessor_handoff.md)
+for the before/after result and reproduction command.
+
 ## Usage
 
 See [USAGE.md](USAGE.md) for detailed usage examples and notes.

--- a/benchmarks/bench_cp_predecessor_nvshmem.py
+++ b/benchmarks/bench_cp_predecessor_nvshmem.py
@@ -1,0 +1,142 @@
+import argparse
+import json
+import os
+import statistics
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from fla.ops.cp import build_cp_context
+from fla.ops.kda import chunk_kda as fla_chunk_kda
+
+from cula.kda import chunk_kda as cula_chunk_kda
+
+
+def _init_distributed() -> tuple[int, int]:
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    try:
+        dist.init_process_group("nccl", device_id=torch.device("cuda", local_rank))
+    except TypeError:
+        dist.init_process_group("nccl")
+    if dist.get_world_size() != 2:
+        raise RuntimeError("This benchmark requires exactly two ranks.")
+    return rank, local_rank
+
+
+def run(args: argparse.Namespace) -> dict:
+    rank, local_rank = _init_distributed()
+    device = torch.device("cuda", local_rank)
+    if args.sequence_length % 2:
+        raise ValueError("sequence length must be divisible by two")
+
+    generator = torch.Generator(device=device).manual_seed(1234 + rank)
+    shape = (1, args.sequence_length // 2, args.heads, 128)
+    q = torch.rand(shape, generator=generator, device=device, dtype=torch.bfloat16)
+    k = torch.rand(shape, generator=generator, device=device, dtype=torch.bfloat16)
+    q = F.normalize(q.float(), p=2, dim=-1).to(torch.bfloat16)
+    k = F.normalize(k.float(), p=2, dim=-1).to(torch.bfloat16)
+    v = torch.rand(shape, generator=generator, device=device, dtype=torch.bfloat16)
+    gate_logits = torch.randn(shape, generator=generator, device=device, dtype=torch.float32)
+    g = F.logsigmoid(gate_logits).clamp_(-5, 0).to(torch.bfloat16)
+    beta_logits = torch.randn(shape[:-1], generator=generator, device=device, dtype=torch.float32)
+    beta = beta_logits.sigmoid_().to(torch.bfloat16)
+    a_log = torch.zeros(args.heads, device=device, dtype=torch.float32)
+    dt_bias = torch.zeros(args.heads * 128, device=device, dtype=torch.float32)
+    global_cu_seqlens = torch.tensor([0, args.sequence_length], device=device, dtype=torch.long)
+    cp_context = build_cp_context(cu_seqlens=global_cu_seqlens, group=dist.group.WORLD)
+    os.environ["CULA_CP_COMM_BACKEND"] = args.backend
+    os.environ["CULA_CP_OVERLAP"] = "1" if args.backend == "nvshmem" else "0"
+    os.environ["CULA_CP_NVSHMEM_READY_WAIT"] = "1"
+    implementation = fla_chunk_kda if args.backend == "fla_full" else cula_chunk_kda
+    safe_gate = args.backend != "fla_full"
+
+    def step() -> None:
+        with torch.inference_mode():
+            implementation(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                A_log=a_log,
+                dt_bias=dt_bias,
+                initial_state=None,
+                output_final_state=False,
+                use_qk_l2norm_in_kernel=False,
+                use_gate_in_kernel=False,
+                safe_gate=safe_gate,
+                lower_bound=-5.0 if safe_gate else None,
+                cu_seqlens=cp_context.cu_seqlens,
+                cu_seqlens_cpu=cp_context.cu_seqlens_cpu,
+                cp_context=cp_context,
+            )
+
+    repeat_results = []
+    for _ in range(args.repeats):
+        for _ in range(args.warmup):
+            step()
+        torch.cuda.synchronize(device)
+        dist.barrier()
+
+        times = []
+        for _ in range(args.iterations):
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            step()
+            end.record()
+            end.synchronize()
+            times.append(start.elapsed_time(end))
+
+        local = torch.tensor(times, device=device)
+        gathered = [torch.empty_like(local) for _ in range(2)]
+        dist.all_gather(gathered, local)
+        all_times = torch.stack(gathered).cpu()
+        rank_max = all_times.amax(dim=0).tolist()
+        repeat_results.append(
+            {
+                "global_p50_ms": round(float(all_times.flatten().median()), 4),
+                "rank_p50_ms": [round(float(rank_times.median()), 4) for rank_times in all_times],
+                "rank_max_median_ms": round(statistics.median(rank_max), 4),
+                "rank_max_min_ms": round(min(rank_max), 4),
+                "rank_max_max_ms": round(max(rank_max), 4),
+            }
+        )
+
+    global_p50_values = [repeat["global_p50_ms"] for repeat in repeat_results]
+    rank_max_p50_values = [repeat["rank_max_median_ms"] for repeat in repeat_results]
+    result = {
+        "backend": args.backend,
+        "world_size": 2,
+        "sequence_length": args.sequence_length,
+        "heads": args.heads,
+        "warmup": args.warmup,
+        "iterations": args.iterations,
+        "repeats": args.repeats,
+        "global_p50_ms": round(statistics.median(global_p50_values), 4),
+        "rank_max_median_ms": round(statistics.median(rank_max_p50_values), 4),
+        "repeat_results": repeat_results,
+    }
+    dist.barrier()
+    dist.destroy_process_group()
+    return result if rank == 0 else {}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", choices=("fla_full", "fla", "nvshmem"), required=True)
+    parser.add_argument("--sequence-length", type=int, default=8192)
+    parser.add_argument("--heads", type=int, default=8)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=60)
+    parser.add_argument("--repeats", type=int, default=1)
+    args = parser.parse_args()
+    result = run(args)
+    if result:
+        print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_cp_predecessor_nvshmem.py
+++ b/benchmarks/bench_cp_predecessor_nvshmem.py
@@ -12,7 +12,7 @@ from fla.ops.kda import chunk_kda as fla_chunk_kda
 from cula.kda import chunk_kda as cula_chunk_kda
 
 
-def _init_distributed() -> tuple[int, int]:
+def _init_distributed(expected_world_size: int) -> tuple[int, int, int]:
     rank = int(os.environ["RANK"])
     local_rank = int(os.environ["LOCAL_RANK"])
     torch.cuda.set_device(local_rank)
@@ -20,19 +20,20 @@ def _init_distributed() -> tuple[int, int]:
         dist.init_process_group("nccl", device_id=torch.device("cuda", local_rank))
     except TypeError:
         dist.init_process_group("nccl")
-    if dist.get_world_size() != 2:
-        raise RuntimeError("This benchmark requires exactly two ranks.")
-    return rank, local_rank
+    world_size = dist.get_world_size()
+    if world_size != expected_world_size:
+        raise RuntimeError(f"This benchmark requires exactly {expected_world_size} ranks, got {world_size}.")
+    return rank, local_rank, world_size
 
 
 def run(args: argparse.Namespace) -> dict:
-    rank, local_rank = _init_distributed()
+    rank, local_rank, world_size = _init_distributed(args.world_size)
     device = torch.device("cuda", local_rank)
-    if args.sequence_length % 2:
-        raise ValueError("sequence length must be divisible by two")
+    if args.sequence_length % world_size:
+        raise ValueError("sequence length must be divisible by world size")
 
     generator = torch.Generator(device=device).manual_seed(1234 + rank)
-    shape = (1, args.sequence_length // 2, args.heads, 128)
+    shape = (1, args.sequence_length // world_size, args.heads, 128)
     q = torch.rand(shape, generator=generator, device=device, dtype=torch.bfloat16)
     k = torch.rand(shape, generator=generator, device=device, dtype=torch.bfloat16)
     q = F.normalize(q.float(), p=2, dim=-1).to(torch.bfloat16)
@@ -91,7 +92,7 @@ def run(args: argparse.Namespace) -> dict:
             times.append(start.elapsed_time(end))
 
         local = torch.tensor(times, device=device)
-        gathered = [torch.empty_like(local) for _ in range(2)]
+        gathered = [torch.empty_like(local) for _ in range(world_size)]
         dist.all_gather(gathered, local)
         all_times = torch.stack(gathered).cpu()
         rank_max = all_times.amax(dim=0).tolist()
@@ -109,7 +110,7 @@ def run(args: argparse.Namespace) -> dict:
     rank_max_p50_values = [repeat["rank_max_median_ms"] for repeat in repeat_results]
     result = {
         "backend": args.backend,
-        "world_size": 2,
+        "world_size": world_size,
         "sequence_length": args.sequence_length,
         "heads": args.heads,
         "warmup": args.warmup,
@@ -126,6 +127,7 @@ def run(args: argparse.Namespace) -> dict:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--world-size", type=int, default=2)
     parser.add_argument("--backend", choices=("fla_full", "fla", "nvshmem"), required=True)
     parser.add_argument("--sequence-length", type=int, default=8192)
     parser.add_argument("--heads", type=int, default=8)

--- a/benchmarks/bench_cp_predecessor_nvshmem.py
+++ b/benchmarks/bench_cp_predecessor_nvshmem.py
@@ -49,7 +49,7 @@ def run(args: argparse.Namespace) -> dict:
     cp_context = build_cp_context(cu_seqlens=global_cu_seqlens, group=dist.group.WORLD)
     os.environ["CULA_CP_COMM_BACKEND"] = args.backend
     os.environ["CULA_CP_OVERLAP"] = "1" if args.backend == "nvshmem" else "0"
-    os.environ["CULA_CP_NVSHMEM_READY_WAIT"] = "1"
+    os.environ.setdefault("CULA_CP_NVSHMEM_READY_WAIT", "1")
     implementation = fla_chunk_kda if args.backend == "fla_full" else cula_chunk_kda
     safe_gate = args.backend != "fla_full"
 

--- a/benchmarks/check_cp_predecessor_nvshmem.py
+++ b/benchmarks/check_cp_predecessor_nvshmem.py
@@ -106,12 +106,11 @@ def run(args: argparse.Namespace) -> dict:
     dist.barrier()
     candidate = _run_backend(backend="nvshmem", inputs=inputs, cp_context=cp_context, heads=args.heads)
 
-    differences = {
-        name: _global_max((candidate[name].float() - reference[name].float()).abs().max()) for name in reference
-    }
-    passed = differences["output"] <= args.output_atol and max(
-        difference for name, difference in differences.items() if name != "output"
-    ) <= args.gradient_atol
+    differences = {name: _global_max((candidate[name].float() - reference[name].float()).abs().max()) for name in reference}
+    passed = (
+        differences["output"] <= args.output_atol
+        and max(difference for name, difference in differences.items() if name != "output") <= args.gradient_atol
+    )
     result = {
         "world_size": world_size,
         "sequence_length": args.sequence_length,

--- a/benchmarks/check_cp_predecessor_nvshmem.py
+++ b/benchmarks/check_cp_predecessor_nvshmem.py
@@ -10,7 +10,7 @@ from fla.ops.cp import build_cp_context
 from cula.kda import chunk_kda
 
 
-def _init_distributed() -> tuple[int, int]:
+def _init_distributed(expected_world_size: int) -> tuple[int, int, int]:
     rank = int(os.environ["RANK"])
     local_rank = int(os.environ["LOCAL_RANK"])
     torch.cuda.set_device(local_rank)
@@ -18,14 +18,15 @@ def _init_distributed() -> tuple[int, int]:
         dist.init_process_group("nccl", device_id=torch.device("cuda", local_rank))
     except TypeError:
         dist.init_process_group("nccl")
-    if dist.get_world_size() != 2:
-        raise RuntimeError("This check requires exactly two ranks.")
-    return rank, local_rank
+    world_size = dist.get_world_size()
+    if world_size != expected_world_size:
+        raise RuntimeError(f"This check requires exactly {expected_world_size} ranks, got {world_size}.")
+    return rank, local_rank, world_size
 
 
-def _make_inputs(*, rank: int, device: torch.device, sequence_length: int, heads: int):
+def _make_inputs(*, rank: int, world_size: int, device: torch.device, sequence_length: int, heads: int):
     generator = torch.Generator(device=device).manual_seed(1234 + rank)
-    shape = (1, sequence_length // 2, heads, 128)
+    shape = (1, sequence_length // world_size, heads, 128)
     q = torch.rand(shape, generator=generator, device=device, dtype=torch.bfloat16)
     k = torch.rand(shape, generator=generator, device=device, dtype=torch.bfloat16)
     q = F.normalize(q.float(), p=2, dim=-1).to(torch.bfloat16)
@@ -86,12 +87,18 @@ def _global_max(value: torch.Tensor) -> float:
 
 
 def run(args: argparse.Namespace) -> dict:
-    rank, local_rank = _init_distributed()
+    rank, local_rank, world_size = _init_distributed(args.world_size)
     device = torch.device("cuda", local_rank)
-    if args.sequence_length % 2:
-        raise ValueError("sequence length must be divisible by two")
+    if args.sequence_length % world_size:
+        raise ValueError("sequence length must be divisible by world size")
 
-    inputs = _make_inputs(rank=rank, device=device, sequence_length=args.sequence_length, heads=args.heads)
+    inputs = _make_inputs(
+        rank=rank,
+        world_size=world_size,
+        device=device,
+        sequence_length=args.sequence_length,
+        heads=args.heads,
+    )
     global_cu_seqlens = torch.tensor([0, args.sequence_length], device=device, dtype=torch.long)
     cp_context = build_cp_context(cu_seqlens=global_cu_seqlens, group=dist.group.WORLD)
 
@@ -106,7 +113,7 @@ def run(args: argparse.Namespace) -> dict:
         difference for name, difference in differences.items() if name != "output"
     ) <= args.gradient_atol
     result = {
-        "world_size": 2,
+        "world_size": world_size,
         "sequence_length": args.sequence_length,
         "heads": args.heads,
         "output_atol": args.output_atol,
@@ -121,6 +128,7 @@ def run(args: argparse.Namespace) -> dict:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--world-size", type=int, default=2)
     parser.add_argument("--sequence-length", type=int, default=1024)
     parser.add_argument("--heads", type=int, default=4)
     parser.add_argument("--output-atol", type=float, default=1e-2)

--- a/benchmarks/check_cp_predecessor_nvshmem.py
+++ b/benchmarks/check_cp_predecessor_nvshmem.py
@@ -1,0 +1,137 @@
+import argparse
+import json
+import os
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from fla.ops.cp import build_cp_context
+
+from cula.kda import chunk_kda
+
+
+def _init_distributed() -> tuple[int, int]:
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    try:
+        dist.init_process_group("nccl", device_id=torch.device("cuda", local_rank))
+    except TypeError:
+        dist.init_process_group("nccl")
+    if dist.get_world_size() != 2:
+        raise RuntimeError("This check requires exactly two ranks.")
+    return rank, local_rank
+
+
+def _make_inputs(*, rank: int, device: torch.device, sequence_length: int, heads: int):
+    generator = torch.Generator(device=device).manual_seed(1234 + rank)
+    shape = (1, sequence_length // 2, heads, 128)
+    q = torch.rand(shape, generator=generator, device=device, dtype=torch.bfloat16)
+    k = torch.rand(shape, generator=generator, device=device, dtype=torch.bfloat16)
+    q = F.normalize(q.float(), p=2, dim=-1).to(torch.bfloat16)
+    k = F.normalize(k.float(), p=2, dim=-1).to(torch.bfloat16)
+    v = torch.rand(shape, generator=generator, device=device, dtype=torch.bfloat16)
+    gate_logits = torch.randn(shape, generator=generator, device=device, dtype=torch.float32)
+    g = F.logsigmoid(gate_logits).clamp_(-5, 0).to(torch.bfloat16)
+    beta_logits = torch.randn(shape[:-1], generator=generator, device=device, dtype=torch.float32)
+    beta = beta_logits.sigmoid_().to(torch.bfloat16)
+    return q, k, v, g, beta
+
+
+def _run_backend(*, backend: str, inputs, cp_context, heads: int):
+    os.environ["CULA_CP_COMM_BACKEND"] = backend
+    os.environ["CULA_CP_OVERLAP"] = "1" if backend == "nvshmem" else "0"
+    os.environ["CULA_CP_NVSHMEM_READY_WAIT"] = "1"
+    q, k, v, g, beta = [tensor.detach().clone().requires_grad_(True) for tensor in inputs]
+    a_log = torch.zeros(heads, device=q.device, dtype=torch.float32, requires_grad=True)
+    dt_bias = torch.zeros(heads * 128, device=q.device, dtype=torch.float32, requires_grad=True)
+    out, _ = chunk_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=a_log,
+        dt_bias=dt_bias,
+        initial_state=None,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=False,
+        use_gate_in_kernel=False,
+        safe_gate=True,
+        lower_bound=-5.0,
+        cu_seqlens=cp_context.cu_seqlens,
+        cu_seqlens_cpu=cp_context.cu_seqlens_cpu,
+        cp_context=cp_context,
+    )
+    out.float().square().mean().backward()
+    torch.cuda.synchronize(q.device)
+    values = {
+        "output": out.detach(),
+        "grad_q": q.grad,
+        "grad_k": k.grad,
+        "grad_v": v.grad,
+        "grad_g": g.grad,
+        "grad_beta": beta.grad,
+    }
+    if any(value is None for value in values.values()):
+        missing = [name for name, value in values.items() if value is None]
+        raise RuntimeError(f"Missing active gradients for {missing}")
+    return values
+
+
+def _global_max(value: torch.Tensor) -> float:
+    value = value.detach().float()
+    dist.all_reduce(value, op=dist.ReduceOp.MAX)
+    return float(value.item())
+
+
+def run(args: argparse.Namespace) -> dict:
+    rank, local_rank = _init_distributed()
+    device = torch.device("cuda", local_rank)
+    if args.sequence_length % 2:
+        raise ValueError("sequence length must be divisible by two")
+
+    inputs = _make_inputs(rank=rank, device=device, sequence_length=args.sequence_length, heads=args.heads)
+    global_cu_seqlens = torch.tensor([0, args.sequence_length], device=device, dtype=torch.long)
+    cp_context = build_cp_context(cu_seqlens=global_cu_seqlens, group=dist.group.WORLD)
+
+    reference = _run_backend(backend="fla", inputs=inputs, cp_context=cp_context, heads=args.heads)
+    dist.barrier()
+    candidate = _run_backend(backend="nvshmem", inputs=inputs, cp_context=cp_context, heads=args.heads)
+
+    differences = {
+        name: _global_max((candidate[name].float() - reference[name].float()).abs().max()) for name in reference
+    }
+    passed = differences["output"] <= args.output_atol and max(
+        difference for name, difference in differences.items() if name != "output"
+    ) <= args.gradient_atol
+    result = {
+        "world_size": 2,
+        "sequence_length": args.sequence_length,
+        "heads": args.heads,
+        "output_atol": args.output_atol,
+        "gradient_atol": args.gradient_atol,
+        "max_abs_diff": differences,
+        "passed": passed,
+    }
+    dist.barrier()
+    dist.destroy_process_group()
+    return result if rank == 0 else {}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sequence-length", type=int, default=1024)
+    parser.add_argument("--heads", type=int, default=4)
+    parser.add_argument("--output-atol", type=float, default=1e-2)
+    parser.add_argument("--gradient-atol", type=float, default=2e-2)
+    args = parser.parse_args()
+    result = run(args)
+    if result:
+        print(json.dumps(result, sort_keys=True))
+        if not result["passed"]:
+            raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/check_cp_predecessor_nvshmem.py
+++ b/benchmarks/check_cp_predecessor_nvshmem.py
@@ -42,7 +42,7 @@ def _make_inputs(*, rank: int, world_size: int, device: torch.device, sequence_l
 def _run_backend(*, backend: str, inputs, cp_context, heads: int):
     os.environ["CULA_CP_COMM_BACKEND"] = backend
     os.environ["CULA_CP_OVERLAP"] = "1" if backend == "nvshmem" else "0"
-    os.environ["CULA_CP_NVSHMEM_READY_WAIT"] = "1"
+    os.environ.setdefault("CULA_CP_NVSHMEM_READY_WAIT", "1")
     q, k, v, g, beta = [tensor.detach().clone().requires_grad_(True) for tensor in inputs]
     a_log = torch.zeros(heads, device=q.device, dtype=torch.float32, requires_grad=True)
     dt_bias = torch.zeros(heads * 128, device=q.device, dtype=torch.float32, requires_grad=True)

--- a/benchmarks/run_cp4_nvshmem_optimized.sh
+++ b/benchmarks/run_cp4_nvshmem_optimized.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+python="${PYTHON:-${repo_root}/.venv/bin/python}"
+repeats="${REPEATS:-5}"
+
+export CUDA_DEVICE_MAX_CONNECTIONS="${CUDA_DEVICE_MAX_CONNECTIONS:-2}"
+export NVSHMEM_DISABLE_CUDA_VMM="${NVSHMEM_DISABLE_CUDA_VMM:-1}"
+export NVSHMEM_SYMMETRIC_SIZE="${NVSHMEM_SYMMETRIC_SIZE:-256M}"
+export NVSHMEM_IB_ENABLE="${NVSHMEM_IB_ENABLE:-0}"
+export CULA_CP_ALLOW_FALLBACK=0
+export CULA_CP_COMM_USE_CURRENT_STREAM=1
+export CULA_CP_NVSHMEM_DIRECT_STORE_CONN1_ONLY=0
+export CULA_CP_NVSHMEM_FUSED_REMOTE_MERGE=1
+export CULA_CP_NVSHMEM_READY_WAIT=0
+
+run_dist() {
+    "${python}" -m torch.distributed.run --standalone --nproc_per_node=4 "$@"
+}
+
+cd "${repo_root}"
+
+run_dist benchmarks/check_cp_predecessor_nvshmem.py \
+    --world-size 4 --sequence-length 8192 --heads 16
+
+run_benchmark() {
+    local backend="$1"
+    local sequence_length="$2"
+    local heads="$3"
+    run_dist benchmarks/bench_cp_predecessor_nvshmem.py \
+        --world-size 4 \
+        --backend "${backend}" \
+        --sequence-length "${sequence_length}" \
+        --heads "${heads}" \
+        --warmup 20 \
+        --iterations 60 \
+        --repeats "${repeats}"
+}
+
+# Rotate backend order between shapes to reduce order bias.
+run_benchmark nvshmem 4096 8
+run_benchmark fla 4096 8
+run_benchmark fla 8192 16
+run_benchmark nvshmem 8192 16

--- a/cula/kda/chunk_fwd.py
+++ b/cula/kda/chunk_fwd.py
@@ -18,15 +18,13 @@ import torch
 
 # from fla.ops.common.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from fla.ops.cp import FLACPContext
-from fla.ops.cp.chunk_delta_h import (
-    chunk_gated_delta_rule_fwd_h_pre_process,
-    compress_h0,
-)
+from fla.ops.cp.chunk_delta_h import compress_h0
 from fla.ops.kda.gate import kda_gate_chunk_cumsum
 from fla.ops.utils import chunk_local_cumsum
 from fla.ops.utils.constant import RCP_LN2
 
 from cula.kda.chunk_intra import chunk_kda_fwd_intra
+from cula.kda.cp_overlap import chunk_gated_delta_rule_fwd_h_pre_process_overlap
 from cula.utils import assert_blackwell
 
 
@@ -95,7 +93,7 @@ def chunk_kda_fwd(
     )
 
     if cp_context is not None:
-        initial_state = chunk_gated_delta_rule_fwd_h_pre_process(
+        initial_state = chunk_gated_delta_rule_fwd_h_pre_process_overlap(
             k=kg,
             w=w,
             u=u,

--- a/cula/kda/cp_overlap.py
+++ b/cula/kda/cp_overlap.py
@@ -19,6 +19,7 @@ import warnings
 import torch
 import torch.distributed as dist
 import triton
+import triton.language as tl
 from fla.ops.cp.chunk_delta_h import (
     chunk_gated_delta_rule_fwd_h_pre_process as _fla_chunk_gated_delta_rule_fwd_h_pre_process,
 )
@@ -76,6 +77,10 @@ def _cp_comm_stream_priority() -> int:
         return -1
 
 
+def _cp_comm_use_current_stream() -> bool:
+    return os.getenv("CULA_CP_COMM_USE_CURRENT_STREAM", "0").lower() in {"1", "true", "on", "yes"}
+
+
 def _get_comm_stream(device: torch.device) -> torch.cuda.Stream:
     idx = device.index if device.index is not None else torch.cuda.current_device()
     stream = _COMM_STREAMS.get(idx)
@@ -131,6 +136,10 @@ def _cp_nvshmem_quiet() -> bool:
 
 def _cp_nvshmem_direct_store() -> bool:
     return os.getenv("CULA_CP_NVSHMEM_DIRECT_STORE", "1").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_fused_remote_merge() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_FUSED_REMOTE_MERGE", "0").lower() in {"1", "true", "on", "yes"}
 
 
 def _cp_nvshmem_direct_store_conn1_only() -> bool:
@@ -546,6 +555,93 @@ def _nvshmem_wait_ready_epoch(
         _cp_debug_log(rank, f"wait_ready_signal_done peer={peer} slot={slot} epoch={epoch}")
 
 
+@triton.autotune(
+    configs=[
+        triton.Config({"BV": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BV": 64}, num_warps=4, num_stages=2),
+    ],
+    key=["H", "K", "V", "NUM_PEERS"],
+)
+@triton.jit
+def _merge_remote_states_kernel(
+    out,
+    peer0,
+    peer1,
+    peer2,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    NUM_PEERS: tl.constexpr,
+):
+    i_v = tl.program_id(0)
+    i_h = tl.program_id(1)
+    state = tl.zeros((BK, BV), dtype=tl.float32)
+    stride = K * (K + V)
+
+    for peer_idx in tl.static_range(NUM_PEERS):
+        if peer_idx == 0:
+            peer = peer0
+        elif peer_idx == 1:
+            peer = peer1
+        else:
+            peer = peer2
+        peer += i_h * stride
+        h_block = tl.make_block_ptr(
+            peer,
+            (K, V),
+            (K + V, 1),
+            (0, i_v * BV),
+            (BK, BV),
+            (1, 0),
+        )
+        m_block = tl.make_block_ptr(
+            peer + V,
+            (K, K),
+            (K + V, 1),
+            (0, 0),
+            (BK, BK),
+            (1, 0),
+        )
+        local_h = tl.load(h_block, boundary_check=(0, 1)).to(tl.float32)
+        local_m = tl.load(m_block, boundary_check=(0, 1)).to(tl.float32)
+        state = tl.dot(local_m, state) + local_h
+
+    out_block = tl.make_block_ptr(
+        out + i_h * K * V,
+        (K, V),
+        (V, 1),
+        (0, i_v * BV),
+        (BK, BV),
+        (1, 0),
+    )
+    tl.store(out_block, state, boundary_check=(0, 1))
+
+
+def _merge_remote_states(out: torch.Tensor, peer_tensors: list[torch.Tensor]) -> None:
+    if not 1 <= len(peer_tensors) <= 3:
+        raise RuntimeError("Fused remote merge supports one to three predecessor peers.")
+    h_dim, k_dim, v_dim = out.shape
+    bk = triton.next_power_of_2(k_dim)
+    padded = peer_tensors + [peer_tensors[0]] * (3 - len(peer_tensors))
+
+    def grid(meta):
+        return (triton.cdiv(v_dim, meta["BV"]), h_dim)
+
+    _merge_remote_states_kernel[grid](
+        out,
+        padded[0],
+        padded[1],
+        padded[2],
+        H=h_dim,
+        K=k_dim,
+        V=v_dim,
+        BK=bk,
+        NUM_PEERS=len(peer_tensors),
+    )
+
+
 def _nvshmem_all_gather_into_tensor(
     inp: torch.Tensor,
     out: torch.Tensor | None,
@@ -559,6 +655,7 @@ def _nvshmem_all_gather_into_tensor(
     allow_signal_mode: bool = True,
     compact_out_layout: bool = False,
     fetch_last_dim: int | None = None,
+    merge_remote_output: bool = False,
 ) -> None:
     world_size = dist.get_world_size(group=group)
     rank = dist.get_rank(group=group)
@@ -613,6 +710,11 @@ def _nvshmem_all_gather_into_tensor(
             stream=ns,
         )
         _cp_debug_log(rank, f"wait_ready_end slot={slot} epoch={epoch} fetch_peers={fetch_peers}")
+    if merge_remote_output:
+        if out is None or out.ndim != 4 or out.shape[0] != 1:
+            raise RuntimeError("Fused remote merge requires an output shaped [1, H, K, V].")
+        _merge_remote_states(out[0], [peers[peer] for peer in fetch_peers])
+        return
     for fetch_idx, peer in enumerate(fetch_peers):
         if out is None:
             raise RuntimeError("out tensor must be provided when fetch_peers is non-empty.")
@@ -852,6 +954,9 @@ def chunk_gated_delta_rule_fwd_h_pre_process_overlap(
         # CUDA Graph capture-safe path: keep communication on the capturing stream.
         comm_stream = torch.cuda.current_stream()
         comm_event = None
+    elif _cp_comm_use_current_stream():
+        comm_stream = torch.cuda.current_stream()
+        comm_event = None
     else:
         comm_stream = _get_comm_stream(hm.device)
         comm_event = _get_comm_event(hm.device)
@@ -864,6 +969,17 @@ def chunk_gated_delta_rule_fwd_h_pre_process_overlap(
         and ((not in_capture) or _cp_direct_pred_fetch_in_graph())
         and (not context.is_first_rank)
     )
+    direct_remote_merge = bool(
+        _cp_nvshmem_fused_remote_merge()
+        and use_nvshmem
+        and _NVSHMEM_INIT_OK
+        and world_size <= 4
+        and pre_num_ranks > 1
+        and not in_capture
+        and not transpose_state_layout
+        and N == 1
+    )
+    direct_initial_state = direct_predecessor_state or direct_remote_merge
 
     initial_state = None
     ag_hm = None
@@ -875,21 +991,25 @@ def chunk_gated_delta_rule_fwd_h_pre_process_overlap(
         comm_end = torch.cuda.Event(enable_timing=True)
     merge_ms = 0.0
     if not context.is_first_rank:
-        _cp_debug_log(rank, f"ag_hm_alloc_enter direct_pred_state={direct_predecessor_state}")
-        if direct_predecessor_state:
-            # Fetch predecessor V-state directly into final output buffer (N=1),
-            # avoiding an extra staging tensor and post-comm copy.
+        _cp_debug_log(
+            rank,
+            f"ag_hm_alloc_enter direct_pred_state={direct_predecessor_state} direct_remote_merge={direct_remote_merge}",
+        )
+        if direct_initial_state:
+            # Materialize the final state directly, avoiding a separate receive
+            # buffer and a second local merge/copy pass.
             initial_state = k.new_empty(N, HV, K, V, dtype=torch.float32)
             ag_hm = initial_state
-            # Keep capture-time cache guard satisfied by materializing the
-            # compact receive cache during warmup.
-            _get_or_create_ag_hm_from_spec(
-                shape=ag_hm_shape,
-                dtype=hm_dtype,
-                num_rows=ag_hm_rows,
-                group=context.group,
-            )
-            _cp_debug_log(rank, "ag_hm_alloc_done direct_pred_state=1")
+            if direct_predecessor_state:
+                # Keep capture-time cache guard satisfied by materializing the
+                # compact receive cache during warmup.
+                _get_or_create_ag_hm_from_spec(
+                    shape=ag_hm_shape,
+                    dtype=hm_dtype,
+                    num_rows=ag_hm_rows,
+                    group=context.group,
+                )
+            _cp_debug_log(rank, "ag_hm_alloc_done direct_initial_state=1")
         else:
             ag_hm = _get_or_create_ag_hm_from_spec(
                 shape=ag_hm_shape,
@@ -901,7 +1021,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process_overlap(
     post_num_ranks = int(getattr(context, "post_num_ranks", 0) or 0)
     signal_target_peers = list(range(rank + 1, rank + post_num_ranks + 1)) if post_num_ranks > 0 else []
     allow_signal_mode = (not in_capture) or _cp_nvshmem_ready_wait_in_graph()
-    if not in_capture:
+    if not in_capture and comm_stream != torch.cuda.current_stream():
         comm_stream.wait_stream(torch.cuda.current_stream())
 
     with torch.cuda.stream(comm_stream):
@@ -963,6 +1083,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process_overlap(
                         allow_signal_mode=allow_signal_mode,
                         compact_out_layout=True,
                         fetch_last_dim=(V if predecessor_only else None),
+                        merge_remote_output=direct_remote_merge,
                     )
                     _cp_debug_log(rank, "comm_fetch_done")
         elif backend in {"auto", "nccl"}:
@@ -1007,14 +1128,14 @@ def chunk_gated_delta_rule_fwd_h_pre_process_overlap(
         assert ag_hm is not None
         merge_rank = pre_num_ranks if compact_ag_hm else rank
         if pre_num_ranks == 1:
-            if not direct_predecessor_state:
+            if not direct_initial_state:
                 source_idx = pre_num_ranks - 1 if compact_ag_hm else (rank - 1)
                 source = ag_hm[source_idx, :, :, :V]
                 if transpose_state_layout:
                     initial_state[0].copy_(source.transpose(-2, -1))
                 else:
                     initial_state[0].copy_(source)
-        else:
+        elif not direct_remote_merge:
             use_compiled_merge = (
                 _cp_merge_impl() == "compile"
                 and (not in_capture or _cp_merge_compile_in_graph())

--- a/cula/kda/cp_overlap.py
+++ b/cula/kda/cp_overlap.py
@@ -1151,6 +1151,7 @@ def chunk_gated_delta_rule_fwd_h_pre_process_overlap(
                 )
                 initial_state[0].copy_(merged)
             else:
+
                 def grid(meta):
                     return (triton.cdiv(V, meta["BV"]), HV)
 

--- a/cula/kda/cp_overlap.py
+++ b/cula/kda/cp_overlap.py
@@ -310,8 +310,11 @@ def _maybe_init_nvshmem(group) -> bool:
             dev = _CudaDevice(torch.cuda.current_device())
             dev.set_current()
             init_kwargs["device"] = dev
+        _cp_debug_log(rank, "nvshmem_init_enter")
         _nvshmem_core.init(**init_kwargs)
         _nvshmem_core.barrier_all(stream=ns)
+        current_stream.synchronize()
+        _cp_debug_log(rank, "nvshmem_init_done")
         _NVSHMEM_INIT_OK = True
     except Exception as exc:
         if _cp_allow_fallback():
@@ -336,7 +339,11 @@ def _get_or_create_nvshmem_cache(*, shape: tuple[int, ...], dtype: torch.dtype, 
     cached = _NVSHMEM_COMM_CACHE.get(key)
     if cached is not None:
         return cached
+    if _is_stream_capturing():
+        raise RuntimeError("CUDA graph capture requires NVSHMEM symmetric buffers to be allocated during warmup.")
     world_size = dist.get_world_size(group=group)
+    rank = dist.get_rank(group=group)
+    _cp_debug_log(rank, f"symmetric_cache_alloc_enter shape={shape} dtype={dtype}")
     sym0 = _nvshmem_core.tensor(tuple(shape), dtype=dtype)
     sym1 = _nvshmem_core.tensor(tuple(shape), dtype=dtype)
     peers0 = [_nvshmem_core.get_peer_tensor(sym0, peer_pe=peer) for peer in range(world_size)]
@@ -357,6 +364,11 @@ def _get_or_create_nvshmem_cache(*, shape: tuple[int, ...], dtype: torch.dtype, 
         )
     dummy_i32 = _nvshmem_core.tensor((1,), dtype=torch.int32)
     dummy_i32.zero_()
+    bootstrap_stream = torch.cuda.current_stream()
+    bootstrap_stream.synchronize()
+    _nvshmem_core.barrier_all(stream=_get_nvshmem_stream(bootstrap_stream))
+    bootstrap_stream.synchronize()
+    _cp_debug_log(rank, "symmetric_cache_alloc_done")
     state = {
         "step": 0,
         "epoch": [0, 0],
@@ -889,6 +901,8 @@ def chunk_gated_delta_rule_fwd_h_pre_process_overlap(
     post_num_ranks = int(getattr(context, "post_num_ranks", 0) or 0)
     signal_target_peers = list(range(rank + 1, rank + post_num_ranks + 1)) if post_num_ranks > 0 else []
     allow_signal_mode = (not in_capture) or _cp_nvshmem_ready_wait_in_graph()
+    if not in_capture:
+        comm_stream.wait_stream(torch.cuda.current_stream())
 
     with torch.cuda.stream(comm_stream):
         if comm_start is not None:

--- a/cula/kda/cp_overlap.py
+++ b/cula/kda/cp_overlap.py
@@ -1,0 +1,1048 @@
+# Copyright 2025-2026 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+import warnings
+
+import torch
+import torch.distributed as dist
+import triton
+from fla.ops.cp.chunk_delta_h import (
+    chunk_gated_delta_rule_fwd_h_pre_process as _fla_chunk_gated_delta_rule_fwd_h_pre_process,
+)
+
+try:
+    import nvshmem.core as _nvshmem_core
+except ImportError:
+    _nvshmem_core = None
+
+try:
+    from nvshmem.core import rma as _nvshmem_rma
+except ImportError:
+    _nvshmem_rma = None
+
+try:
+    from nvshmem.core.direct import ComparisonType as _NVSHMEM_CMP_TYPE
+except ImportError:
+    _NVSHMEM_CMP_TYPE = None
+
+try:
+    from nvshmem.core.direct import SignalOp as _NVSHMEM_SIGNAL_OP
+except ImportError:
+    _NVSHMEM_SIGNAL_OP = None
+
+try:
+    from nvshmem.core.interop.torch import tensor_get_buffer as _nvshmem_tensor_get_buffer
+except ImportError:
+    _nvshmem_tensor_get_buffer = None
+
+try:
+    from cuda.core.experimental import Device as _CudaDevice
+except ImportError:
+    _CudaDevice = None
+
+
+_NVSHMEM_INIT_ATTEMPTED = False
+_NVSHMEM_INIT_OK = False
+_COMM_STREAMS: dict[int, torch.cuda.Stream] = {}
+_COMM_EVENTS: dict[int, torch.cuda.Event] = {}
+_NVSHMEM_STREAMS: dict[int, object] = {}
+_NVSHMEM_COMM_CACHE: dict[tuple[int, int, tuple[int, ...], torch.dtype], dict[str, object]] = {}
+_AG_HM_CACHE: dict[tuple[int, int, tuple[int, ...], torch.dtype], torch.Tensor] = {}
+_COMPILED_MERGE_CACHE: dict[tuple[int, int, int, int], object] = {}
+_CP_TELEMETRY: dict[str, float | int] = {"comm_ms": 0.0, "merge_ms": 0.0, "calls": 0}
+_CP_DEBUG_LOG_COUNT = 0
+_DIRECT_STORE_CONN_GUARD_WARNED = False
+_READY_WAIT_CONN_GUARD_WARNED = False
+
+
+def _cp_comm_stream_priority() -> int:
+    v = os.getenv("CULA_CP_COMM_STREAM_PRIORITY", "-1").strip()
+    try:
+        return int(v)
+    except Exception:
+        return -1
+
+
+def _get_comm_stream(device: torch.device) -> torch.cuda.Stream:
+    idx = device.index if device.index is not None else torch.cuda.current_device()
+    stream = _COMM_STREAMS.get(idx)
+    if stream is None:
+        stream = torch.cuda.Stream(device=idx, priority=_cp_comm_stream_priority())
+        _COMM_STREAMS[idx] = stream
+    return stream
+
+
+def _get_comm_event(device: torch.device) -> torch.cuda.Event:
+    idx = device.index if device.index is not None else torch.cuda.current_device()
+    ev = _COMM_EVENTS.get(idx)
+    if ev is None:
+        ev = torch.cuda.Event()
+        _COMM_EVENTS[idx] = ev
+    return ev
+
+
+def _is_stream_capturing() -> bool:
+    try:
+        return torch.cuda.is_current_stream_capturing()
+    except Exception:
+        return False
+
+
+def _cp_overlap_enabled() -> bool:
+    return os.getenv("CULA_CP_OVERLAP", "0").lower() not in {"0", "false", "off", "no"}
+
+
+def _cp_comm_backend() -> str:
+    return os.getenv("CULA_CP_COMM_BACKEND", "auto").lower()
+
+
+def _cp_allow_fallback() -> bool:
+    return os.getenv("CULA_CP_ALLOW_FALLBACK", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_post_barrier() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_POST_BARRIER", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_pre_barrier() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_PRE_BARRIER", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_collective() -> str:
+    return os.getenv("CULA_CP_NVSHMEM_COLLECTIVE", "peer").lower()
+
+
+def _cp_nvshmem_quiet() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_QUIET", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_direct_store() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_DIRECT_STORE", "1").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_direct_store_conn1_only() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_DIRECT_STORE_CONN1_ONLY", "1").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_device_max_connections() -> int:
+    v = os.getenv("CUDA_DEVICE_MAX_CONNECTIONS", "1").strip()
+    try:
+        return int(v)
+    except Exception:
+        return 1
+
+
+def _cp_nvshmem_nongraph_require_conn1() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_NONGRAPH_REQUIRE_CONN1", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_allow_ready_wait_conn_gt1() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_ALLOW_READY_WAIT_CONN_GT1", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_enforce_visibility() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_ENFORCE_VISIBILITY", "1").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_ready_wait() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_READY_WAIT", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_ready_signal_quiet() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_READY_SIGNAL_QUIET", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_ready_wait_in_graph() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_READY_WAIT_IN_GRAPH", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_ready_wait_poll() -> bool:
+    return os.getenv("CULA_CP_NVSHMEM_READY_WAIT_POLL", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_nvshmem_ready_wait_timeout_ms() -> int:
+    v = os.getenv("CULA_CP_NVSHMEM_READY_WAIT_TIMEOUT_MS", "0").strip()
+    try:
+        n = int(v)
+    except Exception:
+        return 0
+    return max(0, n)
+
+
+def _cp_merge_impl() -> str:
+    return os.getenv("CULA_CP_MERGE_IMPL", "triton").lower()
+
+
+def _cp_merge_compile_mode() -> str:
+    return os.getenv("CULA_CP_MERGE_COMPILE_MODE", "max-autotune")
+
+
+def _cp_merge_compile_in_graph() -> bool:
+    return os.getenv("CULA_CP_MERGE_COMPILE_IN_GRAPH", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_direct_pred_fetch_enabled() -> bool:
+    return os.getenv("CULA_CP_DIRECT_PRED_FETCH", "1").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_direct_pred_fetch_in_graph() -> bool:
+    return os.getenv("CULA_CP_DIRECT_PRED_FETCH_IN_GRAPH", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_telemetry_enabled() -> bool:
+    return os.getenv("CULA_CP_TELEMETRY", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_debug_enabled() -> bool:
+    return os.getenv("CULA_CP_DEBUG", "0").lower() in {"1", "true", "on", "yes"}
+
+
+def _cp_debug_max_logs() -> int:
+    v = os.getenv("CULA_CP_DEBUG_MAX_LOGS", "64").strip()
+    try:
+        n = int(v)
+    except Exception:
+        return 64
+    return max(1, n)
+
+
+def _cp_debug_log(rank: int, msg: str) -> None:
+    global _CP_DEBUG_LOG_COUNT
+    if not _cp_debug_enabled():
+        return
+    if _cp_debug_max_logs() <= _CP_DEBUG_LOG_COUNT:
+        return
+    print(f"[cpdbg][rank{rank}] {msg}", flush=True)
+    _CP_DEBUG_LOG_COUNT += 1
+
+
+def reset_cp_overlap_telemetry() -> None:
+    _CP_TELEMETRY["comm_ms"] = 0.0
+    _CP_TELEMETRY["merge_ms"] = 0.0
+    _CP_TELEMETRY["calls"] = 0
+
+
+def get_cp_overlap_telemetry() -> dict[str, float | int]:
+    return {
+        "comm_ms": float(_CP_TELEMETRY["comm_ms"]),
+        "merge_ms": float(_CP_TELEMETRY["merge_ms"]),
+        "calls": int(_CP_TELEMETRY["calls"]),
+    }
+
+
+def _nvshmem_requires_implicit_visibility_barrier() -> bool:
+    if _cp_nvshmem_ready_wait():
+        return False
+    if not _cp_nvshmem_enforce_visibility():
+        return False
+    if _cp_allow_fallback():
+        return False
+    if _cp_comm_backend() != "nvshmem":
+        return False
+    return (not _cp_nvshmem_pre_barrier()) and (not _cp_nvshmem_post_barrier())
+
+
+def _nvshmem_should_do_visibility_barrier(*, use_signal_mode: bool) -> bool:
+    if _cp_nvshmem_pre_barrier():
+        return True
+    if _nvshmem_requires_implicit_visibility_barrier():
+        return True
+    # Ready/wait requested but disabled in this path (e.g. graph-safe mode):
+    # fall back to strict implicit visibility barrier policy.
+    if use_signal_mode:
+        return False
+    if not _cp_nvshmem_enforce_visibility():
+        return False
+    if _cp_allow_fallback():
+        return False
+    if _cp_comm_backend() != "nvshmem":
+        return False
+    return (not _cp_nvshmem_pre_barrier()) and (not _cp_nvshmem_post_barrier())
+
+
+def _nvshmem_can_init(group) -> bool:
+    if _nvshmem_core is None:
+        return False
+    try:
+        return dist.get_world_size(group=group) == dist.get_world_size() and dist.get_rank(group=group) == dist.get_rank()
+    except Exception:
+        return False
+
+
+def _maybe_init_nvshmem(group) -> bool:
+    global _NVSHMEM_INIT_ATTEMPTED, _NVSHMEM_INIT_OK
+    if _NVSHMEM_INIT_OK:
+        return True
+    if _NVSHMEM_INIT_ATTEMPTED:
+        return False
+    _NVSHMEM_INIT_ATTEMPTED = True
+    if not _nvshmem_can_init(group):
+        return False
+
+    try:
+        current_stream = torch.cuda.current_stream()
+        ns = _get_nvshmem_stream(current_stream)
+        rank = dist.get_rank(group=group)
+        world_size = dist.get_world_size(group=group)
+        uid = _nvshmem_core.get_unique_id() if rank == 0 else None
+        uid_holder = [uid]
+        dist.broadcast_object_list(uid_holder, src=0, group=group)
+        init_kwargs = {
+            "uid": uid_holder[0],
+            "rank": rank,
+            "nranks": world_size,
+            "initializer_method": "uid",
+        }
+        if _CudaDevice is not None:
+            dev = _CudaDevice(torch.cuda.current_device())
+            dev.set_current()
+            init_kwargs["device"] = dev
+        _nvshmem_core.init(**init_kwargs)
+        _nvshmem_core.barrier_all(stream=ns)
+        _NVSHMEM_INIT_OK = True
+    except Exception as exc:
+        if _cp_allow_fallback():
+            warnings.warn(f"NVSHMEM init failed, fallback to NCCL all_gather path. reason: {exc}", stacklevel=2)
+        else:
+            raise RuntimeError(f"NVSHMEM init failed in strict mode: {exc}") from exc
+        _NVSHMEM_INIT_OK = False
+    return _NVSHMEM_INIT_OK
+
+
+def _get_nvshmem_stream(stream: torch.cuda.Stream):
+    idx = torch.cuda.current_device()
+    ns = _NVSHMEM_STREAMS.get(idx)
+    if ns is None or getattr(ns, "__cuda_stream__", None) != stream.cuda_stream:
+        ns = _nvshmem_core.NvshmemStream(stream)
+        _NVSHMEM_STREAMS[idx] = ns
+    return ns
+
+
+def _get_or_create_nvshmem_cache(*, shape: tuple[int, ...], dtype: torch.dtype, group):
+    key = (id(group), torch.cuda.current_device(), tuple(shape), dtype)
+    cached = _NVSHMEM_COMM_CACHE.get(key)
+    if cached is not None:
+        return cached
+    world_size = dist.get_world_size(group=group)
+    sym0 = _nvshmem_core.tensor(tuple(shape), dtype=dtype)
+    sym1 = _nvshmem_core.tensor(tuple(shape), dtype=dtype)
+    peers0 = [_nvshmem_core.get_peer_tensor(sym0, peer_pe=peer) for peer in range(world_size)]
+    peers1 = [_nvshmem_core.get_peer_tensor(sym1, peer_pe=peer) for peer in range(world_size)]
+    ready_tensors = None
+    ready_buffers = None
+    if _nvshmem_tensor_get_buffer is not None and _nvshmem_core is not None:
+        ready0 = [_nvshmem_core.tensor((1,), dtype=torch.int64) for _ in range(world_size)]
+        ready1 = [_nvshmem_core.tensor((1,), dtype=torch.int64) for _ in range(world_size)]
+        for t in ready0:
+            t.zero_()
+        for t in ready1:
+            t.zero_()
+        ready_tensors = (ready0, ready1)
+        ready_buffers = (
+            [_nvshmem_tensor_get_buffer(t)[0] for t in ready0],
+            [_nvshmem_tensor_get_buffer(t)[0] for t in ready1],
+        )
+    dummy_i32 = _nvshmem_core.tensor((1,), dtype=torch.int32)
+    dummy_i32.zero_()
+    state = {
+        "step": 0,
+        "epoch": [0, 0],
+        "sym": (sym0, sym1),
+        "peers": (peers0, peers1),
+        "ready_tensors": ready_tensors,
+        "ready_buffers": ready_buffers,
+        "dummy_i32": dummy_i32,
+    }
+    _NVSHMEM_COMM_CACHE[key] = state
+    return state
+
+
+def _get_or_create_ag_hm(hm: torch.Tensor, num_rows: int, group):
+    key = (id(group), torch.cuda.current_device(), tuple(hm.shape), hm.dtype, int(num_rows))
+    out = _AG_HM_CACHE.get(key)
+    if out is None:
+        out = torch.empty(int(num_rows), *hm.shape, device=hm.device, dtype=hm.dtype)
+        _AG_HM_CACHE[key] = out
+    return out
+
+
+def _get_or_create_ag_hm_from_spec(*, shape: tuple[int, ...], dtype: torch.dtype, num_rows: int, group):
+    key = (id(group), torch.cuda.current_device(), tuple(shape), dtype, int(num_rows))
+    out = _AG_HM_CACHE.get(key)
+    if out is None:
+        out = torch.empty(int(num_rows), *shape, device=torch.device("cuda"), dtype=dtype)
+        _AG_HM_CACHE[key] = out
+    return out
+
+
+def _ag_hm_cache_key(hm: torch.Tensor, group, num_rows: int):
+    return (id(group), torch.cuda.current_device(), tuple(hm.shape), hm.dtype, int(num_rows))
+
+
+def _ag_hm_cache_key_from_spec(*, shape: tuple[int, ...], dtype: torch.dtype, group, num_rows: int):
+    return (id(group), torch.cuda.current_device(), tuple(shape), dtype, int(num_rows))
+
+
+def _nvshmem_cache_key(inp: torch.Tensor, group):
+    return (id(group), torch.cuda.current_device(), tuple(inp.shape), inp.dtype)
+
+
+def _nvshmem_cache_key_from_spec(*, shape: tuple[int, ...], dtype: torch.dtype, group):
+    return (id(group), torch.cuda.current_device(), tuple(shape), dtype)
+
+
+def _reserve_nvshmem_slot(*, shape: tuple[int, ...], dtype: torch.dtype, group):
+    state = _get_or_create_nvshmem_cache(shape=shape, dtype=dtype, group=group)
+    slot = int(state["step"]) & 1
+    state["step"] = int(state["step"]) + 1
+    state["epoch"][slot] = int(state["epoch"][slot]) + 1
+    return slot, state["sym"][slot], int(state["epoch"][slot])
+
+
+def _nvshmem_signal_api_ready(state: dict[str, object]) -> bool:
+    return (
+        _nvshmem_rma is not None
+        and _NVSHMEM_CMP_TYPE is not None
+        and _NVSHMEM_SIGNAL_OP is not None
+        and state.get("ready_buffers") is not None
+    )
+
+
+def _nvshmem_signal_mode_enabled(state: dict[str, object], *, allow_in_graph: bool) -> bool:
+    global _READY_WAIT_CONN_GUARD_WARNED
+    if not _cp_nvshmem_ready_wait():
+        return False
+    if not allow_in_graph:
+        return False
+    if (not _is_stream_capturing()) and _cp_device_max_connections() != 1 and (not _cp_nvshmem_allow_ready_wait_conn_gt1()):
+        if not _READY_WAIT_CONN_GUARD_WARNED:
+            warnings.warn(
+                "Disabling NVSHMEM ready-wait for CUDA_DEVICE_MAX_CONNECTIONS!=1 in non-graph mode "
+                "(set CULA_CP_NVSHMEM_ALLOW_READY_WAIT_CONN_GT1=1 to override).",
+                stacklevel=2,
+            )
+            _READY_WAIT_CONN_GUARD_WARNED = True
+        return False
+    if _nvshmem_signal_api_ready(state):
+        return True
+    if _cp_allow_fallback():
+        warnings.warn(
+            "CULA_CP_NVSHMEM_READY_WAIT=1 requested but signal API is unavailable; falling back to barrier/peer-copy path.",
+            stacklevel=2,
+        )
+        return False
+    raise RuntimeError(
+        "CULA_CP_NVSHMEM_READY_WAIT=1 requires nvshmem.core.rma + nvshmem.core.direct + tensor_get_buffer support."
+    )
+
+
+def _nvshmem_publish_ready_epoch(
+    *,
+    state: dict[str, object],
+    slot: int,
+    epoch: int,
+    rank: int,
+    world_size: int,
+    target_peers: list[int] | None,
+    stream,
+) -> None:
+    ready_buffers = state["ready_buffers"][slot]
+    dummy = state["dummy_i32"]
+    peers = list(range(world_size)) if target_peers is None else target_peers
+    for peer in peers:
+        if peer == rank:
+            continue
+        _nvshmem_rma.put_signal(
+            dummy,
+            dummy,
+            signal_var=ready_buffers[rank],
+            signal_val=epoch,
+            signal_op=_NVSHMEM_SIGNAL_OP.SIGNAL_SET,
+            remote_pe=peer,
+            stream=stream,
+        )
+
+
+def _nvshmem_wait_ready_epoch(
+    *,
+    state: dict[str, object],
+    slot: int,
+    epoch: int,
+    fetch_peers: list[int],
+    rank: int,
+    stream,
+) -> None:
+    timeout_ms = _cp_nvshmem_ready_wait_timeout_ms()
+    poll_mode = _cp_nvshmem_ready_wait_poll() or timeout_ms > 0
+    if poll_mode:
+        ready_tensors = state.get("ready_tensors")
+        if ready_tensors is None:
+            if _cp_allow_fallback():
+                warnings.warn(
+                    "CULA_CP_NVSHMEM_READY_WAIT_POLL requested but ready_tensors unavailable; using signal_wait.",
+                    stacklevel=2,
+                )
+            else:
+                raise RuntimeError(
+                    "CULA_CP_NVSHMEM_READY_WAIT_POLL requires ready_tensors support (nvshmem tensor_get_buffer)."
+                )
+        else:
+            ready_slot = ready_tensors[slot]
+            sleep_s = 1e-4
+            for peer in fetch_peers:
+                if peer == rank:
+                    continue
+                _cp_debug_log(rank, f"wait_ready_poll_enter peer={peer} slot={slot} epoch={epoch}")
+                deadline = None if timeout_ms <= 0 else (time.monotonic() + (float(timeout_ms) / 1000.0))
+                while True:
+                    observed = int(ready_slot[peer].item())
+                    if observed >= epoch:
+                        _cp_debug_log(rank, f"wait_ready_poll_done peer={peer} slot={slot} epoch={epoch} observed={observed}")
+                        break
+                    if deadline is not None and time.monotonic() >= deadline:
+                        raise RuntimeError(
+                            "NVSHMEM ready-wait timeout: "
+                            f"peer={peer}, slot={slot}, observed={observed}, required_epoch={epoch}, timeout_ms={timeout_ms}"
+                        )
+                    time.sleep(sleep_s)
+            return
+    ready_buffers = state["ready_buffers"][slot]
+    cmp_op = _NVSHMEM_CMP_TYPE.CMP_GE if hasattr(_NVSHMEM_CMP_TYPE, "CMP_GE") else _NVSHMEM_CMP_TYPE.CMP_EQ
+    for peer in fetch_peers:
+        if peer == rank:
+            continue
+        _cp_debug_log(rank, f"wait_ready_signal_enter peer={peer} slot={slot} epoch={epoch}")
+        _nvshmem_rma.signal_wait(
+            ready_buffers[peer],
+            epoch,
+            cmp_op,
+            stream=stream,
+        )
+        _cp_debug_log(rank, f"wait_ready_signal_done peer={peer} slot={slot} epoch={epoch}")
+
+
+def _nvshmem_all_gather_into_tensor(
+    inp: torch.Tensor,
+    out: torch.Tensor | None,
+    group,
+    stream: torch.cuda.Stream,
+    fetch_peers: list[int] | None = None,
+    signal_target_peers: list[int] | None = None,
+    reserved_slot: int | None = None,
+    reserved_epoch: int | None = None,
+    input_in_symmetric: bool = False,
+    allow_signal_mode: bool = True,
+    compact_out_layout: bool = False,
+    fetch_last_dim: int | None = None,
+) -> None:
+    world_size = dist.get_world_size(group=group)
+    rank = dist.get_rank(group=group)
+    if _cp_nvshmem_collective() == "fcollect":
+        raise RuntimeError(
+            "CULA_CP_NVSHMEM_COLLECTIVE=fcollect is not supported in this build; use CULA_CP_NVSHMEM_COLLECTIVE=peer"
+        )
+    if fetch_peers is None:
+        fetch_peers = list(range(world_size))
+
+    state = _get_or_create_nvshmem_cache(shape=tuple(inp.shape), dtype=inp.dtype, group=group)
+    if reserved_slot is None:
+        slot = int(state["step"]) & 1
+        state["step"] = int(state["step"]) + 1
+        state["epoch"][slot] = int(state["epoch"][slot]) + 1
+        epoch = int(state["epoch"][slot])
+    else:
+        slot = reserved_slot
+        epoch = int(state["epoch"][slot] if reserved_epoch is None else reserved_epoch)
+    sym = state["sym"][slot]
+    peers = state["peers"][slot]
+    use_signal_mode = _nvshmem_signal_mode_enabled(state, allow_in_graph=allow_signal_mode)
+    ns = _get_nvshmem_stream(stream)
+    if not input_in_symmetric:
+        sym.copy_(inp)
+    if use_signal_mode:
+        _cp_debug_log(rank, f"publish_ready slot={slot} epoch={epoch} targets={signal_target_peers}")
+        # Ensure producer writes are globally visible before signaling readiness.
+        _nvshmem_core.quiet(stream=ns)
+        _nvshmem_publish_ready_epoch(
+            state=state,
+            slot=slot,
+            epoch=epoch,
+            rank=rank,
+            world_size=world_size,
+            target_peers=signal_target_peers,
+            stream=ns,
+        )
+        if _cp_nvshmem_ready_signal_quiet():
+            _nvshmem_core.quiet(stream=ns)
+    if _nvshmem_should_do_visibility_barrier(use_signal_mode=use_signal_mode):
+        _cp_debug_log(rank, f"visibility_barrier_before_fetch slot={slot} epoch={epoch}")
+        _nvshmem_core.barrier_all(stream=ns)
+    if use_signal_mode:
+        _cp_debug_log(rank, f"wait_ready_begin slot={slot} epoch={epoch} fetch_peers={fetch_peers}")
+        _nvshmem_wait_ready_epoch(
+            state=state,
+            slot=slot,
+            epoch=epoch,
+            fetch_peers=fetch_peers,
+            rank=rank,
+            stream=ns,
+        )
+        _cp_debug_log(rank, f"wait_ready_end slot={slot} epoch={epoch} fetch_peers={fetch_peers}")
+    for fetch_idx, peer in enumerate(fetch_peers):
+        if out is None:
+            raise RuntimeError("out tensor must be provided when fetch_peers is non-empty.")
+        out_row = peer
+        if compact_out_layout:
+            out_row = fetch_idx
+        local_src = inp
+        peer_src = peers[peer]
+        if fetch_last_dim is not None:
+            local_src = local_src[..., :fetch_last_dim]
+            peer_src = peer_src[..., :fetch_last_dim]
+        if peer == rank:
+            out[out_row].copy_(local_src, non_blocking=True)
+        else:
+            out[out_row].copy_(peer_src, non_blocking=True)
+    if _cp_nvshmem_quiet():
+        _nvshmem_core.quiet(stream=ns)
+    if _cp_nvshmem_post_barrier():
+        _nvshmem_core.barrier_all(stream=ns)
+
+
+def _nvshmem_publish_only(
+    inp: torch.Tensor,
+    group,
+    stream: torch.cuda.Stream,
+    signal_target_peers: list[int] | None = None,
+    reserved_slot: int | None = None,
+    reserved_epoch: int | None = None,
+    input_in_symmetric: bool = False,
+    allow_signal_mode: bool = True,
+) -> None:
+    state = _get_or_create_nvshmem_cache(shape=tuple(inp.shape), dtype=inp.dtype, group=group)
+    world_size = dist.get_world_size(group=group)
+    rank = dist.get_rank(group=group)
+    if reserved_slot is None:
+        slot = int(state["step"]) & 1
+        state["step"] = int(state["step"]) + 1
+        state["epoch"][slot] = int(state["epoch"][slot]) + 1
+        epoch = int(state["epoch"][slot])
+    else:
+        slot = reserved_slot
+        epoch = int(state["epoch"][slot] if reserved_epoch is None else reserved_epoch)
+    sym = state["sym"][slot]
+    use_signal_mode = _nvshmem_signal_mode_enabled(state, allow_in_graph=allow_signal_mode)
+    ns = _get_nvshmem_stream(stream)
+    if not input_in_symmetric:
+        sym.copy_(inp)
+    if use_signal_mode:
+        _cp_debug_log(rank, f"publish_only_ready slot={slot} epoch={epoch} targets={signal_target_peers}")
+        # Ensure producer writes are globally visible before signaling readiness.
+        _nvshmem_core.quiet(stream=ns)
+        _nvshmem_publish_ready_epoch(
+            state=state,
+            slot=slot,
+            epoch=epoch,
+            rank=rank,
+            world_size=world_size,
+            target_peers=signal_target_peers,
+            stream=ns,
+        )
+        if _cp_nvshmem_ready_signal_quiet():
+            _nvshmem_core.quiet(stream=ns)
+    if _nvshmem_should_do_visibility_barrier(use_signal_mode=use_signal_mode):
+        _cp_debug_log(rank, f"publish_only_visibility_barrier slot={slot} epoch={epoch}")
+        _nvshmem_core.barrier_all(stream=ns)
+    if _cp_nvshmem_quiet():
+        _nvshmem_core.quiet(stream=ns)
+    if _cp_nvshmem_post_barrier():
+        _nvshmem_core.barrier_all(stream=ns)
+
+
+def _get_compiled_merge_fn(*, num_ranks: int, h_dim: int, k_dim: int, v_dim: int):
+    compile_mode = _cp_merge_compile_mode()
+    key = (num_ranks, h_dim, k_dim, v_dim, torch.cuda.current_device(), compile_mode)
+    fn = _COMPILED_MERGE_CACHE.get(key)
+    if fn is not None:
+        return fn
+
+    def _merge_impl(ag_hm_local: torch.Tensor):
+        _, h_dim_local, _, vk_dim = ag_hm_local.shape
+        v_local = vk_dim - k_dim
+        h_state = torch.zeros(h_dim_local, k_dim, v_local, device=ag_hm_local.device, dtype=torch.float32)
+        for ridx in range(num_ranks):
+            he_local = ag_hm_local[ridx, :, :, :v_local]
+            m_local = ag_hm_local[ridx, :, :, v_local:]
+            h_state = torch.matmul(m_local, h_state) + he_local
+        return h_state
+
+    compiled = torch.compile(_merge_impl, fullgraph=True, mode=compile_mode)
+    _COMPILED_MERGE_CACHE[key] = compiled
+    return compiled
+
+
+def _merge_recurrence_compiled(ag_hm: torch.Tensor, *, rank: int, pre_num_ranks: int) -> torch.Tensor:
+    start = rank - int(pre_num_ranks)
+    end = rank
+    ag_local = ag_hm[start:end]
+    num_ranks, h_dim, k_dim, vk_dim = ag_local.shape
+    v_dim = vk_dim - k_dim
+    fn = _get_compiled_merge_fn(num_ranks=num_ranks, h_dim=h_dim, k_dim=k_dim, v_dim=v_dim)
+    return fn(ag_local)
+
+
+def chunk_gated_delta_rule_fwd_h_pre_process_overlap(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    bg: torch.Tensor | None = None,
+    v: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    cu_seqlens: torch.LongTensor | None = None,
+    use_exp2: bool = False,
+    initial_state: torch.Tensor | None = None,
+    context=None,
+    transpose_state_layout: bool = False,
+):
+    global _DIRECT_STORE_CONN_GUARD_WARNED
+    if context is None or context.group is None or not _cp_overlap_enabled():
+        return _fla_chunk_gated_delta_rule_fwd_h_pre_process(
+            k=k,
+            w=w,
+            u=u,
+            g=g,
+            gk=gk,
+            bg=bg,
+            v=v,
+            chunk_size=chunk_size,
+            cu_seqlens=cu_seqlens,
+            use_exp2=use_exp2,
+            initial_state=initial_state,
+            context=context,
+            transpose_state_layout=transpose_state_layout,
+        )
+
+    assert initial_state is None, "When enable CP, the provided initial_state must be None."
+    from fla.ops.cp import chunk_delta_h as cp_chunk_delta_h
+
+    rank = dist.get_rank(group=context.group)
+    world_size = dist.get_world_size(group=context.group)
+    pre_num_ranks = int(getattr(context, "pre_num_ranks", 0) or 0)
+    _, T, H, K = k.shape
+    HV, V = u.shape[2:]
+    _cp_debug_log(rank, f"overlap_enter T={T} H={H} HV={HV} K={K} V={V} pre={pre_num_ranks} world={world_size}")
+    BT = chunk_size
+    BK = triton.next_power_of_2(K)
+    if cu_seqlens is None:
+        N = k.shape[0]
+    else:
+        N = len(cu_seqlens) - 1
+    assert K <= 256, "current kernel does not support head dimension larger than 256."
+
+    hm_shape = (HV, K, (V + K))
+    hm_dtype = torch.float32
+    predecessor_only = bool((not context.is_first_rank) and pre_num_ranks == 1)
+    in_capture = _is_stream_capturing()
+    backend = _cp_comm_backend()
+    use_nvshmem = backend == "nvshmem" or (backend == "auto" and _nvshmem_core is not None)
+    if use_nvshmem and (not in_capture) and _cp_nvshmem_nongraph_require_conn1() and _cp_device_max_connections() != 1:
+        raise RuntimeError(
+            "Non-graph NVSHMEM CP path requires CUDA_DEVICE_MAX_CONNECTIONS=1 for stability in this build. "
+            "Set CULA_CP_NVSHMEM_NONGRAPH_REQUIRE_CONN1=0 to override at your own risk."
+        )
+    ag_hm_shape = (HV, K, V) if (use_nvshmem and predecessor_only) else hm_shape
+    direct_store = False
+    reserved_slot = None
+    reserved_epoch = None
+    direct_store_allowed = True
+    if _cp_nvshmem_direct_store_conn1_only() and (not in_capture) and _cp_device_max_connections() != 1:
+        direct_store_allowed = False
+    if use_nvshmem and _cp_nvshmem_direct_store() and direct_store_allowed:
+        init_ok = _NVSHMEM_INIT_OK or (not in_capture and _maybe_init_nvshmem(context.group))
+        if init_ok:
+            reserved_slot, hm, reserved_epoch = _reserve_nvshmem_slot(shape=hm_shape, dtype=hm_dtype, group=context.group)
+            direct_store = True
+            _cp_debug_log(rank, f"reserve_slot_ok slot={reserved_slot} epoch={reserved_epoch} direct_store=1")
+        else:
+            hm = k.new_zeros(*hm_shape, dtype=hm_dtype)
+            _cp_debug_log(rank, "reserve_slot_init_not_ok direct_store=0")
+    else:
+        hm = k.new_zeros(*hm_shape, dtype=hm_dtype)
+        if use_nvshmem and _cp_nvshmem_direct_store() and (not direct_store_allowed) and (not _DIRECT_STORE_CONN_GUARD_WARNED):
+            warnings.warn(
+                "Disabling NVSHMEM direct_store because CUDA_DEVICE_MAX_CONNECTIONS!=1 in non-graph mode "
+                "(set CULA_CP_NVSHMEM_DIRECT_STORE_CONN1_ONLY=0 to override).",
+                stacklevel=2,
+            )
+            _DIRECT_STORE_CONN_GUARD_WARNED = True
+        _cp_debug_log(
+            rank,
+            f"reserve_slot_bypass use_nvshmem={use_nvshmem} direct_store={direct_store} "
+            f"direct_store_allowed={direct_store_allowed}",
+        )
+    if not context.is_last_rank:
+        _cp_debug_log(rank, "preprocess_kernel_enter")
+        block_size = 32 if K <= 64 else 64
+        grid = (triton.cdiv(V, block_size) + triton.cdiv(K, block_size), HV)
+        cp_chunk_delta_h.pre_process_fwd_kernel_merged[grid](
+            k=k,
+            v=u if v is None else v,
+            w=w,
+            g=g,
+            gk=gk,
+            bg=bg,
+            u=u,
+            hm=hm,
+            cu_seqlens=cu_seqlens[-2:],
+            T=T,
+            H=H,
+            HV=HV,
+            K=K,
+            V=V,
+            BT=BT,
+            BK1=BK,
+            USE_EXP2=use_exp2,
+            BLOCK_SIZE=block_size,
+            MULTI_SEQS=False,
+        )
+        _cp_debug_log(rank, "preprocess_kernel_done")
+
+    compact_ag_hm = bool(use_nvshmem and (not context.is_first_rank))
+    ag_hm_rows = pre_num_ranks if compact_ag_hm else world_size
+    ag_hm_key = _ag_hm_cache_key_from_spec(shape=ag_hm_shape, dtype=hm_dtype, group=context.group, num_rows=ag_hm_rows)
+    if in_capture:
+        if (not context.is_first_rank) and ag_hm_key not in _AG_HM_CACHE:
+            raise RuntimeError(
+                "CUDA graph capture requires warmup before capture (missing ag_hm cache for this shape/device)."
+            )
+        if use_nvshmem:
+            if not _NVSHMEM_INIT_OK:
+                raise RuntimeError("CUDA graph capture requires NVSHMEM to be initialized before capture.")
+            if _nvshmem_cache_key_from_spec(shape=hm_shape, dtype=hm_dtype, group=context.group) not in _NVSHMEM_COMM_CACHE:
+                raise RuntimeError(
+                    "CUDA graph capture requires warmup before capture (missing NVSHMEM comm cache for this shape/device)."
+                )
+        # CUDA Graph capture-safe path: keep communication on the capturing stream.
+        comm_stream = torch.cuda.current_stream()
+        comm_event = None
+    else:
+        comm_stream = _get_comm_stream(hm.device)
+        comm_event = _get_comm_event(hm.device)
+    direct_predecessor_state = bool(
+        _cp_direct_pred_fetch_enabled()
+        and use_nvshmem
+        and predecessor_only
+        and (not transpose_state_layout)
+        and (N == 1)
+        and ((not in_capture) or _cp_direct_pred_fetch_in_graph())
+        and (not context.is_first_rank)
+    )
+
+    initial_state = None
+    ag_hm = None
+    telemetry_enabled = _cp_telemetry_enabled() and (not in_capture)
+    comm_start = None
+    comm_end = None
+    if telemetry_enabled:
+        comm_start = torch.cuda.Event(enable_timing=True)
+        comm_end = torch.cuda.Event(enable_timing=True)
+    merge_ms = 0.0
+    if not context.is_first_rank:
+        _cp_debug_log(rank, f"ag_hm_alloc_enter direct_pred_state={direct_predecessor_state}")
+        if direct_predecessor_state:
+            # Fetch predecessor V-state directly into final output buffer (N=1),
+            # avoiding an extra staging tensor and post-comm copy.
+            initial_state = k.new_empty(N, HV, K, V, dtype=torch.float32)
+            ag_hm = initial_state
+            # Keep capture-time cache guard satisfied by materializing the
+            # compact receive cache during warmup.
+            _get_or_create_ag_hm_from_spec(
+                shape=ag_hm_shape,
+                dtype=hm_dtype,
+                num_rows=ag_hm_rows,
+                group=context.group,
+            )
+            _cp_debug_log(rank, "ag_hm_alloc_done direct_pred_state=1")
+        else:
+            ag_hm = _get_or_create_ag_hm_from_spec(
+                shape=ag_hm_shape,
+                dtype=hm_dtype,
+                num_rows=ag_hm_rows,
+                group=context.group,
+            )
+            _cp_debug_log(rank, "ag_hm_alloc_done direct_pred_state=0")
+    post_num_ranks = int(getattr(context, "post_num_ranks", 0) or 0)
+    signal_target_peers = list(range(rank + 1, rank + post_num_ranks + 1)) if post_num_ranks > 0 else []
+    allow_signal_mode = (not in_capture) or _cp_nvshmem_ready_wait_in_graph()
+
+    with torch.cuda.stream(comm_stream):
+        if comm_start is not None:
+            comm_start.record(comm_stream)
+        _cp_debug_log(
+            rank,
+            (
+                f"comm_begin in_capture={in_capture} use_nvshmem={use_nvshmem} backend={backend} "
+                f"pre_num_ranks={pre_num_ranks} post_num_ranks={post_num_ranks} "
+                f"direct_store={direct_store} direct_pred_state={direct_predecessor_state}"
+            ),
+        )
+        if use_nvshmem:
+            if not _NVSHMEM_INIT_OK and not _maybe_init_nvshmem(context.group):
+                if backend == "nvshmem" and not _cp_allow_fallback():
+                    raise RuntimeError("NVSHMEM backend requested but initialization failed (strict mode).")
+                if ag_hm is None:
+                    raise RuntimeError("ag_hm is required for fallback gather path.")
+                if ag_hm.shape[0] == world_size:
+                    work = dist.all_gather_into_tensor(ag_hm, hm, group=context.group, async_op=True)
+                    work.wait()
+                else:
+                    ag_hm_world = _get_or_create_ag_hm(hm=hm, num_rows=world_size, group=context.group)
+                    work = dist.all_gather_into_tensor(ag_hm_world, hm, group=context.group, async_op=True)
+                    work.wait()
+                    start = rank - pre_num_ranks
+                    if predecessor_only:
+                        ag_hm.copy_(ag_hm_world[start:rank, :, :, :V], non_blocking=True)
+                    else:
+                        ag_hm.copy_(ag_hm_world[start:rank], non_blocking=True)
+            else:
+                if context.is_first_rank:
+                    _cp_debug_log(rank, "comm_publish_only_enter")
+                    _nvshmem_publish_only(
+                        hm,
+                        group=context.group,
+                        stream=comm_stream,
+                        signal_target_peers=signal_target_peers,
+                        reserved_slot=reserved_slot,
+                        reserved_epoch=reserved_epoch,
+                        input_in_symmetric=direct_store,
+                        allow_signal_mode=allow_signal_mode,
+                    )
+                    _cp_debug_log(rank, "comm_publish_only_done")
+                else:
+                    fetch_peers = list(range(rank - pre_num_ranks, rank))
+                    _cp_debug_log(rank, f"comm_fetch_enter fetch_peers={fetch_peers}")
+                    _nvshmem_all_gather_into_tensor(
+                        hm,
+                        ag_hm,
+                        group=context.group,
+                        stream=comm_stream,
+                        fetch_peers=fetch_peers,
+                        signal_target_peers=signal_target_peers,
+                        reserved_slot=reserved_slot,
+                        reserved_epoch=reserved_epoch,
+                        input_in_symmetric=direct_store,
+                        allow_signal_mode=allow_signal_mode,
+                        compact_out_layout=True,
+                        fetch_last_dim=(V if predecessor_only else None),
+                    )
+                    _cp_debug_log(rank, "comm_fetch_done")
+        elif backend in {"auto", "nccl"}:
+            # all_gather is collective: every rank must participate.
+            gather_dst = ag_hm
+            if gather_dst is None:
+                gather_dst = _get_or_create_ag_hm(hm=hm, num_rows=world_size, group=context.group)
+            if in_capture:
+                # Graph capture path: avoid async handle + host wait inside capture.
+                dist.all_gather_into_tensor(gather_dst, hm, group=context.group)
+            else:
+                work = dist.all_gather_into_tensor(gather_dst, hm, group=context.group, async_op=True)
+                work.wait()
+        else:
+            raise ValueError(f"Unsupported CULA_CP_COMM_BACKEND={backend}")
+        if comm_event is not None:
+            comm_event.record(comm_stream)
+        if comm_end is not None:
+            comm_end.record(comm_stream)
+        _cp_debug_log(rank, "comm_end")
+    if comm_event is not None and (not context.is_first_rank):
+        torch.cuda.current_stream().wait_event(comm_event)
+
+    comm_ms = 0.0
+    if telemetry_enabled and comm_start is not None and comm_end is not None:
+        comm_end.synchronize()
+        comm_ms = float(comm_start.elapsed_time(comm_end))
+
+    if initial_state is None:
+        if transpose_state_layout:
+            initial_state = k.new_zeros(N, HV, V, K, dtype=torch.float32)
+        else:
+            initial_state = k.new_zeros(N, HV, K, V, dtype=torch.float32)
+
+    if not context.is_first_rank:
+        merge_start = None
+        merge_end = None
+        if telemetry_enabled:
+            merge_start = torch.cuda.Event(enable_timing=True)
+            merge_end = torch.cuda.Event(enable_timing=True)
+            merge_start.record(torch.cuda.current_stream())
+        assert ag_hm is not None
+        merge_rank = pre_num_ranks if compact_ag_hm else rank
+        if pre_num_ranks == 1:
+            if not direct_predecessor_state:
+                source_idx = pre_num_ranks - 1 if compact_ag_hm else (rank - 1)
+                source = ag_hm[source_idx, :, :, :V]
+                if transpose_state_layout:
+                    initial_state[0].copy_(source.transpose(-2, -1))
+                else:
+                    initial_state[0].copy_(source)
+        else:
+            use_compiled_merge = (
+                _cp_merge_impl() == "compile"
+                and (not in_capture or _cp_merge_compile_in_graph())
+                and not transpose_state_layout
+                and ag_hm.dtype == torch.float32
+                and pre_num_ranks > 1
+            )
+            if use_compiled_merge:
+                merged = _merge_recurrence_compiled(
+                    ag_hm,
+                    rank=merge_rank,
+                    pre_num_ranks=pre_num_ranks,
+                )
+                initial_state[0].copy_(merged)
+            else:
+                def grid(meta):
+                    return (triton.cdiv(V, meta["BV"]), HV)
+
+                cp_chunk_delta_h.merge_fwd_bwd_kernel[grid](
+                    h=initial_state[0],
+                    ag_hm=ag_hm,
+                    pre_or_post_num_ranks=pre_num_ranks,
+                    rank=merge_rank,
+                    seq_offsets=None,
+                    init_offsets=None,
+                    h0_seq_ids=None,
+                    h0=None,
+                    HV=HV,
+                    K=K,
+                    V=V,
+                    BK=BK,
+                    FORWARD=True,
+                    INTRACARD_MODE=False,
+                    NUM_SEQ_ENTRIES=0,
+                    TRANSPOSE_STATE=transpose_state_layout,
+                )
+        if telemetry_enabled and merge_start is not None and merge_end is not None:
+            merge_end.record(torch.cuda.current_stream())
+            merge_end.synchronize()
+            merge_ms = float(merge_start.elapsed_time(merge_end))
+    if telemetry_enabled:
+        _CP_TELEMETRY["comm_ms"] = float(_CP_TELEMETRY["comm_ms"]) + comm_ms
+        _CP_TELEMETRY["merge_ms"] = float(_CP_TELEMETRY["merge_ms"]) + merge_ms
+        _CP_TELEMETRY["calls"] = int(_CP_TELEMETRY["calls"]) + 1
+    return initial_state

--- a/docs/cp_overlap/nvshmem_cp4_optimized_2026-07-22.md
+++ b/docs/cp_overlap/nvshmem_cp4_optimized_2026-07-22.md
@@ -1,0 +1,77 @@
+# NVSHMEM CP=4 optimized state assembly
+
+## Goals and status
+
+This follow-up starts from the stable world-size-four NVSHMEM bootstrap in commit `59a245e` and targets the CP preprocessing boundary used by cuLA KDA.
+
+| Goal | Status |
+| :--- | :--- |
+| Exact forward and backward agreement with FLA CP | Pass |
+| Stable across fresh four-process launches | Pass |
+| Faster than FLA CP preprocessing by rank-max median | Pass |
+| At least 20% faster | Not met |
+| Integrated Megatron production result | Out of scope for this cuLA experiment |
+
+The result is an opt-in CP=4 research path. It is not evidence for the full Megatron training iteration or the 256K production shape.
+
+## Retained design
+
+The winning eager-mode path makes four changes:
+
+1. Each rank writes its local affine recurrence state directly into NVSHMEM symmetric memory.
+2. A single NVSHMEM barrier establishes publication and visibility before peer reads.
+3. Ranks with multiple predecessors read the remote symmetric states directly and fuse the recurrence assembly into one Triton kernel, eliminating peer-copy staging and a second local merge pass.
+4. Communication and merge run on the producer's current CUDA stream, avoiding the extra stream event handoff for this serialized boundary.
+
+The path is enabled with:
+
+```bash
+CUDA_DEVICE_MAX_CONNECTIONS=2
+CULA_CP_COMM_USE_CURRENT_STREAM=1
+CULA_CP_NVSHMEM_DIRECT_STORE_CONN1_ONLY=0
+CULA_CP_NVSHMEM_FUSED_REMOTE_MERGE=1
+CULA_CP_NVSHMEM_READY_WAIT=0
+```
+
+The optimized remote merge is restricted to eager execution, one global sequence, non-transposed state layout, and world size at most four. Other configurations retain the existing path.
+
+## Correctness
+
+Environment: one host with four NVIDIA GB200 GPUs, PyTorch `2.10.0+cu130`, CUDA 13.0, NVSHMEM 3.4.5, and CUTLASS DSL 4.4.2.
+
+The deterministic oracle compares the cuLA NVSHMEM result with FLA CP at the same output/backward boundary. It checks output and active Q/K/V/g/beta gradients.
+
+| World size | Global sequence | Heads | Fresh launches | Maximum absolute difference |
+| ---: | ---: | ---: | ---: | ---: |
+| 4 | 1,024 | 4 | 3/3 pass | 0.0 |
+| 4 | 4,096 | 8 | pass | 0.0 |
+| 4 | 8,192 | 16 | pass | 0.0 |
+
+The opt-in integration suite, which also includes a CP=2 regression, reports `3 passed`.
+
+## Performance
+
+Measurements use BF16, 20 warmups, 60 iterations, five in-process repeats, and the median of each repeat's rank-max iteration median. Backend order is rotated between shapes.
+
+| Shape | FLA CP preprocessing | NVSHMEM optimized | Improvement |
+| :--- | ---: | ---: | ---: |
+| `4096x8` | 0.6317 ms | 0.5680 ms | 10.08% |
+| `8192x16` | 0.6112 ms | 0.5662 ms | 7.36% |
+
+The optimization reverses the stable pre-optimization result, where NVSHMEM was 12.5-13.7% slower than FLA at these cells. It does not meet the 20% target. Further gains require reducing or fusing the local preprocessing kernel, because transport and state assembly no longer account for enough of the end-to-end boundary.
+
+## Rejected experiments
+
+- Chained predecessor publication serialized the CP ranks and regressed both cells.
+- Per-peer ready signals were correct but slower than the collective barrier on this one-host topology.
+- Connection counts three and four were slower than two.
+- Eight-warp remote-merge candidates regressed the 8192x16 cell.
+- A CUDA Graph comparison did not produce a valid FLA baseline and is not included.
+
+## Reproduction
+
+```bash
+benchmarks/run_cp4_nvshmem_optimized.sh
+```
+
+Set `PYTHON` if the repository virtual environment is not at `.venv/bin/python`. The machine must provide four visible GPUs and `nvshmem4py`.

--- a/docs/cp_overlap/nvshmem_cp4_optimized_report_2026-07-22.json
+++ b/docs/cp_overlap/nvshmem_cp4_optimized_report_2026-07-22.json
@@ -1,0 +1,85 @@
+{
+  "date": "2026-07-22",
+  "status": {
+    "correct_forward_backward": true,
+    "faster_than_fla_cp": true,
+    "met_20_percent_target": false,
+    "integrated_megatron_result": false
+  },
+  "environment": {
+    "gpus": "4x NVIDIA GB200, one host",
+    "pytorch": "2.10.0+cu130",
+    "cuda": "13.0",
+    "nvshmem": "3.4.5",
+    "cutlass_dsl": "4.4.2",
+    "NVSHMEM_DISABLE_CUDA_VMM": "1",
+    "NVSHMEM_SYMMETRIC_SIZE": "256M",
+    "CUDA_DEVICE_MAX_CONNECTIONS": "2"
+  },
+  "candidate": {
+    "world_size": 4,
+    "ready_protocol": "barrier",
+    "direct_symmetric_store": true,
+    "fused_remote_merge": true,
+    "current_stream": true,
+    "execution": "eager"
+  },
+  "correctness": [
+    {
+      "sequence_length": 1024,
+      "heads": 4,
+      "launches_passed": 3,
+      "launches_total": 3,
+      "max_abs_diff": 0.0
+    },
+    {
+      "sequence_length": 4096,
+      "heads": 8,
+      "launches_passed": 1,
+      "launches_total": 1,
+      "max_abs_diff": 0.0
+    },
+    {
+      "sequence_length": 8192,
+      "heads": 16,
+      "launches_passed": 1,
+      "launches_total": 1,
+      "max_abs_diff": 0.0
+    }
+  ],
+  "timing_protocol": {
+    "dtype": "bf16",
+    "warmups": 20,
+    "iterations": 60,
+    "repeats": 5,
+    "score": "median repeat of rank-max iteration median"
+  },
+  "timings": [
+    {
+      "sequence_length": 4096,
+      "heads": 8,
+      "fla_rank_max_median_ms": 0.6317,
+      "nvshmem_rank_max_median_ms": 0.5680,
+      "improvement_percent": 10.08,
+      "fla_repeat_rank_max_median_ms": [0.6438, 0.6368, 0.6317, 0.6230, 0.6230],
+      "nvshmem_repeat_rank_max_median_ms": [0.5792, 0.5680, 0.5738, 0.5620, 0.5619]
+    },
+    {
+      "sequence_length": 8192,
+      "heads": 16,
+      "fla_rank_max_median_ms": 0.6112,
+      "nvshmem_rank_max_median_ms": 0.5662,
+      "improvement_percent": 7.36,
+      "fla_repeat_rank_max_median_ms": [0.6289, 0.6237, 0.6079, 0.6112, 0.6077],
+      "nvshmem_repeat_rank_max_median_ms": [0.5826, 0.5641, 0.5677, 0.5662, 0.5565]
+    }
+  ],
+  "rejected": [
+    "serialized chained predecessor schedule",
+    "per-peer ready signals",
+    "CUDA_DEVICE_MAX_CONNECTIONS=3",
+    "CUDA_DEVICE_MAX_CONNECTIONS=4",
+    "eight-warp fused merge configurations",
+    "CUDA Graph comparison without a valid FLA baseline"
+  ]
+}

--- a/docs/cp_overlap/nvshmem_cp4_stability_2026-07-22.md
+++ b/docs/cp_overlap/nvshmem_cp4_stability_2026-07-22.md
@@ -1,0 +1,51 @@
+# NVSHMEM CP=4 stability follow-up
+
+## Result
+
+The NVSHMEM CP path now completes reliably at world size four on one GB200 host. The fix establishes two dependencies that were implicit in the CP=2 implementation:
+
+1. NVSHMEM initialization and symmetric cache construction now finish collectively before any rank can publish or wait on a readiness epoch.
+2. The communication stream explicitly waits for the producer stream before publishing a state computed directly in symmetric memory.
+
+Before the fix, ranks could leave asynchronous NVSHMEM initialization at different times. Later ranks reached `wait_ready(peer=0, epoch=1)` while rank 0 had not completed symmetric cache construction, causing an unbounded wait. Increasing `NVSHMEM_SYMMETRIC_SIZE` did not address this ordering bug.
+
+## Correctness and stability
+
+Environment:
+
+- 4x NVIDIA GB200, one host
+- PyTorch `2.10.0+cu130`
+- NVSHMEM `3.4.5`
+- CUTLASS DSL `4.4.2`
+- `NVSHMEM_DISABLE_CUDA_VMM=1`
+- `NVSHMEM_SYMMETRIC_SIZE=256M`
+- `CUDA_DEVICE_MAX_CONNECTIONS=1`
+
+The deterministic oracle compares the FLA CP preprocessing path and the NVSHMEM path at the same output and backward boundary.
+
+| World size | Global sequence | Heads | Process launches | Result | Maximum absolute difference |
+| ---: | ---: | ---: | ---: | :--- | ---: |
+| 2 | 1,024 | 4 | 1 | pass | 0.0 |
+| 4 | 1,024 | 4 | 5 | 5/5 pass | 0.0 |
+| 4 | 4,096 | 8 | 1 | pass | 0.0 |
+
+The maximum covers output and active Q/K/V/g/beta gradients. The opt-in pytest, including CP=2 and CP=4 subprocess checks, reports `3 passed`.
+
+```bash
+CULA_RUN_NVSHMEM_TESTS=1 \
+NVSHMEM_DISABLE_CUDA_VMM=1 \
+NVSHMEM_SYMMETRIC_SIZE=256M \
+NVSHMEM_IB_ENABLE=0 \
+.venv/bin/python -m pytest tests/test_cp_predecessor_nvshmem.py -q
+```
+
+## Performance status
+
+The stability fix makes CP=4 measurable, but the current multi-peer NVSHMEM implementation is slower than FLA's collective preprocessing path. Measurements use BF16, 20 warmups, 60 iterations, five in-process repeats, and the median repeat rank-max iteration median.
+
+| Shape | FLA CP preprocessing | NVSHMEM multi-peer | NVSHMEM change |
+| :--- | ---: | ---: | ---: |
+| `4096x8` | 0.6088 ms | 0.6921 ms | +13.68% |
+| `8192x16` | 0.6011 ms | 0.6764 ms | +12.53% |
+
+The CP=4 backend is therefore correctness- and stability-ready for further optimization, but it is not ready to replace FLA on performance grounds. The next performance hypothesis is a chained predecessor-state handoff that publishes the already-merged V-state, avoiding rank 2 and rank 3 fetching and merging all earlier affine states.

--- a/docs/cp_overlap/nvshmem_cp4_stability_report_2026-07-22.json
+++ b/docs/cp_overlap/nvshmem_cp4_stability_report_2026-07-22.json
@@ -1,0 +1,49 @@
+{
+  "date": "2026-07-22",
+  "base_commit": "7bbf9cd94eb5b7d174a0852802ba909437846c29",
+  "hardware": "4x NVIDIA GB200, one host",
+  "software": {
+    "torch": "2.10.0+cu130",
+    "cuda": "13.0",
+    "nvshmem": "3.4.5",
+    "cutlass_dsl": "4.4.2"
+  },
+  "environment": {
+    "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+    "NVSHMEM_DISABLE_CUDA_VMM": "1",
+    "NVSHMEM_SYMMETRIC_SIZE": "256M",
+    "NVSHMEM_IB_ENABLE": "0"
+  },
+  "root_cause": {
+    "category": "cross_stream_and_collective_bootstrap_ordering",
+    "first_divergence": "consumer ranks waited for peer 0 epoch 1 before peer 0 completed symmetric cache construction",
+    "heap_exhaustion": false
+  },
+  "fix": [
+    "synchronize NVSHMEM initialization barrier before symmetric allocation",
+    "synchronize ready-flag initialization and complete a collective bootstrap barrier",
+    "make the communication stream wait for the producer stream before publication",
+    "reject first-time symmetric cache allocation during CUDA graph capture"
+  ],
+  "correctness": [
+    {"world_size": 2, "sequence_length": 1024, "heads": 4, "process_launches": 1, "passes": 1, "max_abs_diff": 0.0},
+    {"world_size": 4, "sequence_length": 1024, "heads": 4, "process_launches": 5, "passes": 5, "max_abs_diff": 0.0},
+    {"world_size": 4, "sequence_length": 4096, "heads": 8, "process_launches": 1, "passes": 1, "max_abs_diff": 0.0}
+  ],
+  "pytest": {
+    "passed": 3,
+    "failed": 0
+  },
+  "timing_protocol": {
+    "dtype": "bfloat16",
+    "warmup": 20,
+    "iterations": 60,
+    "repeats": 5,
+    "metric": "median of repeat rank-max iteration medians"
+  },
+  "timing_ms": [
+    {"sequence_length": 4096, "heads": 8, "fla_cp": 0.6088, "nvshmem_multi_peer": 0.6921, "nvshmem_change_percent": 13.68},
+    {"sequence_length": 8192, "heads": 16, "fla_cp": 0.6011, "nvshmem_multi_peer": 0.6764, "nvshmem_change_percent": 12.53}
+  ],
+  "status": "stable_and_correct_but_not_faster"
+}

--- a/docs/cp_overlap/nvshmem_predecessor_handoff.md
+++ b/docs/cp_overlap/nvshmem_predecessor_handoff.md
@@ -1,0 +1,67 @@
+# NVSHMEM CP overlap
+
+## Scope
+
+This opt-in backend overlaps KDA CP preprocessing with an NVSHMEM symmetric-memory
+state exchange. The strict public validation covers the CP=2, predecessor-only
+topology. It does not replace general FLA CP communication.
+
+## Locked CP=2 performance
+
+The implementation was extracted from the private checkpoint at commit
+`6823a3a`. The locked CP=2 matrix used BF16, 20 warmup iterations, 60 measured
+iterations, and five process repeats per cell. The score is the median of the
+five per-run mean rank latencies. All six cells had five valid runs, the
+fairness checks passed, and there were no timeouts.
+
+| Cell | cuLA NVSHMEM overlap | NCCL symmetric-memory baseline | FLA CP KDA | vs NCCL | vs FLA |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| graph 4096x8 | 0.1517 ms | 0.1750 ms | 0.2400 ms | -13.3% | -36.8% |
+| non-graph 4096x8 | 0.5700 ms | 0.6731 ms | 0.7571 ms | -15.3% | -24.7% |
+| graph 8192x8 | 0.2531 ms | 0.2763 ms | 0.3663 ms | -8.4% | -30.9% |
+| non-graph 8192x8 | 0.5857 ms | 0.6762 ms | 0.7670 ms | -13.4% | -23.6% |
+| graph 8192x16 | 0.3154 ms | 0.3601 ms | 0.4643 ms | -12.4% | -32.1% |
+| non-graph 8192x16 | 0.5767 ms | 0.6770 ms | 0.7910 ms | -14.8% | -27.1% |
+
+Negative percentages denote lower latency. NVSHMEM overlap won all six cells.
+The Megatron measurements collected by the original harness are omitted because
+they measured full training iterations and are not comparable with this
+operation-level benchmark.
+
+## Fresh GB200 validation
+
+The upstream-ready branch was revalidated on two GB200 GPUs with NVSHMEM 3.4.5. Forward
+output and active Q/K/V/g/beta gradients matched the FLA-preprocessing baseline
+exactly (`max_abs_diff=0.0`). A five-repeat non-graph check at 8192x8 produced a
+`0.5636 ms` median rank-max latency, versus `0.6076 ms` for cuLA with FLA CP
+preprocessing on the same branch and run protocol.
+See
+[`nvshmem_predecessor_handoff_report.json`](nvshmem_predecessor_handoff_report.json)
+for the repeat values and environment.
+
+## Reproduce
+
+```bash
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export NVSHMEM_DISABLE_CUDA_VMM=1
+export NVSHMEM_SYMMETRIC_SIZE=256M
+export NVSHMEM_IB_ENABLE=0
+export CULA_CP_OVERLAP=1
+export CULA_CP_ALLOW_FALLBACK=0
+export CULA_CP_NVSHMEM_READY_WAIT=1
+
+torchrun --standalone --nproc-per-node=2 \
+  benchmarks/check_cp_predecessor_nvshmem.py
+
+for backend in fla_full fla nvshmem; do
+  torchrun --standalone --nproc-per-node=2 \
+    benchmarks/bench_cp_predecessor_nvshmem.py \
+    --backend="$backend" --sequence-length=8192 --heads=8 \
+    --warmup=20 --iterations=60 --repeats=5
+done
+```
+
+`NVSHMEM_DISABLE_CUDA_VMM=0` failed during NVSHMEM initialization with
+`cuMemCreate` status 800 on this GB200/NVSHMEM 3.4.5 environment. cuLA does not
+override the setting because other NVSHMEM installations may require a
+different policy.

--- a/docs/cp_overlap/nvshmem_predecessor_handoff_report.json
+++ b/docs/cp_overlap/nvshmem_predecessor_handoff_report.json
@@ -1,0 +1,93 @@
+{
+  "date": "2026-07-22",
+  "hardware": "2x NVIDIA GB200",
+  "software": {
+    "torch": "2.10.0+cu130",
+    "cuda": "13.0",
+    "nvshmem": "3.4.5",
+    "cula_base_commit": "326a307",
+    "fla_submodule_commit": "3a9ce1c8"
+  },
+  "environment": {
+    "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+    "NVSHMEM_DISABLE_CUDA_VMM": "1",
+    "NVSHMEM_SYMMETRIC_SIZE": "256M",
+    "NVSHMEM_IB_ENABLE": "0"
+  },
+  "shape": {
+    "world_size": 2,
+    "sequence_length": 8192,
+    "heads": 8,
+    "key_dim": 128,
+    "value_dim": 128,
+    "dtype": "bfloat16"
+  },
+  "protocol": {
+    "warmup": 20,
+    "iterations": 60,
+    "repeats": 5,
+    "repeat_mode": "in_process",
+    "score": "median of repeat rank-max iteration medians"
+  },
+  "correctness": {
+    "sequence_length": 1024,
+    "heads": 4,
+    "forward_and_backward": true,
+    "max_abs_diff": {
+      "output": 0.0,
+      "grad_q": 0.0,
+      "grad_k": 0.0,
+      "grad_v": 0.0,
+      "grad_g": 0.0,
+      "grad_beta": 0.0
+    }
+  },
+  "timing_ms": {
+    "fla_full": {
+      "repeat_rank_max_medians": [0.9580, 0.9409, 0.9400, 0.9360, 0.9829],
+      "median": 0.9409
+    },
+    "cula_fla_cp": {
+      "repeat_rank_max_medians": [0.6325, 0.6144, 0.6076, 0.6059, 0.6065],
+      "median": 0.6076
+    },
+    "cula_nvshmem_cp": {
+      "repeat_rank_max_medians": [0.5806, 0.5695, 0.5636, 0.5547, 0.5542],
+      "median": 0.5636
+    }
+  },
+  "latency_reduction_percent": {
+    "nvshmem_vs_fla_full": 40.10,
+    "nvshmem_vs_cula_fla_cp": 7.24
+  },
+  "locked_cp2_matrix": {
+    "source_commit": "98b55fd",
+    "implementation_commit": "6823a3a",
+    "protocol": {
+      "hosts": 1,
+      "world_size": 2,
+      "dtype": "bfloat16",
+      "warmup": 20,
+      "iterations": 60,
+      "recorded_repeats": 5,
+      "score": "median of five per-run mean rank latencies"
+    },
+    "fairness_checks_passed": true,
+    "timeouts": 0,
+    "timing_ms": [
+      {"sequence_length": 4096, "heads": 8, "mode": "graph", "nvshmem_overlap": 0.1517, "nccl_symmetric_memory": 0.1750, "fla_cp": 0.2400, "vs_nccl_percent": -13.3, "vs_fla_percent": -36.8},
+      {"sequence_length": 4096, "heads": 8, "mode": "non_graph", "nvshmem_overlap": 0.5700, "nccl_symmetric_memory": 0.6731, "fla_cp": 0.7571, "vs_nccl_percent": -15.3, "vs_fla_percent": -24.7},
+      {"sequence_length": 8192, "heads": 8, "mode": "graph", "nvshmem_overlap": 0.2531, "nccl_symmetric_memory": 0.2763, "fla_cp": 0.3663, "vs_nccl_percent": -8.4, "vs_fla_percent": -30.9},
+      {"sequence_length": 8192, "heads": 8, "mode": "non_graph", "nvshmem_overlap": 0.5857, "nccl_symmetric_memory": 0.6762, "fla_cp": 0.7670, "vs_nccl_percent": -13.4, "vs_fla_percent": -23.6},
+      {"sequence_length": 8192, "heads": 16, "mode": "graph", "nvshmem_overlap": 0.3154, "nccl_symmetric_memory": 0.3601, "fla_cp": 0.4643, "vs_nccl_percent": -12.4, "vs_fla_percent": -32.1},
+      {"sequence_length": 8192, "heads": 16, "mode": "non_graph", "nvshmem_overlap": 0.5767, "nccl_symmetric_memory": 0.6770, "fla_cp": 0.7910, "vs_nccl_percent": -14.8, "vs_fla_percent": -27.1}
+    ],
+    "winner_in_all_cells": "nvshmem_overlap"
+  },
+  "notes": [
+    "Only cula_fla_cp versus cula_nvshmem_cp isolates the effect of this change.",
+    "The comparison with fla_full also includes cuLA local-kernel improvements.",
+    "NVSHMEM_DISABLE_CUDA_VMM=0 failed at initialization with cuMemCreate status 800.",
+    "Repeats were measured in one long-lived distributed process."
+  ]
+}

--- a/tests/test_cp_predecessor_nvshmem.py
+++ b/tests/test_cp_predecessor_nvshmem.py
@@ -49,7 +49,11 @@ def test_nvshmem_predecessor_handoff_matches_fla_forward_and_backward(world_size
     env = os.environ.copy()
     env.update(
         {
-            "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+            "CUDA_DEVICE_MAX_CONNECTIONS": "2",
+            "CULA_CP_COMM_USE_CURRENT_STREAM": "1",
+            "CULA_CP_NVSHMEM_DIRECT_STORE_CONN1_ONLY": "0",
+            "CULA_CP_NVSHMEM_FUSED_REMOTE_MERGE": "1",
+            "CULA_CP_NVSHMEM_READY_WAIT": "0",
             "NVSHMEM_DISABLE_CUDA_VMM": env.get("NVSHMEM_DISABLE_CUDA_VMM", "1"),
             "NVSHMEM_SYMMETRIC_SIZE": "256M",
             "NVSHMEM_IB_ENABLE": "0",

--- a/tests/test_cp_predecessor_nvshmem.py
+++ b/tests/test_cp_predecessor_nvshmem.py
@@ -1,0 +1,73 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+from cula.kda import cp_overlap
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _json_payload(stdout: str) -> dict:
+    for line in reversed(stdout.splitlines()):
+        if line.startswith("{"):
+            return json.loads(line)
+    raise AssertionError(f"No JSON result found in output:\n{stdout}")
+
+
+def test_cp_overlap_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("CULA_CP_OVERLAP", raising=False)
+    expected = object()
+    monkeypatch.setattr(cp_overlap, "_fla_chunk_gated_delta_rule_fwd_h_pre_process", lambda **_: expected)
+
+    result = cp_overlap.chunk_gated_delta_rule_fwd_h_pre_process_overlap(
+        k=None,
+        w=None,
+        u=None,
+        context=None,
+    )
+
+    assert not cp_overlap._cp_overlap_enabled()
+    assert result is expected
+
+
+@pytest.mark.skipif(
+    os.getenv("CULA_RUN_NVSHMEM_TESTS") != "1",
+    reason="Set CULA_RUN_NVSHMEM_TESTS=1 to run the NVSHMEM integration test",
+)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Two GPUs are required")
+def test_nvshmem_predecessor_handoff_matches_fla_forward_and_backward():
+    pytest.importorskip("nvshmem.core")
+    env = os.environ.copy()
+    env.update(
+        {
+            "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+            "NVSHMEM_DISABLE_CUDA_VMM": env.get("NVSHMEM_DISABLE_CUDA_VMM", "1"),
+            "NVSHMEM_SYMMETRIC_SIZE": "256M",
+            "NVSHMEM_IB_ENABLE": "0",
+        }
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--standalone",
+            "--nproc-per-node=2",
+            "benchmarks/check_cp_predecessor_nvshmem.py",
+            "--sequence-length=1024",
+            "--heads=4",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert completed.returncode == 0, completed.stderr[-4000:]
+    assert _json_payload(completed.stdout)["passed"]

--- a/tests/test_cp_predecessor_nvshmem.py
+++ b/tests/test_cp_predecessor_nvshmem.py
@@ -41,8 +41,11 @@ def test_cp_overlap_is_disabled_by_default(monkeypatch):
 )
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Two GPUs are required")
-def test_nvshmem_predecessor_handoff_matches_fla_forward_and_backward():
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_nvshmem_predecessor_handoff_matches_fla_forward_and_backward(world_size):
     pytest.importorskip("nvshmem.core")
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(f"{world_size} GPUs are required")
     env = os.environ.copy()
     env.update(
         {
@@ -58,8 +61,9 @@ def test_nvshmem_predecessor_handoff_matches_fla_forward_and_backward():
             "-m",
             "torch.distributed.run",
             "--standalone",
-            "--nproc-per-node=2",
+            f"--nproc-per-node={world_size}",
             "benchmarks/check_cp_predecessor_nvshmem.py",
+            f"--world-size={world_size}",
             "--sequence-length=1024",
             "--heads=4",
         ],


### PR DESCRIPTION
## Summary

- add an opt-in NVSHMEM backend for KDA context-parallel recurrent-state communication
- support the CP=2 predecessor handoff with signal-based publication and selective V-state fetch
- support CP=4 multi-predecessor assembly with symmetric state storage, one visibility barrier, and a fused remote recurrence merge
- preserve the existing FLA preprocessing path as the default
- add deterministic distributed forward/backward checks, reproducible benchmarks, and machine-readable reports

## Motivation

The general FLA CP preprocessing path communicates and stages complete intermediate states. The NVSHMEM backend specializes the recurrent-state boundary:

- At CP=2, rank 0 publishes its state in symmetric memory and rank 1 fetches only the V-state it consumes.
- At CP=4, each producer writes its affine recurrence state directly into symmetric memory. Ranks with multiple predecessors read those states directly and assemble the final state in one Triton kernel, avoiding peer-copy staging and a second local merge pass.

The backend is disabled by default. Existing behavior is unchanged unless both `CULA_CP_OVERLAP=1` and `CULA_CP_COMM_BACKEND=nvshmem` are set.

## Supported configuration

- one host with a global CP group of size two or four
- one global sequence and eager execution
- BF16 KDA inputs with FP32 recurrent state
- NVSHMEM 3.4.5 on GB200 with `NVSHMEM_DISABLE_CUDA_VMM=1`
- CP=2 signal path: `CUDA_DEVICE_MAX_CONNECTIONS=1`
- CP=4 optimized path: `CUDA_DEVICE_MAX_CONNECTIONS=2`, barrier publication, fused remote merge, and current-stream execution

The CP=4 optimization is limited to world size at most four and a non-transposed state layout. Other configurations retain the existing path unless strict opt-in settings request an error instead of fallback.

## Correctness

The deterministic oracle compares the cuLA NVSHMEM path with FLA CP at the same output and backward boundary. It checks output and active Q/K/V/g/beta gradients.

| CP size | Global sequence | Heads | Fresh launches | Maximum absolute difference |
| ---: | ---: | ---: | ---: | ---: |
| 2 | 1,024 | 4 | pass | 0.0 |
| 4 | 1,024 | 4 | 3/3 pass | 0.0 |
| 4 | 4,096 | 8 | pass | 0.0 |
| 4 | 8,192 | 16 | pass | 0.0 |

## Performance

Measurements use BF16, 20 warmups, 60 iterations, five in-process repeats, and the median of each repeat's rank-max iteration median.

### CP=2

| Path | Latency | Improvement |
| --- | ---: | ---: |
| cuLA + FLA CP preprocessing | 0.6076 ms | reference |
| cuLA + NVSHMEM overlap | 0.5636 ms | 7.24% |

### CP=4

| Shape | FLA CP preprocessing | NVSHMEM optimized | Improvement |
| --- | ---: | ---: | ---: |
| `4096x8` | 0.6317 ms | 0.5680 ms | 10.08% |
| `8192x16` | 0.6112 ms | 0.5662 ms | 7.36% |

These numbers isolate the cuLA KDA CP preprocessing boundary. They are not an integrated Megatron training result and do not claim a 20% end-to-end speedup.

## Validation

- based on `inclusionAI/cuLA` commit `326a307`
- FLA submodule commit `3a9ce1c8`
- Ruff, shell syntax, Python compilation, and JSON validation passed
- opt-in CP=2 and CP=4 forward/backward suite: `3 passed`
- CP=4 optimized path passed three fresh tiny-oracle launches and the 8192x16 oracle
- documented five-repeat CP=2 and CP=4 benchmark matrices completed

Reproduction commands and complete repeat data are under `docs/cp_overlap/` and `benchmarks/run_cp4_nvshmem_optimized.sh`.