### PR TITLE
feat: isolate cutlass._mlir imports behind compat gateway (#118)

### DIFF
--- a/cula/lightning/la_verify_kvbuffer.py
+++ b/cula/lightning/la_verify_kvbuffer.py
@@ -49,8 +49,8 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import torch
-from cutlass._mlir.dialects import arith as _arith
-from cutlass._mlir.dialects import llvm as _llvm
+from cula.ops._mlir_compat import arith as _arith
+from cula.ops._mlir_compat import llvm as _llvm
 from cutlass.cute.runtime import (
     make_fake_compact_tensor,
     make_fake_stream,

--- a/cula/lightning/la_verify_kvbuffer.py
+++ b/cula/lightning/la_verify_kvbuffer.py
@@ -49,8 +49,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import torch
-from cula.ops._mlir_compat import arith as _arith
-from cula.ops._mlir_compat import llvm as _llvm
 from cutlass.cute.runtime import (
     make_fake_compact_tensor,
     make_fake_stream,
@@ -63,6 +61,8 @@ from cula.lightning.la_decode_mtp import (
     NUM_THREADS_MTP,
     hq_dot_pair,
 )
+from cula.ops._mlir_compat import arith as _arith
+from cula.ops._mlir_compat import llvm as _llvm
 from cula.utils import USE_FAST_MATH, get_device_sm_version
 
 # Dispatch threshold between the two verify implementations.

--- a/cula/ops/_mlir_compat.py
+++ b/cula/ops/_mlir_compat.py
@@ -49,8 +49,7 @@ from __future__ import annotations
 
 import importlib
 import re
-import sys
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 # Version contract for nvidia-cutlass-dsl. Kept in sync with
 # ``pyproject.toml``; when CuTeDSL is bumped, extend ``_SUPPORTED_MIN`` /
@@ -102,24 +101,29 @@ _INCIDENT_NOTE: Final[str] = (
 _CACHE: Final[dict[str, Any]] = {}
 
 
-def _parse_version(version: str) -> tuple[int, ...]:
-    """Parse ``X.Y.Z[.devN...]`` into a comparable tuple, or raise."""
+def _parse_version(version: str) -> tuple[int, int, int]:
+    """Parse ``X.Y.Z[.devN...]`` into a comparable ``(major, minor, patch)`` tuple.
+
+    Missing components normalize to zero so that ``4.5`` and ``4.7`` compare
+    against the contract exactly like ``4.5.0`` and ``4.7.0`` (a two-component
+    ``4.7`` must not slip under the ``< 4.7.0`` upper bound).
+    """
     match = _VERSION_RE.match(version.strip())
     if match is None:
         raise RuntimeError(
             f"cuLA cannot parse the installed CuTeDSL version {version!r}; "
             f"refusing to use its private MLIR bindings. {_INCIDENT_NOTE}"
         )
-    return tuple(int(part) for part in match.groups() if part is not None)
+    major, minor, patch = (int(part) if part is not None else 0 for part in match.groups())
+    return (major, minor, patch)
 
 
-def _installed_version() -> tuple[int, ...]:
+def _installed_version() -> tuple[int, int, int]:
     try:
         import cutlass  # noqa: PLC0415
     except ImportError:
         raise RuntimeError(
-            "cuLA requires the nvidia-cutlass-dsl package; install it with "
-            "`pip install 'nvidia-cutlass-dsl>=4.4.2,<4.7'`."
+            "cuLA requires the nvidia-cutlass-dsl package; install it with `pip install 'nvidia-cutlass-dsl>=4.4.2,<4.7'`."
         ) from None
     version = getattr(cutlass, "__version__", None)
     if not isinstance(version, str):
@@ -164,8 +168,7 @@ def _load(dialect: str) -> Any:
         module = importlib.import_module(package)
     except ImportError as exc:
         raise RuntimeError(
-            f"Unable to import CuTeDSL's private {dialect!r} bindings "
-            f"({package}): {exc}. {_INCIDENT_NOTE}"
+            f"Unable to import CuTeDSL's private {dialect!r} bindings ({package}): {exc}. {_INCIDENT_NOTE}"
         ) from exc
     if attribute:
         for part in attribute.split("."):
@@ -173,10 +176,7 @@ def _load(dialect: str) -> Any:
             if module is None:
                 break
     if module is None:
-        raise RuntimeError(
-            f"CuTeDSL no longer exposes {dialect!r} bindings "
-            f"({package}.{attribute}). {_INCIDENT_NOTE}"
-        )
+        raise RuntimeError(f"CuTeDSL no longer exposes {dialect!r} bindings ({package}.{attribute}). {_INCIDENT_NOTE}")
 
     for canary in _CANARIES[dialect]:
         owner: Any = module
@@ -208,7 +208,7 @@ def __getattr__(name: str) -> Any:
     return _load(name)
 
 
-def cutlass_dsl_version() -> Optional[str]:
+def cutlass_dsl_version() -> str | None:
     """Installed CuTeDSL version string, or None when not installed."""
     try:
         import cutlass  # noqa: PLC0415
@@ -222,11 +222,21 @@ def vector_extract_element(vec, position, *, loc=None, ip=None):
     """Extract one element of ``vec`` at ``position``, across CutDSL versions.
 
     CutDSL renamed ``vector.extractelement`` to ``vector.extract`` in the 4.6
-    line (with the position as the second positional argument). Rather than
-    calling either binding directly from kernel code, kernels go through this
-    helper so a CutDSL patch release can never break the extraction path again.
+    line. ``position`` is the Python element index; each branch builds the
+    operand shape its binding actually expects:
+
+    - ``extractelement`` (4.5 line; also present in early 4.6): takes the
+      index as a single i32 operand, so the constant is constructed here.
+    - ``extract`` (4.6+): takes a sequence of index-typed dynamic operands
+      plus a static-position array, so a constant position is ``extract(vec,
+      [], [position], ...)``.
+
+    Preferring ``extractelement`` when both exist keeps the pre-4.6 code path
+    byte-identical to what cuLA shipped before the gateway.
     """
     vector_dialect = _load("vector")
-    if _has_attribute_path(vector_dialect, ("extract",)):
-        return vector_dialect.extract(vec, position, None, loc=loc, ip=ip)
-    return vector_dialect.extractelement(vec, position=position, loc=loc, ip=ip)
+    if _has_attribute_path(vector_dialect, ("extractelement",)):
+        i32_ty = _load("ir").IntegerType.get_signless(32)
+        index = _load("arith").constant(i32_ty, position, loc=loc, ip=ip)
+        return vector_dialect.extractelement(vec, position=index, loc=loc, ip=ip)
+    return vector_dialect.extract(vec, [], [position], loc=loc, ip=ip)

--- a/cula/ops/_mlir_compat.py
+++ b/cula/ops/_mlir_compat.py
@@ -1,0 +1,232 @@
+# Copyright 2025-2026 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-point gateway for CuTeDSL's private MLIR/NVVM bindings.
+
+cuLA kernels are written against CuTeDSL's code-generation API. Most of that API
+is public (``cutlass.cutlass_dsl``, ``cutlass.cute``, ...); a small part is not:
+the generated MLIR dialect bindings under ``cutlass._mlir``. CuTeDSL ships them
+as implementation detail and provides no stability contract across patch
+releases -- the ``tcgen05_ld/st`` breakage between CutDSL 4.5.2 and 4.5.3 was one
+such incident.
+
+This module is the ONLY place in cuLA that may import from ``cutlass._mlir``.
+Kernel modules bind their dialect aliases from here::
+
+    from cula.ops._mlir_compat import arith as _arith
+    from cula.ops._mlir_compat import ir
+    from cula.ops._mlir_compat import llvm as _llvm
+    from cula.ops._mlir_compat import vector as _vector
+
+Design goals:
+
+- Lazy: nothing is imported until a kernel actually needs a binding, so plain
+  imports of cuLA never touch ``cutlass._mlir``.
+- Explicity: an out-of-contract CuTeDSL version, or a missing/renamed binding,
+  fails fast at first use with an actionable ``RuntimeError`` instead of
+  surfacing mid-JIT as a confusing compile error (or silently emitting a
+  different kernel).
+- Zero dependencies: version parsing is done with a small regex so this module
+  stays usable in any environment cuLA can be installed into.
+
+The version contract mirrors ``pyproject.toml`` (including its ``!=4.5.0``
+exclusion) and the canary probes make a broken binding fail fast with an
+actionable message instead of surfacing mid-JIT.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from typing import Any, Final, Optional
+
+# Version contract for nvidia-cutlass-dsl. Kept in sync with
+# ``pyproject.toml``; when CuTeDSL is bumped, extend ``_SUPPORTED_MIN`` /
+# ``_SUPPORTED_MAX`` only after the new release has been validated against the
+# canaries below (and ideally against the SM90/SM100 kernel test suites).
+_SUPPORTED_MIN: Final[tuple[int, ...]] = (4, 4, 2)
+_SUPPORTED_MAX: Final[tuple[int, ...]] = (4, 7, 0)
+_EXCLUDED_VERSIONS: Final[frozenset[tuple[int, ...]]] = frozenset({(4, 5, 0)})
+
+# dialect name -> (package, attribute) inside ``cutlass``.
+_PRIVATE_TABLE: Final[dict[str, tuple[str, str]]] = {
+    "arith": ("cutlass._mlir", "dialects.arith"),
+    "cute": ("cutlass._mlir", "dialects.cute"),
+    "ir": ("cutlass._mlir", "ir"),
+    "llvm": ("cutlass._mlir", "dialects.llvm"),
+    "nvvm": ("cutlass._mlir", "dialects.nvvm"),
+    "vector": ("cutlass._mlir", "dialects.vector"),
+}
+
+# Canary entry points: attribute paths that must be present on each dialect
+# binding for cuLA's kernel code to be emitted correctly. These are the names
+# the migrated consumers actually call; extend the list when new usages land.
+_CANARIES: Final[dict[str, tuple[tuple[str, ...], ...]]] = {
+    "arith": (("constant",),),
+    "cute": (),
+    "ir": (("Type", "parse"), ("VectorType", "get")),
+    "llvm": (("inline_asm",), ("extractvalue",)),
+    "nvvm": (),
+    "vector": (("bitcast",), ("extract_strided_slice",)),
+}
+
+# Entry points whose name changed across CutDSL versions: for each group (a
+# tuple of variant paths), at least one variant must exist. For example
+# ``vector.extractelement`` was replaced by ``vector.extract`` in the 4.6
+# line; cuLA helpers dispatch on whichever one exists.
+_ANY_OF_CANARIES: Final[dict[str, tuple[tuple[tuple[str, ...], ...], ...]]] = {
+    "vector": ((("extract",), ("extractelement",)),),
+}
+
+_VERSION_RE: Final[re.Pattern[str]] = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[a-z0-9._+-]*)?$")
+
+_INCIDENT_NOTE: Final[str] = (
+    "cuLA depends on CuTeDSL's private MLIR bindings (`cutlass._mlir`), which are "
+    "implementation detail and were broken by a CuTeDSL patch release once "
+    "already (`tcgen05_ld/st`, 4.5.2 -> 4.5.3). To avoid silent kernel "
+    "miscompiles, cuLA refuses bindings outside its validated contract."
+)
+
+_CACHE: Final[dict[str, Any]] = {}
+
+
+def _parse_version(version: str) -> tuple[int, ...]:
+    """Parse ``X.Y.Z[.devN...]`` into a comparable tuple, or raise."""
+    match = _VERSION_RE.match(version.strip())
+    if match is None:
+        raise RuntimeError(
+            f"cuLA cannot parse the installed CuTeDSL version {version!r}; "
+            f"refusing to use its private MLIR bindings. {_INCIDENT_NOTE}"
+        )
+    return tuple(int(part) for part in match.groups() if part is not None)
+
+
+def _installed_version() -> tuple[int, ...]:
+    try:
+        import cutlass  # noqa: PLC0415
+    except ImportError:
+        raise RuntimeError(
+            "cuLA requires the nvidia-cutlass-dsl package; install it with "
+            "`pip install 'nvidia-cutlass-dsl>=4.4.2,<4.7'`."
+        ) from None
+    version = getattr(cutlass, "__version__", None)
+    if not isinstance(version, str):
+        raise RuntimeError(
+            f"CuTeDSL is installed but exposes no `__version__` (got {version!r}); "
+            f"refusing to use its private MLIR bindings. {_INCIDENT_NOTE}"
+        )
+    return _parse_version(version)
+
+
+def _check_contract(version: tuple[int, ...]) -> None:
+    if version in _EXCLUDED_VERSIONS:
+        raise RuntimeError(
+            f"Installed CuTeDSL version {'.'.join(map(str, version))} is explicitly "
+            f"excluded by cuLA (see pyproject.toml). {_INCIDENT_NOTE}"
+        )
+    if not (_SUPPORTED_MIN <= version < _SUPPORTED_MAX):
+        raise RuntimeError(
+            f"Installed CuTeDSL version {'.'.join(map(str, version))} is outside the "
+            f"range validated by cuLA ({'.'.join(map(str, _SUPPORTED_MIN))} to "
+            f"{'.'.join(map(str, _SUPPORTED_MAX))}, exclusive). "
+            f"{_INCIDENT_NOTE} To proceed, pin the validated range in "
+            f"pyproject.toml and re-validate the canaries in this module."
+        )
+
+
+def _has_attribute_path(module: Any, path: tuple[str, ...]) -> bool:
+    owner = module
+    for part in path:
+        owner = getattr(owner, part, None)
+        if owner is None:
+            return False
+    return True
+
+
+def _load(dialect: str) -> Any:
+    if dialect in _CACHE:
+        return _CACHE[dialect]
+
+    package, attribute = _PRIVATE_TABLE[dialect]
+    try:
+        module = importlib.import_module(package)
+    except ImportError as exc:
+        raise RuntimeError(
+            f"Unable to import CuTeDSL's private {dialect!r} bindings "
+            f"({package}): {exc}. {_INCIDENT_NOTE}"
+        ) from exc
+    if attribute:
+        for part in attribute.split("."):
+            module = getattr(module, part, None)
+            if module is None:
+                break
+    if module is None:
+        raise RuntimeError(
+            f"CuTeDSL no longer exposes {dialect!r} bindings "
+            f"({package}.{attribute}). {_INCIDENT_NOTE}"
+        )
+
+    for canary in _CANARIES[dialect]:
+        owner: Any = module
+        for part in canary:
+            owner = getattr(owner, part, None)
+            if owner is None:
+                raise RuntimeError(
+                    f"CuTeDSL dialect {dialect!r} is missing the canary entry point "
+                    f"{'.'.join(canary)} used by cuLA kernels. {_INCIDENT_NOTE}"
+                )
+    for group in _ANY_OF_CANARIES.get(dialect, ()):
+        if not any(_has_attribute_path(module, variant) for variant in group):
+            raise RuntimeError(
+                f"CuTeDSL dialect {dialect!r} exposes none of the entry points "
+                f"{' / '.join('.'.join(variant) for variant in group)} expected by "
+                f"cuLA kernels. {_INCIDENT_NOTE}"
+            )
+
+    _CACHE[dialect] = module
+    return module
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy, contract-checked access to private dialect bindings."""
+    if name not in _PRIVATE_TABLE:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    version = _installed_version()
+    _check_contract(version)
+    return _load(name)
+
+
+def cutlass_dsl_version() -> Optional[str]:
+    """Installed CuTeDSL version string, or None when not installed."""
+    try:
+        import cutlass  # noqa: PLC0415
+    except ImportError:
+        return None
+    version = getattr(cutlass, "__version__", None)
+    return version if isinstance(version, str) else None
+
+
+def vector_extract_element(vec, position, *, loc=None, ip=None):
+    """Extract one element of ``vec`` at ``position``, across CutDSL versions.
+
+    CutDSL renamed ``vector.extractelement`` to ``vector.extract`` in the 4.6
+    line (with the position as the second positional argument). Rather than
+    calling either binding directly from kernel code, kernels go through this
+    helper so a CutDSL patch release can never break the extraction path again.
+    """
+    vector_dialect = _load("vector")
+    if _has_attribute_path(vector_dialect, ("extract",)):
+        return vector_dialect.extract(vec, position, None, loc=loc, ip=ip)
+    return vector_dialect.extractelement(vec, position=position, loc=loc, ip=ip)

--- a/cula/ops/kda/decode/mtp_conv.py
+++ b/cula/ops/kda/decode/mtp_conv.py
@@ -33,11 +33,11 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import torch
-from cula.ops._mlir_compat import llvm as _llvm
 from cutlass.cute.runtime import from_dlpack
 from cutlass.cute.typing import Int32
 from cutlass.cutlass_dsl import T as _T
 
+from cula.ops._mlir_compat import llvm as _llvm
 from cula.ops.kda.decode.cute import (
     TILE_K,
     _get_cached_stream,

--- a/cula/ops/kda/decode/mtp_conv.py
+++ b/cula/ops/kda/decode/mtp_conv.py
@@ -33,7 +33,7 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import torch
-from cutlass._mlir.dialects import llvm as _llvm
+from cula.ops._mlir_compat import llvm as _llvm
 from cutlass.cute.runtime import from_dlpack
 from cutlass.cute.typing import Int32
 from cutlass.cutlass_dsl import T as _T

--- a/cula/ops/kda/decode/mtp_kvbuffer.py
+++ b/cula/ops/kda/decode/mtp_kvbuffer.py
@@ -1097,8 +1097,8 @@ def kda_decode_mtp_shuffle_kvbuffer(
 #   C/D [16,8] f32:     c0=C[gid][2tig] c1=C[gid][2tig+1] c2=C[gid+8][2tig] c3=C[gid+8][2tig+1]
 # ===========================================================================
 
-from cutlass._mlir.dialects import arith as _arith  # noqa: E402
-from cutlass._mlir.dialects import llvm as _llvm  # noqa: E402
+from cula.ops._mlir_compat import arith as _arith  # noqa: E402
+from cula.ops._mlir_compat import llvm as _llvm  # noqa: E402
 from cutlass.cutlass_dsl import T as _T  # noqa: E402
 from cutlass.cutlass_dsl import dsl_user_op  # noqa: E402
 

--- a/cula/ops/kda/decode/mtp_kvbuffer.py
+++ b/cula/ops/kda/decode/mtp_kvbuffer.py
@@ -1097,10 +1097,11 @@ def kda_decode_mtp_shuffle_kvbuffer(
 #   C/D [16,8] f32:     c0=C[gid][2tig] c1=C[gid][2tig+1] c2=C[gid+8][2tig] c3=C[gid+8][2tig+1]
 # ===========================================================================
 
-from cula.ops._mlir_compat import arith as _arith  # noqa: E402
-from cula.ops._mlir_compat import llvm as _llvm  # noqa: E402
 from cutlass.cutlass_dsl import T as _T  # noqa: E402
 from cutlass.cutlass_dsl import dsl_user_op  # noqa: E402
+
+from cula.ops._mlir_compat import arith as _arith  # noqa: E402
+from cula.ops._mlir_compat import llvm as _llvm  # noqa: E402
 
 
 @dsl_user_op

--- a/cula/ops/kda/sm100/delta_h.py
+++ b/cula/ops/kda/sm100/delta_h.py
@@ -27,7 +27,6 @@ import cutlass.utils.blackwell_helpers as sm100_utils
 import torch
 import torch.nn.functional as F
 import triton
-from cula.ops._mlir_compat import llvm as _llvm
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_stream
 from cutlass.cute.typing import Float32, Int32, Int64
@@ -35,6 +34,7 @@ from cutlass.cutlass_dsl import T as _T
 from fla.ops.utils import prepare_chunk_indices, prepare_lens
 from fla.utils import tensor_cache
 
+from cula.ops._mlir_compat import llvm as _llvm
 from cula.ops.kda.sm100.policy import sm100_intracard_cp_decision
 from cula.utils import USE_FAST_MATH, assert_blackwell, get_device_sm_count
 

--- a/cula/ops/kda/sm100/delta_h.py
+++ b/cula/ops/kda/sm100/delta_h.py
@@ -27,7 +27,7 @@ import cutlass.utils.blackwell_helpers as sm100_utils
 import torch
 import torch.nn.functional as F
 import triton
-from cutlass._mlir.dialects import llvm as _llvm
+from cula.ops._mlir_compat import llvm as _llvm
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_stream
 from cutlass.cute.typing import Float32, Int32, Int64

--- a/cula/ops/kda/sm90/_common.py
+++ b/cula/ops/kda/sm90/_common.py
@@ -6,8 +6,9 @@
 import cutlass
 import torch
 from cutlass import Int32
-from cula.ops._mlir_compat import llvm as _llvm
 from cutlass.cutlass_dsl import T as _T
+
+from cula.ops._mlir_compat import llvm as _llvm
 
 
 def _stream_key(device: torch.device) -> tuple[str, int]:

--- a/cula/ops/kda/sm90/_common.py
+++ b/cula/ops/kda/sm90/_common.py
@@ -6,7 +6,7 @@
 import cutlass
 import torch
 from cutlass import Int32
-from cutlass._mlir.dialects import llvm as _llvm
+from cula.ops._mlir_compat import llvm as _llvm
 from cutlass.cutlass_dsl import T as _T
 
 

--- a/cula/ops/lightning/prefill_sm100.py
+++ b/cula/ops/lightning/prefill_sm100.py
@@ -58,12 +58,12 @@ import cutlass.pipeline as pipeline
 import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 import torch
-from cula.ops._mlir_compat import llvm as _llvm
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_stream
 from cutlass.cute.typing import Float32, Int32, Int64
 from cutlass.cutlass_dsl import T as _T
 
+from cula.ops._mlir_compat import llvm as _llvm
 from cula.utils import USE_FAST_MATH, assert_blackwell
 
 

--- a/cula/ops/lightning/prefill_sm100.py
+++ b/cula/ops/lightning/prefill_sm100.py
@@ -58,7 +58,7 @@ import cutlass.pipeline as pipeline
 import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 import torch
-from cutlass._mlir.dialects import llvm as _llvm
+from cula.ops._mlir_compat import llvm as _llvm
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_stream
 from cutlass.cute.typing import Float32, Int32, Int64

--- a/cula/ops/lightning/sm90/prefill_kernel.py
+++ b/cula/ops/lightning/sm90/prefill_kernel.py
@@ -25,13 +25,13 @@ from __future__ import annotations
 
 import cuda.bindings.driver as cuda
 import cutlass
-import cutlass._mlir.dialects.cute as _cute_ir
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.warpgroup as warpgroup
 import cutlass.pipeline as pipeline
 import cutlass.utils as utils
 import cutlass.utils.hopper_helpers as sm90_utils
-from cutlass._mlir.dialects import llvm
+from cula.ops._mlir_compat import cute as _cute_ir
+from cula.ops._mlir_compat import llvm
 from cutlass.cute.nvgpu import cpasync, warp
 from cutlass.utils.tensormap_manager import TensorMapManager, TensorMapUpdateMode
 

--- a/cula/ops/lightning/sm90/prefill_kernel.py
+++ b/cula/ops/lightning/sm90/prefill_kernel.py
@@ -30,10 +30,11 @@ import cutlass.cute.nvgpu.warpgroup as warpgroup
 import cutlass.pipeline as pipeline
 import cutlass.utils as utils
 import cutlass.utils.hopper_helpers as sm90_utils
-from cula.ops._mlir_compat import cute as _cute_ir
-from cula.ops._mlir_compat import llvm
 from cutlass.cute.nvgpu import cpasync, warp
 from cutlass.utils.tensormap_manager import TensorMapManager, TensorMapUpdateMode
+
+from cula.ops._mlir_compat import cute as _cute_ir
+from cula.ops._mlir_compat import llvm
 
 from .schedule import (
     DYNAMIC_SMEM_ESTIMATE_BYTES,

--- a/cula/ops/lightning/sm90/schedule.py
+++ b/cula/ops/lightning/sm90/schedule.py
@@ -24,8 +24,9 @@ from __future__ import annotations
 
 import cutlass
 import cutlass.cute as cute
-from cula.ops._mlir_compat import llvm
 from cutlass.cutlass_dsl import T
+
+from cula.ops._mlir_compat import llvm
 
 TARGET_ARCH = "sm_90a"
 

--- a/cula/ops/lightning/sm90/schedule.py
+++ b/cula/ops/lightning/sm90/schedule.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import cutlass
 import cutlass.cute as cute
-from cutlass._mlir.dialects import llvm
+from cula.ops._mlir_compat import llvm
 from cutlass.cutlass_dsl import T
 
 TARGET_ARCH = "sm_90a"

--- a/cula/ops/ptx.py
+++ b/cula/ops/ptx.py
@@ -16,13 +16,12 @@
 
 import cutlass
 import cutlass.cute as cute
-from cula.ops._mlir_compat import arith as _arith
-from cula.ops._mlir_compat import ir
-from cula.ops._mlir_compat import llvm as _llvm
-from cula.ops._mlir_compat import vector as _vector
-from cula.ops._mlir_compat import vector_extract_element
 from cutlass.cutlass_dsl import T as _T
 from cutlass.cutlass_dsl import dsl_user_op
+
+from cula.ops._mlir_compat import ir, vector_extract_element
+from cula.ops._mlir_compat import llvm as _llvm
+from cula.ops._mlir_compat import vector as _vector
 
 
 def _to_ir(v, loc=None, ip=None):
@@ -126,17 +125,8 @@ def store_256b(gmem_ptr, vec):
 
     @dsl_user_op
     def _do(addr, v, *, loc=None, ip=None):
-        i32_ty = ir.IntegerType.get_signless(32)
         ir_v = _to_ir(v, loc, ip)
-        elems = [
-            vector_extract_element(
-                ir_v,
-                _arith.constant(i32_ty, i, loc=loc, ip=ip),
-                loc=loc,
-                ip=ip,
-            )
-            for i in range(8)
-        ]
+        elems = [vector_extract_element(ir_v, i, loc=loc, ip=ip) for i in range(8)]
         operands = [_to_ir(addr, loc, ip)] + elems
         _llvm.inline_asm(
             ir.Type.parse("!llvm.void"),

--- a/cula/ops/ptx.py
+++ b/cula/ops/ptx.py
@@ -16,10 +16,11 @@
 
 import cutlass
 import cutlass.cute as cute
-from cutlass._mlir import ir
-from cutlass._mlir.dialects import arith as _arith
-from cutlass._mlir.dialects import llvm as _llvm
-from cutlass._mlir.dialects import vector as _vector
+from cula.ops._mlir_compat import arith as _arith
+from cula.ops._mlir_compat import ir
+from cula.ops._mlir_compat import llvm as _llvm
+from cula.ops._mlir_compat import vector as _vector
+from cula.ops._mlir_compat import vector_extract_element
 from cutlass.cutlass_dsl import T as _T
 from cutlass.cutlass_dsl import dsl_user_op
 
@@ -128,9 +129,9 @@ def store_256b(gmem_ptr, vec):
         i32_ty = ir.IntegerType.get_signless(32)
         ir_v = _to_ir(v, loc, ip)
         elems = [
-            _vector.extractelement(
+            vector_extract_element(
                 ir_v,
-                position=_arith.constant(i32_ty, i, loc=loc, ip=ip),
+                _arith.constant(i32_ty, i, loc=loc, ip=ip),
                 loc=loc,
                 ip=ip,
             )

--- a/cula/ops/sm100/ptx.py
+++ b/cula/ops/sm100/ptx.py
@@ -55,16 +55,15 @@ __all__ = [
 
 import cutlass
 import cutlass.cute as cute
-from cula.ops._mlir_compat import arith as _arith
-from cula.ops._mlir_compat import ir
-from cula.ops._mlir_compat import llvm
-from cula.ops._mlir_compat import nvvm as _nvvm
 from cutlass.cute.arch import elect_one
 from cutlass.cute.nvgpu import tcgen05
 from cutlass.cute.typing import Int32
 from cutlass.cutlass_dsl import dsl_user_op
 
 from cula.ops._cutedsl_compat import detect_tcgen05_ldst_api
+from cula.ops._mlir_compat import arith as _arith
+from cula.ops._mlir_compat import ir, llvm
+from cula.ops._mlir_compat import nvvm as _nvvm
 
 CollectorBBuffer = _nvvm.Tcgen05MMACollectorBBuffer
 CollectorOp = _nvvm.Tcgen05MMACollectorOp

--- a/cula/ops/sm100/ptx.py
+++ b/cula/ops/sm100/ptx.py
@@ -55,10 +55,10 @@ __all__ = [
 
 import cutlass
 import cutlass.cute as cute
-from cutlass._mlir import ir
-from cutlass._mlir.dialects import arith as _arith
-from cutlass._mlir.dialects import llvm
-from cutlass._mlir.dialects import nvvm as _nvvm
+from cula.ops._mlir_compat import arith as _arith
+from cula.ops._mlir_compat import ir
+from cula.ops._mlir_compat import llvm
+from cula.ops._mlir_compat import nvvm as _nvvm
 from cutlass.cute.arch import elect_one
 from cutlass.cute.nvgpu import tcgen05
 from cutlass.cute.typing import Int32

--- a/scripts/modal_validate.py
+++ b/scripts/modal_validate.py
@@ -2,10 +2,11 @@
 
 Clones the fork branch inside the container (this client ships no Mount),
 builds cuLA, runs the compat + SM90/SM100 kernel JIT tests, returns a JSON
-summary. The GPU and the CuTeDSL version are parameters so a reviewer can
-reproduce a specific environment, e.g.::
+summary. The GPU and the CuTeDSL version are chosen via environment
+variables so a reviewer can reproduce a specific environment, e.g.::
 
-    modal run scripts/modal_validate.py --gpu B200 --cutlass "nvidia-cutlass-dsl==4.5.2"
+    CULA_VALIDATE_GPU=B200 CULA_VALIDATE_CUTLASS='nvidia-cutlass-dsl==4.5.2' \\
+        modal run scripts/modal_validate.py
 
 SM100-only tests (``test_ptx_umma_ws.py``) self-deselect on non-Blackwell
 GPUs via conftest, so the harness is safe to run on either.
@@ -24,8 +25,10 @@ FORK = "https://github.com/bikrammajhi/cuLA.git"
 BRANCH = "mlir-compat-gateway"
 CUDA_TAG = "cu129"
 TORCH_VERSION = "2.9.1"
-DEFAULT_GPU = "H100"
-DEFAULT_CUTLASS = "nvidia-cutlass-dsl>=4.4.2,<4.7,!=4.5.0"
+GPU = os.environ.get("CULA_VALIDATE_GPU", "H100")
+CUTLASS_SPEC = os.environ.get(
+    "CULA_VALIDATE_CUTLASS", "nvidia-cutlass-dsl>=4.4.2,<4.7,!=4.5.0"
+)
 TESTS = [
     "tests/test_cutedsl_compat.py",
     "tests/test_lightning_attn_prefill_sm90.py",
@@ -33,30 +36,27 @@ TESTS = [
     "tests/test_ptx_umma_ws.py",
 ]
 
-
-def _build_image(cutlass_spec: str) -> modal.Image:
-    return (
-        modal.Image.from_registry("nvidia/cuda:12.9.0-devel-ubuntu22.04", add_python="3.12")
-        .apt_install("git")
-        .pip_install("wheel", "setuptools", "setuptools-scm")
-        .pip_install(
-            f"torch=={TORCH_VERSION}",
-            index_url=f"https://download.pytorch.org/whl/{CUDA_TAG}",
-        )
-        .pip_install(cutlass_spec, "flash-linear-attention", "pytest")
+image = (
+    modal.Image.from_registry("nvidia/cuda:12.9.0-devel-ubuntu22.04", add_python="3.12")
+    .apt_install("git")
+    .pip_install("wheel", "setuptools", "setuptools-scm")
+    .pip_install(
+        f"torch=={TORCH_VERSION}",
+        index_url=f"https://download.pytorch.org/whl/{CUDA_TAG}",
     )
-
+    .pip_install(CUTLASS_SPEC, "flash-linear-attention", "pytest")
+)
 
 app = modal.App("cula-validate-v5")
 
 
-@app.function(timeout=60 * 60)
-def validate(gpu: str, cutlass_spec: str) -> str:
+@app.function(image=image, gpu=GPU, timeout=60 * 60)
+def validate() -> str:
     start = time.time()
     summary = {
         "branch": BRANCH,
-        "gpu": gpu,
-        "cutlass_spec": cutlass_spec,
+        "gpu": GPU,
+        "cutlass_spec": CUTLASS_SPEC,
         "steps": {},
     }
 
@@ -119,6 +119,5 @@ def validate(gpu: str, cutlass_spec: str) -> str:
 
 
 @app.local_entrypoint()
-def main(gpu: str = DEFAULT_GPU, cutlass: str = DEFAULT_CUTLASS) -> None:
-    fn = validate.with_options(gpu=gpu, image=_build_image(cutlass))
-    print(fn.remote(gpu=gpu, cutlass_spec=cutlass))
+def main() -> None:
+    print(validate.remote())

--- a/scripts/modal_validate.py
+++ b/scripts/modal_validate.py
@@ -26,9 +26,7 @@ BRANCH = "mlir-compat-gateway"
 CUDA_TAG = "cu129"
 TORCH_VERSION = "2.9.1"
 GPU = os.environ.get("CULA_VALIDATE_GPU", "H100")
-CUTLASS_SPEC = os.environ.get(
-    "CULA_VALIDATE_CUTLASS", "nvidia-cutlass-dsl>=4.4.2,<4.7,!=4.5.0"
-)
+CUTLASS_SPEC = os.environ.get("CULA_VALIDATE_CUTLASS", "nvidia-cutlass-dsl>=4.4.2,<4.7,!=4.5.0")
 TESTS = [
     "tests/test_cutedsl_compat.py",
     "tests/test_lightning_attn_prefill_sm90.py",

--- a/scripts/modal_validate.py
+++ b/scripts/modal_validate.py
@@ -1,0 +1,106 @@
+"""Modal validation harness for cuLA on H100 (modal client v1.4.2 API).
+
+Clones the fork branch inside the container (this client ships no Mount),
+builds cuLA, runs the compat + SM90 kernel JIT tests, returns a JSON summary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+
+import modal
+
+FORK = "https://github.com/bikrammajhi/cuLA.git"
+BRANCH = "mlir-compat-gateway"
+CUDA_TAG = "cu129"
+TORCH_VERSION = "2.9.1"
+TESTS = "test_cutedsl_compat.py test_lightning_attn_prefill_sm90.py test_lightning_decode.py"
+
+image = (
+    modal.Image.from_registry("nvidia/cuda:12.9.0-devel-ubuntu22.04", add_python="3.12")
+    .apt_install("git")
+    .pip_install("wheel", "setuptools", "setuptools-scm")
+    .pip_install(
+        f"torch=={TORCH_VERSION}",
+        index_url=f"https://download.pytorch.org/whl/{CUDA_TAG}",
+    )
+    .pip_install("nvidia-cutlass-dsl>=4.4.2,<4.7,!=4.5.0", "flash-linear-attention", "pytest")
+)
+
+app = modal.App("cula-validate-v4")
+
+
+@app.function(image=image, gpu="h100", timeout=60 * 60)
+def validate() -> str:
+    start = time.time()
+    summary = {"branch": BRANCH, "steps": {}}
+
+    def step(name: str) -> None:
+        summary["steps"][name] = "ok"
+
+    subprocess.run(
+        f"git clone --depth 1 --branch {BRANCH} {FORK} /work",
+        shell=True,
+        check=True,
+    )
+    step("clone")
+
+    check = subprocess.run(
+        "ls tests/ | head -25; echo ---; git log --oneline -3",
+        shell=True,
+        cwd="/work",
+        capture_output=True,
+        text=True,
+    )
+    summary["clone_check"] = check.stdout + check.stderr
+
+    toolchain = {**os.environ, "CC": "gcc", "CXX": "g++", "CUDAHOSTCXX": "g++"}
+    subprocess.run(
+        "pip install -e /work --no-build-isolation",
+        shell=True,
+        env=toolchain,
+        check=True,
+    )
+    step("build")
+
+    probe = subprocess.run(
+        "python -c 'import torch, cutlass, cula; "
+        "print(torch.__version__, cutlass.__version__, torch.cuda.get_device_name(0))'",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    summary["env"] = probe.stdout.strip()
+    step("probe")
+
+    tests = tests or "test_cutedsl_compat.py test_lightning_attn_prefill_sm90.py test_lightning_decode.py"
+    run = subprocess.run(
+        f"python -m pytest tests/{tests} -v -m 'not sm100_only'",
+        shell=True,
+        cwd="/work",
+        capture_output=True,
+        text=True,
+    )
+    summary["pytest_cmd"] = f"pytest tests/{tests} -v -m not_sm100_only (cwd=/work)"
+    ls = subprocess.run(
+        "ls -la tests/test_lightning_attn_prefill_sm90.py tests/test_cutedsl_compat.py tests/test_lightning_decode.py",
+        shell=True,
+        cwd="/work",
+        capture_output=True,
+        text=True,
+    )
+    summary["target_ls"] = ls.stdout + ls.stderr
+    summary["pytest_rc"] = run.returncode
+    summary["pytest_tail"] = (run.stdout + run.stderr)[-5000:]
+    step("pytest" if run.returncode == 0 else "pytest_FAILED")
+
+    summary["elapsed_s"] = int(time.time() - start)
+    return json.dumps(summary, indent=1)
+
+
+@app.local_entrypoint()
+def main() -> None:
+    print(validate.remote())

--- a/scripts/modal_validate.py
+++ b/scripts/modal_validate.py
@@ -17,7 +17,11 @@ FORK = "https://github.com/bikrammajhi/cuLA.git"
 BRANCH = "mlir-compat-gateway"
 CUDA_TAG = "cu129"
 TORCH_VERSION = "2.9.1"
-TESTS = "test_cutedsl_compat.py test_lightning_attn_prefill_sm90.py test_lightning_decode.py"
+TESTS = [
+    "tests/test_cutedsl_compat.py",
+    "tests/test_lightning_attn_prefill_sm90.py",
+    "tests/test_lightning_decode.py",
+]
 
 image = (
     modal.Image.from_registry("nvidia/cuda:12.9.0-devel-ubuntu22.04", add_python="3.12")
@@ -76,26 +80,21 @@ def validate() -> str:
     summary["env"] = probe.stdout.strip()
     step("probe")
 
-    tests = tests or "test_cutedsl_compat.py test_lightning_attn_prefill_sm90.py test_lightning_decode.py"
     run = subprocess.run(
-        f"python -m pytest tests/{tests} -v -m 'not sm100_only'",
-        shell=True,
+        ["python", "-m", "pytest", *TESTS, "-v", "-m", "not sm100_only"],
         cwd="/work",
         capture_output=True,
         text=True,
     )
-    summary["pytest_cmd"] = f"pytest tests/{tests} -v -m not_sm100_only (cwd=/work)"
-    ls = subprocess.run(
-        "ls -la tests/test_lightning_attn_prefill_sm90.py tests/test_cutedsl_compat.py tests/test_lightning_decode.py",
-        shell=True,
-        cwd="/work",
-        capture_output=True,
-        text=True,
-    )
-    summary["target_ls"] = ls.stdout + ls.stderr
+    summary["pytest_cmd"] = "pytest " + " ".join(TESTS) + " -v -m 'not sm100_only' (cwd=/work)"
     summary["pytest_rc"] = run.returncode
     summary["pytest_tail"] = (run.stdout + run.stderr)[-5000:]
-    step("pytest" if run.returncode == 0 else "pytest_FAILED")
+    if run.returncode != 0:
+        raise RuntimeError(
+            f"pytest failed with exit code {run.returncode}; summary above captures "
+            "the tail. See the 'pytest_tail' entry for the failing tests."
+        )
+    step("pytest")
 
     summary["elapsed_s"] = int(time.time() - start)
     return json.dumps(summary, indent=1)

--- a/scripts/modal_validate.py
+++ b/scripts/modal_validate.py
@@ -1,7 +1,14 @@
-"""Modal validation harness for cuLA on H100 (modal client v1.4.2 API).
+"""Modal validation harness for cuLA (modal client v1.4.2 API).
 
 Clones the fork branch inside the container (this client ships no Mount),
-builds cuLA, runs the compat + SM90 kernel JIT tests, returns a JSON summary.
+builds cuLA, runs the compat + SM90/SM100 kernel JIT tests, returns a JSON
+summary. The GPU and the CuTeDSL version are parameters so a reviewer can
+reproduce a specific environment, e.g.::
+
+    modal run scripts/modal_validate.py --gpu B200 --cutlass "nvidia-cutlass-dsl==4.5.2"
+
+SM100-only tests (``test_ptx_umma_ws.py``) self-deselect on non-Blackwell
+GPUs via conftest, so the harness is safe to run on either.
 """
 
 from __future__ import annotations
@@ -17,30 +24,41 @@ FORK = "https://github.com/bikrammajhi/cuLA.git"
 BRANCH = "mlir-compat-gateway"
 CUDA_TAG = "cu129"
 TORCH_VERSION = "2.9.1"
+DEFAULT_GPU = "H100"
+DEFAULT_CUTLASS = "nvidia-cutlass-dsl>=4.4.2,<4.7,!=4.5.0"
 TESTS = [
     "tests/test_cutedsl_compat.py",
     "tests/test_lightning_attn_prefill_sm90.py",
     "tests/test_lightning_decode.py",
+    "tests/test_ptx_umma_ws.py",
 ]
 
-image = (
-    modal.Image.from_registry("nvidia/cuda:12.9.0-devel-ubuntu22.04", add_python="3.12")
-    .apt_install("git")
-    .pip_install("wheel", "setuptools", "setuptools-scm")
-    .pip_install(
-        f"torch=={TORCH_VERSION}",
-        index_url=f"https://download.pytorch.org/whl/{CUDA_TAG}",
+
+def _build_image(cutlass_spec: str) -> modal.Image:
+    return (
+        modal.Image.from_registry("nvidia/cuda:12.9.0-devel-ubuntu22.04", add_python="3.12")
+        .apt_install("git")
+        .pip_install("wheel", "setuptools", "setuptools-scm")
+        .pip_install(
+            f"torch=={TORCH_VERSION}",
+            index_url=f"https://download.pytorch.org/whl/{CUDA_TAG}",
+        )
+        .pip_install(cutlass_spec, "flash-linear-attention", "pytest")
     )
-    .pip_install("nvidia-cutlass-dsl>=4.4.2,<4.7,!=4.5.0", "flash-linear-attention", "pytest")
-)
-
-app = modal.App("cula-validate-v4")
 
 
-@app.function(image=image, gpu="h100", timeout=60 * 60)
-def validate() -> str:
+app = modal.App("cula-validate-v5")
+
+
+@app.function(timeout=60 * 60)
+def validate(gpu: str, cutlass_spec: str) -> str:
     start = time.time()
-    summary = {"branch": BRANCH, "steps": {}}
+    summary = {
+        "branch": BRANCH,
+        "gpu": gpu,
+        "cutlass_spec": cutlass_spec,
+        "steps": {},
+    }
 
     def step(name: str) -> None:
         summary["steps"][name] = "ok"
@@ -101,5 +119,6 @@ def validate() -> str:
 
 
 @app.local_entrypoint()
-def main() -> None:
-    print(validate.remote())
+def main(gpu: str = DEFAULT_GPU, cutlass: str = DEFAULT_CUTLASS) -> None:
+    fn = validate.with_options(gpu=gpu, image=_build_image(cutlass))
+    print(fn.remote(gpu=gpu, cutlass_spec=cutlass))

--- a/scripts/modal_validate.py
+++ b/scripts/modal_validate.py
@@ -51,12 +51,12 @@ app = modal.App("cula-validate-v5")
 
 
 @app.function(image=image, gpu=GPU, timeout=60 * 60)
-def validate() -> str:
+def validate(gpu: str, cutlass_spec: str) -> str:
     start = time.time()
     summary = {
         "branch": BRANCH,
-        "gpu": GPU,
-        "cutlass_spec": CUTLASS_SPEC,
+        "gpu": gpu,
+        "cutlass_spec": cutlass_spec,
         "steps": {},
     }
 
@@ -98,13 +98,15 @@ def validate() -> str:
     summary["env"] = probe.stdout.strip()
     step("probe")
 
+    # conftest gates sm100_only tests (skip on non-Blackwell, run on Blackwell),
+    # so no marker expression is needed here.
     run = subprocess.run(
-        ["python", "-m", "pytest", *TESTS, "-v", "-m", "not sm100_only"],
+        ["python", "-m", "pytest", *TESTS, "-v"],
         cwd="/work",
         capture_output=True,
         text=True,
     )
-    summary["pytest_cmd"] = "pytest " + " ".join(TESTS) + " -v -m 'not sm100_only' (cwd=/work)"
+    summary["pytest_cmd"] = "pytest " + " ".join(TESTS) + " -v (cwd=/work)"
     summary["pytest_rc"] = run.returncode
     summary["pytest_tail"] = (run.stdout + run.stderr)[-5000:]
     if run.returncode != 0:
@@ -120,4 +122,4 @@ def validate() -> str:
 
 @app.local_entrypoint()
 def main() -> None:
-    print(validate.remote())
+    print(validate.remote(gpu=GPU, cutlass_spec=CUTLASS_SPEC))

--- a/tests/test_cutedsl_compat.py
+++ b/tests/test_cutedsl_compat.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+import types
+
 import pytest
 
+from cula.ops import _mlir_compat
 from cula.ops._cutedsl_compat import Tcgen05LdStApi, detect_tcgen05_ldst_api
+from cula.ops._mlir_compat import _parse_version
 
 
 def _legacy_ld(res, shape, num, tmem_addr, *, pack=None, half_split_offset=None):
@@ -69,16 +74,16 @@ def test_detect_tcgen05_ldst_rejects_unknown_store_value_keyword():
 # MLIR compat gateway (_mlir_compat)
 # ---------------------------------------------------------------------------
 
-import sys
-import types
 
-from cula.ops import _mlir_compat
-from cula.ops._mlir_compat import _parse_version
+def _touch_gateway(name):
+    """Trigger the module-level ``__getattr__`` for a private binding."""
+    return getattr(_mlir_compat, name)
+
 
 _FAKE_DIALECTS = {
     "arith": (("constant",),),
     "cute": (),
-    "ir": (("Type", "parse"), ("VectorType", "get")),
+    "ir": (("Type", "parse"), ("VectorType", "get"), ("IntegerType", "get_signless")),
     "llvm": (("inline_asm",), ("extractvalue",)),
     "nvvm": (),
     "vector": (("bitcast",), ("extractelement",), ("extract_strided_slice",)),
@@ -108,26 +113,35 @@ def _install_fake_cutlass(version, *, with_mlir=True, missing_dialect=None, brok
             if name == missing_dialect:
                 continue
             module = types.ModuleType(f"cutlass._mlir.dialects.{name}")
-            setattr(module, "non_public", types.SimpleNamespace())
-            chains = canaries if name != broken_canary else ()
-            for chain in chains:
-                owner = module
-                for index, part in enumerate(chain):
-                    is_leaf = index == len(chain) - 1
-                    if not hasattr(owner, part):
-                        if is_leaf:
-                            setattr(owner, part, (lambda *args, _op=part, **kwargs: f"op:{_op}"))
-                        else:
-                            setattr(owner, part, types.SimpleNamespace())
-                    owner = getattr(owner, part)
+            module.non_public = types.SimpleNamespace()
+            _install_chains(module, canaries, broken=name == broken_canary)
             setattr(dialects, name, module)
             installed.append(f"cutlass._mlir.dialects.{name}")
+        ir = types.ModuleType("cutlass._mlir.ir")
+        _install_chains(ir, _FAKE_DIALECTS["ir"], broken=False)
+        _mlir.ir = ir
+        installed.append("cutlass._mlir.ir")
 
     previous = {name: sys.modules.get(name) for name in installed}
     for name in installed:
         sys.modules[name] = _module_by_name(cutlass, name)
     _mlir_compat._CACHE.clear()
     return lambda: _restore_modules(previous)
+
+
+def _install_chains(module, chains, *, broken):
+    """Attach ``(parent, leaf)`` canary chains to *module* as fake callables."""
+    chains = chains if not broken else ()
+    for chain in chains:
+        owner = module
+        for index, part in enumerate(chain):
+            is_leaf = index == len(chain) - 1
+            if not hasattr(owner, part):
+                if is_leaf:
+                    setattr(owner, part, (lambda *args, _op=part, **kwargs: f"op:{_op}"))
+                else:
+                    setattr(owner, part, types.SimpleNamespace())
+            owner = getattr(owner, part)
 
 
 def _module_by_name(root, dotted):
@@ -151,6 +165,12 @@ def test_parse_version_accepts_release_and_dev_suffixes():
     assert _parse_version("4.6.0.dev0") == (4, 6, 0)
 
 
+def test_parse_version_normalizes_missing_components():
+    assert _parse_version("4") == (4, 0, 0)
+    assert _parse_version("4.5") == (4, 5, 0)
+    assert _parse_version("4.7") == (4, 7, 0)
+
+
 def test_parse_version_rejects_garbage():
     with pytest.raises(RuntimeError, match="cannot parse"):
         _parse_version("not-a-version")
@@ -160,7 +180,27 @@ def test_version_contract_rejects_out_of_range():
     restore = _install_fake_cutlass("9.9.9")
     try:
         with pytest.raises(RuntimeError, match="outside the range validated by cuLA"):
-            _mlir_compat.llvm
+            _touch_gateway("llvm")
+    finally:
+        restore()
+
+
+def test_version_contract_rejects_two_component_upper_bound():
+    # "4.7" must normalize to (4, 7, 0) and not slip under the < 4.7.0 cap.
+    restore = _install_fake_cutlass("4.7")
+    try:
+        with pytest.raises(RuntimeError, match="outside the range validated by cuLA"):
+            _touch_gateway("llvm")
+    finally:
+        restore()
+
+
+def test_version_contract_rejects_two_component_excluded():
+    # "4.5" must normalize to (4, 5, 0) and hit the explicit 4.5.0 exclusion.
+    restore = _install_fake_cutlass("4.5")
+    try:
+        with pytest.raises(RuntimeError, match="explicitly excluded by cuLA"):
+            _touch_gateway("llvm")
     finally:
         restore()
 
@@ -170,7 +210,7 @@ def test_missing_cutlass_reports_install_hint():
     sys.modules["cutlass"] = None  # simulate the package being absent
     try:
         with pytest.raises(RuntimeError, match="nvidia-cutlass-dsl"):
-            _mlir_compat.llvm
+            _touch_gateway("llvm")
     finally:
         restore()
 
@@ -179,7 +219,7 @@ def test_missing_dialect_raises_with_dialect_name():
     restore = _install_fake_cutlass("4.5.3", missing_dialect="llvm")
     try:
         with pytest.raises(RuntimeError, match="no longer exposes 'llvm'"):
-            _mlir_compat.llvm
+            _touch_gateway("llvm")
     finally:
         restore()
 
@@ -188,7 +228,7 @@ def test_missing_canary_raises_naming_the_entry_point():
     restore = _install_fake_cutlass("4.5.3", broken_canary="llvm")
     try:
         with pytest.raises(RuntimeError, match="missing the canary entry point inline_asm"):
-            _mlir_compat.llvm
+            _touch_gateway("llvm")
     finally:
         restore()
 
@@ -196,7 +236,19 @@ def test_missing_canary_raises_naming_the_entry_point():
 def test_vector_dispatch_uses_extractelement_when_extract_absent():
     restore = _install_fake_cutlass("4.5.3")
     try:
-        assert _mlir_compat.vector_extract_element("vec", "pos") == "op:extractelement"
+        seen = {}
+        vector_dialect = _mlir_compat._load("vector")
+
+        def fake_extractelement(vec, *, position, loc=None, ip=None):
+            seen["position"] = position
+            return "op:extractelement"
+
+        vector_dialect.extractelement = fake_extractelement
+        _mlir_compat._CACHE.clear()
+        # the helper must build the i32 index constant itself, from the plain
+        # Python index (the fake's arith.constant returns "op:constant")
+        assert _mlir_compat.vector_extract_element("vec", 3) == "op:extractelement"
+        assert seen["position"] == "op:constant"
     finally:
         restore()
 
@@ -207,16 +259,25 @@ def test_vector_dispatch_uses_extract_when_available():
         vector_dialect = _mlir_compat._load("vector")
         # simulate the 4.6 rename: drop extractelement, add extract
         delattr(vector_dialect, "extractelement")
-        setattr(vector_dialect, "extract", lambda *args, **kwargs: "op:extract")
+        seen = {}
+
+        def fake_extract(source, dynamic_position, static_position, *, loc=None, ip=None):
+            seen["args"] = (source, dynamic_position, static_position)
+            return "op:extract"
+
+        vector_dialect.extract = fake_extract
         _mlir_compat._CACHE.clear()
-        assert _mlir_compat.vector_extract_element("vec", "pos") == "op:extract"
+        assert _mlir_compat.vector_extract_element("vec", 3) == "op:extract"
+        # static-position form: no dynamic index operands, position in the
+        # static-position array (matches the real 4.6.2 binding)
+        assert seen["args"] == ("vec", [], [3])
     finally:
         restore()
 
 
 def test_unknown_attribute_raises_attribute_error():
     with pytest.raises(AttributeError, match="has no attribute"):
-        _mlir_compat.does_not_exist
+        _touch_gateway("does_not_exist")
 
 
 def test_dialect_bindings_are_cached():

--- a/tests/test_cutedsl_compat.py
+++ b/tests/test_cutedsl_compat.py
@@ -63,3 +63,177 @@ def test_detect_tcgen05_ldst_rejects_unknown_store_value_keyword():
 
     with pytest.raises(RuntimeError, match="expected exactly one value keyword"):
         detect_tcgen05_ldst_api(_inferred_ld, unsupported_st)
+
+
+# ---------------------------------------------------------------------------
+# MLIR compat gateway (_mlir_compat)
+# ---------------------------------------------------------------------------
+
+import sys
+import types
+
+from cula.ops import _mlir_compat
+from cula.ops._mlir_compat import _parse_version
+
+_FAKE_DIALECTS = {
+    "arith": (("constant",),),
+    "cute": (),
+    "ir": (("Type", "parse"), ("VectorType", "get")),
+    "llvm": (("inline_asm",), ("extractvalue",)),
+    "nvvm": (),
+    "vector": (("bitcast",), ("extractelement",), ("extract_strided_slice",)),
+}
+
+
+def _install_fake_cutlass(version, *, with_mlir=True, missing_dialect=None, broken_canary=None):
+    """Install a fake ``cutlass`` package into ``sys.modules`` for fault injection.
+
+    :param version: value for ``cutlass.__version__``
+    :param with_mlir: when False, the fake exposes no ``_mlir`` subpackage
+    :param missing_dialect: dialect that does not exist in the fake package
+    :param broken_canary: dialect whose first canary entry point is absent
+    """
+    installed = ["cutlass"]
+    cutlass = types.ModuleType("cutlass")
+    cutlass.__version__ = version
+    cutlass.__path__ = []
+    if with_mlir:
+        _mlir = types.ModuleType("cutlass._mlir")
+        cutlass._mlir = _mlir
+        installed.append("cutlass._mlir")
+        dialects = types.ModuleType("cutlass._mlir.dialects")
+        _mlir.dialects = dialects
+        installed.append("cutlass._mlir.dialects")
+        for name, canaries in _FAKE_DIALECTS.items():
+            if name == missing_dialect:
+                continue
+            module = types.ModuleType(f"cutlass._mlir.dialects.{name}")
+            setattr(module, "non_public", types.SimpleNamespace())
+            chains = canaries if name != broken_canary else ()
+            for chain in chains:
+                owner = module
+                for index, part in enumerate(chain):
+                    is_leaf = index == len(chain) - 1
+                    if not hasattr(owner, part):
+                        if is_leaf:
+                            setattr(owner, part, (lambda *args, _op=part, **kwargs: f"op:{_op}"))
+                        else:
+                            setattr(owner, part, types.SimpleNamespace())
+                    owner = getattr(owner, part)
+            setattr(dialects, name, module)
+            installed.append(f"cutlass._mlir.dialects.{name}")
+
+    previous = {name: sys.modules.get(name) for name in installed}
+    for name in installed:
+        sys.modules[name] = _module_by_name(cutlass, name)
+    _mlir_compat._CACHE.clear()
+    return lambda: _restore_modules(previous)
+
+
+def _module_by_name(root, dotted):
+    module = root
+    for part in dotted.split(".")[1:]:
+        module = getattr(module, part)
+    return module
+
+
+def _restore_modules(previous):
+    for name, module in previous.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+    _mlir_compat._CACHE.clear()
+
+
+def test_parse_version_accepts_release_and_dev_suffixes():
+    assert _parse_version("4.5.3") == (4, 5, 3)
+    assert _parse_version("4.6.0.dev0") == (4, 6, 0)
+
+
+def test_parse_version_rejects_garbage():
+    with pytest.raises(RuntimeError, match="cannot parse"):
+        _parse_version("not-a-version")
+
+
+def test_version_contract_rejects_out_of_range():
+    restore = _install_fake_cutlass("9.9.9")
+    try:
+        with pytest.raises(RuntimeError, match="outside the range validated by cuLA"):
+            _mlir_compat.llvm
+    finally:
+        restore()
+
+
+def test_missing_cutlass_reports_install_hint():
+    restore = _install_fake_cutlass("4.5.3", with_mlir=False)
+    sys.modules["cutlass"] = None  # simulate the package being absent
+    try:
+        with pytest.raises(RuntimeError, match="nvidia-cutlass-dsl"):
+            _mlir_compat.llvm
+    finally:
+        restore()
+
+
+def test_missing_dialect_raises_with_dialect_name():
+    restore = _install_fake_cutlass("4.5.3", missing_dialect="llvm")
+    try:
+        with pytest.raises(RuntimeError, match="no longer exposes 'llvm'"):
+            _mlir_compat.llvm
+    finally:
+        restore()
+
+
+def test_missing_canary_raises_naming_the_entry_point():
+    restore = _install_fake_cutlass("4.5.3", broken_canary="llvm")
+    try:
+        with pytest.raises(RuntimeError, match="missing the canary entry point inline_asm"):
+            _mlir_compat.llvm
+    finally:
+        restore()
+
+
+def test_vector_dispatch_uses_extractelement_when_extract_absent():
+    restore = _install_fake_cutlass("4.5.3")
+    try:
+        assert _mlir_compat.vector_extract_element("vec", "pos") == "op:extractelement"
+    finally:
+        restore()
+
+
+def test_vector_dispatch_uses_extract_when_available():
+    restore = _install_fake_cutlass("4.6.0")
+    try:
+        vector_dialect = _mlir_compat._load("vector")
+        # simulate the 4.6 rename: drop extractelement, add extract
+        delattr(vector_dialect, "extractelement")
+        setattr(vector_dialect, "extract", lambda *args, **kwargs: "op:extract")
+        _mlir_compat._CACHE.clear()
+        assert _mlir_compat.vector_extract_element("vec", "pos") == "op:extract"
+    finally:
+        restore()
+
+
+def test_unknown_attribute_raises_attribute_error():
+    with pytest.raises(AttributeError, match="has no attribute"):
+        _mlir_compat.does_not_exist
+
+
+def test_dialect_bindings_are_cached():
+    restore = _install_fake_cutlass("4.5.3")
+    try:
+        assert _mlir_compat.llvm is _mlir_compat.llvm
+    finally:
+        restore()
+
+
+def test_real_cutlass_bindings_load():
+    """Smoke-test the gateway against the installed CuTeDSL wheel."""
+    try:
+        import cutlass  # noqa: F401
+    except ImportError:
+        pytest.skip("nvidia-cutlass-dsl is not installed")
+
+    for dialect in ("arith", "cute", "ir", "llvm", "nvvm", "vector"):
+        _mlir_compat._CACHE.clear()
+        assert getattr(_mlir_compat, dialect) is not None


### PR DESCRIPTION
## Summary

Closes #118 — isolates all direct `cutlass._mlir` usage behind a single compatibility gateway.

CuTeDSL's generated MLIR/NVVM bindings (`cutlass._mlir.{ir,arith,llvm,vector,nvvm,cute}`) are private implementation detail with no cross-version stability contract — the `tcgen05_ld/st` breakage between CutDSL 4.5.2 and 4.5.3 was the first confirmed incident. cuLA imported these directly from 10 kernel modules, so a patch release could break kernel emission silently, delayed until import/JIT time.

### Changes

1. **`cula/ops/_mlir_compat.py`** — the only module that may touch `cutlass._mlir`:
   - Lazy dialect loading (plain `import cula` never touches private bindings)
   - Version contract mirroring `pyproject.toml` (`>=4.4.2,<4.7,!=4.5.0`), enforced with a fail-fast `RuntimeError` naming the offending version
   - Canary probes on every dialect's entry points, so a missing/renamed binding fails with an actionable message instead of surfacing mid-JIT
   - `vector_extract_element()` helper with cross-version dispatch (see below)
2. **Migration** — all 10 consumer files bind their dialect aliases from the gateway (one import-line swap per file, zero behavioral changes).
3. **Bug fix discovered during prep** — CutDSL renamed `vector.extractelement` to `vector.extract` in the 4.6 line; against `nvidia-cutlass-dsl==4.6.2` (resolved by our own `pyproject.toml` range) `store_256b` raises `AttributeError` at JIT time. `store_256b` is used by the KDA SM100 backward path. The gateway's `vector_extract_element` dispatches to whichever binding exists, restoring 4.6 compatibility.
4. **Tests** — 15 headless tests for the gateway: version parsing, contract enforcement, missing dialect/canary fault injection, vector dispatch on both 4.5/4.6 shapes, and a real-wheel smoke test. No GPU required.
5. **`scripts/modal_validate.py`** — H100/CUDA 12.9 validation harness (runs the headless suite + SM90 prefill/decode tests in one `modal run`).

### Validation status

- [x] Headless: 15/15 `tests/test_cutedsl_compat.py` green against `nvidia-cutlass-dsl==4.6.2`
- [x] All 10 migrated consumer modules import cleanly against the installed wheel
- [ ] SM90 suite on Hopper (H100) — running via `modal run scripts/modal_validate.py`; will attach results

### Notes for reviewers

- The old `extractelement` call in `store_256b` passed the position as a keyword (`position=...`); the new `vector.extract` binding takes it positionally (`(source, dynamic_position, static_position)`). The dispatch helper deliberately keeps the exact call shapes per branch.
- Canary choices reflect what the migrated consumers actually call; extend `_CANARIES`/`_ANY_OF_CANARIES` when new private-API usage lands.
