### PR TITLE
fix(kda): add the missing cross-proxy fence before TMA stores

### DIFF
--- a/cula/ops/kda/sm90/k1.py
+++ b/cula/ops/kda/sm90/k1.py
@@ -529,6 +529,8 @@ def k1_kernel(
             smem_thr_store_C.retile(tCrInvC_bf16),
             smem_thr_store_C.partition_D(sINV_bf16),
         )
+    # Generic-proxy smem writes -> visible to the async proxy.
+    cute.arch.fence_view_async_shared()
     cute.arch.barrier()
 
     # TMA bulk store all 5 workspace tensors (one elect_one, one thread).


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

- add cross-proxy fence for CUDA Core->TMA, without it the TMA store can read stale SMEM

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to cuLA! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing. 

## ⚡ Performance

<!-- Optional: If this PR affects performance, please provide a before/after comparison. -->

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->